### PR TITLE
Add seeded dreamscape artist experience

### DIFF
--- a/artist/index.html
+++ b/artist/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dreamseed Artist</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <canvas id="dream-canvas" aria-hidden="true"></canvas>
+    <div class="overlay" role="region" aria-label="Dreamseed controls">
+      <header class="panel">
+        <h1>Dreamseed Artist</h1>
+        <p>
+          숫자를 씨앗으로 삼아 우주적이고 몽환적인 예술을 만듭니다. 새로운
+          세계를 보고 싶다면 씨앗을 입력하세요.
+        </p>
+        <form id="seed-form" autocomplete="off">
+          <label for="seed-input">씨앗 숫자</label>
+          <div class="controls">
+            <input
+              id="seed-input"
+              name="seed"
+              type="number"
+              inputmode="numeric"
+              placeholder="예: 314159"
+              required
+            />
+            <button type="submit">소환</button>
+            <button type="button" id="random-seed">무작위</button>
+          </div>
+        </form>
+        <div class="palette" aria-live="polite">
+          <span>현재 팔레트</span>
+          <div class="swatches" id="palette-swatches"></div>
+        </div>
+        <p class="hint">
+          화면을 터치하거나 마우스를 움직이면 새로운 흐름이 생기고, 스크롤로
+          리듬을 바꿀 수 있습니다.
+        </p>
+      </header>
+    </div>
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/artist/script.js
+++ b/artist/script.js
@@ -1,0 +1,390 @@
+const canvas = document.getElementById("dream-canvas");
+const ctx = canvas.getContext("2d", { alpha: true });
+const form = document.getElementById("seed-form");
+const seedInput = document.getElementById("seed-input");
+const randomButton = document.getElementById("random-seed");
+const paletteContainer = document.getElementById("palette-swatches");
+
+let width = 0;
+let height = 0;
+let dpr = Math.min(window.devicePixelRatio || 1, 2.5);
+
+let animationId = null;
+let particles = [];
+let cosmicBursts = [];
+let palette = [];
+let flowLayers = [];
+let auraSeeds = [];
+let currentSeed = 0;
+let baseTempo = 1;
+let time = 0;
+
+const pointer = {
+  x: 0.5,
+  y: 0.5,
+  active: false,
+  strength: 0,
+  rhythm: 0,
+};
+
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+function createMulberry32(seed) {
+  let t = seed >>> 0;
+  return function () {
+    t += 0x6d2b79f5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function mix(a, b, t) {
+  return a + (b - a) * t;
+}
+
+function lerpColor(colorA, colorB, t) {
+  const parse = (color) => {
+    const match = /hsla?\(([^)]+)\)/.exec(color);
+    if (!match) return [0, 0, 0, 1];
+    const parts = match[1].split(/[,\s]+/).filter(Boolean);
+    const h = parseFloat(parts[0]);
+    const s = parseFloat(parts[1]);
+    const l = parseFloat(parts[2]);
+    const a = parts.length > 3 ? parseFloat(parts[3]) : 1;
+    return [h, s, l, a];
+  };
+  const [h1, s1, l1, a1] = parse(colorA);
+  const [h2, s2, l2, a2] = parse(colorB);
+  const hueDiff = ((((h2 - h1 + 540) % 360) - 180) / 360) * t;
+  const h = (h1 + hueDiff * 360 + 360) % 360;
+  const s = mix(s1, s2, t);
+  const l = mix(l1, l2, t);
+  const a = mix(a1, a2, t);
+  return `hsla(${h.toFixed(2)}, ${s.toFixed(2)}%, ${l.toFixed(2)}%, ${a.toFixed(3)})`;
+}
+
+function generatePalette(rng) {
+  const baseHue = rng() * 360;
+  const spread = mix(30, 120, rng());
+  const saturation = mix(65, 95, rng());
+  const lightnessBase = mix(40, 70, rng());
+
+  const colors = Array.from({ length: 5 }, (_, i) => {
+    const offset = (i / 5 - 0.5) * spread + rng() * 10;
+    const hue = (baseHue + offset + 360) % 360;
+    const sat = clamp(saturation + rng() * 10 - 5, 55, 100);
+    const light = clamp(lightnessBase + rng() * 20 - 10, 25, 85);
+    const alpha = mix(0.55, 0.9, rng());
+    return `hsla(${hue.toFixed(2)}, ${sat.toFixed(2)}%, ${light.toFixed(2)}%, ${alpha.toFixed(3)})`;
+  });
+
+  return colors;
+}
+
+function updatePaletteSwatches() {
+  paletteContainer.innerHTML = "";
+  palette.forEach((color) => {
+    const swatch = document.createElement("span");
+    swatch.className = "swatch";
+    swatch.style.background = color;
+    paletteContainer.appendChild(swatch);
+  });
+}
+
+function createFlowLayers(rng) {
+  const layers = Array.from({ length: 4 }, () => ({
+    amp: mix(0.2, 1.6, rng()),
+    freqX: mix(0.4, 1.5, rng()),
+    freqY: mix(0.4, 1.5, rng()),
+    twist: mix(-Math.PI, Math.PI, rng()),
+    pulse: mix(0.2, 1.6, rng()),
+    offset: rng() * Math.PI * 2,
+  }));
+  return layers;
+}
+
+function createAuraSeeds(rng) {
+  return Array.from({ length: 3 }, () => ({
+    hueShift: rng(),
+    radius: mix(0.15, 0.45, rng()),
+    pulse: mix(0.5, 1.5, rng()),
+    phase: rng() * Math.PI * 2,
+  }));
+}
+
+function createParticles(rng) {
+  const count = Math.floor(180 + rng() * 160);
+  const list = [];
+  for (let i = 0; i < count; i++) {
+    list.push({
+      x: rng(),
+      y: rng(),
+      drift: rng(),
+      glow: rng(),
+      scale: mix(0.25, 1.3, rng()),
+      layer: i % palette.length,
+      phase: rng() * Math.PI * 2,
+      sway: mix(0.5, 1.6, rng()),
+    });
+  }
+  return list;
+}
+
+function createBursts(rng) {
+  const count = 12 + Math.floor(rng() * 8);
+  const list = [];
+  for (let i = 0; i < count; i++) {
+    list.push({
+      x: rng(),
+      y: rng(),
+      radius: mix(0.1, 0.35, rng()),
+      pulse: mix(0.5, 1.4, rng()),
+      delay: rng() * 1000,
+      layer: Math.floor(rng() * palette.length),
+    });
+  }
+  return list;
+}
+
+function resizeCanvas() {
+  width = window.innerWidth;
+  height = window.innerHeight;
+  dpr = Math.min(window.devicePixelRatio || 1, 2.5);
+  canvas.width = width * dpr;
+  canvas.height = height * dpr;
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+}
+
+function flowField(x, y, t) {
+  let value = 0;
+  for (const layer of flowLayers) {
+    const angle =
+      Math.sin((x * layer.freqX + y * layer.freqY) * Math.PI * 2 + t * layer.amp + layer.offset) +
+      Math.cos((x * layer.freqY - y * layer.freqX) * Math.PI + t * layer.pulse + layer.offset * 1.3);
+    value += angle * layer.twist;
+  }
+  return value;
+}
+
+function applyPointerInfluence(particle) {
+  if (!pointer.active) return;
+  const dx = pointer.x - particle.x;
+  const dy = pointer.y - particle.y;
+  const distSq = dx * dx + dy * dy;
+  const influence = Math.exp(-distSq * 12) * pointer.strength;
+  if (influence > 0.001) {
+    particle.x -= dy * influence * 0.35;
+    particle.y += dx * influence * 0.35;
+  }
+}
+
+function updateParticles(dt) {
+  const fade = 0.12 * clamp(baseTempo, 0.35, 2.4);
+  ctx.fillStyle = `rgba(3, 2, 12, ${fade.toFixed(3)})`;
+  ctx.fillRect(0, 0, width, height);
+
+  ctx.globalCompositeOperation = "lighter";
+
+  const tempo = baseTempo * mix(0.8, 1.4, Math.sin(time * 0.2) * 0.5 + 0.5);
+
+  particles.forEach((particle) => {
+    const angle = flowField(particle.x, particle.y, time + particle.phase) * 0.6;
+    const speed = mix(0.0003, 0.0028, particle.scale) * tempo;
+
+    particle.x += Math.cos(angle) * speed + Math.sin(time * 0.4 + particle.phase) * 0.0004;
+    particle.y += Math.sin(angle) * speed + Math.cos(time * 0.37 + particle.phase) * 0.0004;
+
+    applyPointerInfluence(particle);
+
+    particle.x += (Math.sin(time * particle.sway + particle.phase) * 0.0006) / tempo;
+    particle.y += (Math.cos(time * particle.sway + particle.phase) * 0.0006) / tempo;
+
+    if (particle.x < -0.2 || particle.x > 1.2 || particle.y < -0.2 || particle.y > 1.2) {
+      particle.x = (particle.x + 1.2) % 1.2;
+      particle.y = (particle.y + 1.2) % 1.2;
+    }
+
+    const px = particle.x * width;
+    const py = particle.y * height;
+    const baseColor = palette[particle.layer % palette.length];
+    const nextColor = palette[(particle.layer + 1) % palette.length];
+    const colorMix = (Math.sin(time * 0.8 + particle.phase) * 0.5 + 0.5) ** 1.5;
+    ctx.fillStyle = lerpColor(baseColor, nextColor, colorMix);
+    const r = mix(0.5, 2.4, particle.scale) * (1 + Math.sin(time * 0.9 + particle.phase) * 0.35);
+    const gradient = ctx.createRadialGradient(px, py, 0, px, py, r * 40);
+    gradient.addColorStop(0, ctx.fillStyle.replace(/\d?\.\d+\)/, "1)"));
+    gradient.addColorStop(1, ctx.fillStyle.replace(/\d?\.\d+\)/, "0)"));
+    ctx.fillStyle = gradient;
+    ctx.beginPath();
+    ctx.arc(px, py, r * mix(18, 48, particle.glow), 0, Math.PI * 2);
+    ctx.fill();
+  });
+
+  ctx.globalCompositeOperation = "screen";
+
+  cosmicBursts.forEach((burst) => {
+    const pulse = Math.sin((time + burst.delay) * burst.pulse) * 0.5 + 0.5;
+    const radius = mix(120, Math.max(width, height) * burst.radius, pulse);
+    const cx = burst.x * width;
+    const cy = burst.y * height;
+    const color = palette[burst.layer % palette.length];
+    const gradient = ctx.createRadialGradient(cx, cy, 0, cx, cy, radius);
+    gradient.addColorStop(0, color.replace(/\d?\.\d+\)/, "0.95)"));
+    gradient.addColorStop(0.6, color.replace(/\d?\.\d+\)/, "0.35)"));
+    gradient.addColorStop(1, color.replace(/\d?\.\d+\)/, "0)"));
+    ctx.fillStyle = gradient;
+    ctx.beginPath();
+    ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+    ctx.fill();
+  });
+
+  renderAuras();
+
+  ctx.globalCompositeOperation = "source-over";
+}
+
+function updatePointerDecay(dt) {
+  if (!pointer.active && pointer.strength > 0.001) {
+    pointer.strength = Math.max(0, pointer.strength - dt * 0.35);
+  }
+}
+
+function animate(timestamp) {
+  if (!animationId) {
+    animationId = timestamp;
+  }
+  const deltaMs = timestamp - animationId;
+  animationId = timestamp;
+  const dt = deltaMs / 1000;
+  time += dt * baseTempo * mix(0.8, 1.4, Math.sin(time * 0.12) * 0.5 + 0.5);
+
+  updateParticles(dt);
+  updatePointerDecay(dt);
+
+  requestAnimationFrame(animate);
+}
+
+function setSeed(seed) {
+  const normalized = Math.abs(Math.floor(seed)) || 1;
+  currentSeed = normalized;
+  const url = new URL(window.location.href);
+  url.searchParams.set("seed", normalized);
+  history.replaceState(null, "Dreamseed", url.toString());
+
+  const rng = createMulberry32(normalized);
+  palette = generatePalette(rng);
+  flowLayers = createFlowLayers(rng);
+  auraSeeds = createAuraSeeds(rng);
+  particles = createParticles(rng);
+  cosmicBursts = createBursts(rng);
+  baseTempo = mix(0.6, 1.8, rng());
+  time = rng() * Math.PI * 2;
+
+  updatePaletteSwatches();
+  seedInput.value = normalized;
+}
+
+function parseInitialSeed() {
+  const url = new URL(window.location.href);
+  const paramSeed = url.searchParams.get("seed");
+  if (paramSeed && /^-?\d+$/.test(paramSeed)) {
+    return parseInt(paramSeed, 10);
+  }
+  if (window.location.hash && /^#-?\d+$/.test(window.location.hash)) {
+    return parseInt(window.location.hash.slice(1), 10);
+  }
+  const segments = window.location.pathname.split("/").filter(Boolean);
+  const last = segments[segments.length - 1];
+  if (last && /^-?\d+$/.test(last)) {
+    return parseInt(last, 10);
+  }
+  return Math.floor(Math.random() * 10 ** 9);
+}
+
+function handleFormSubmit(event) {
+  event.preventDefault();
+  const value = seedInput.value.trim();
+  if (!value || !/^-?\d+$/.test(value)) {
+    seedInput.focus();
+    return;
+  }
+  setSeed(parseInt(value, 10));
+}
+
+function handleRandomSeed() {
+  const randomSeed = Math.floor(Math.random() * 10 ** 9);
+  setSeed(randomSeed);
+}
+
+function handlePointer(event) {
+  pointer.active = true;
+  const bounds = canvas.getBoundingClientRect();
+  pointer.x = (event.clientX - bounds.left) / bounds.width;
+  pointer.y = (event.clientY - bounds.top) / bounds.height;
+  pointer.strength = clamp(pointer.strength + 0.35, 0, 2);
+  pointer.rhythm = event.pressure || 1;
+}
+
+function handlePointerEnd() {
+  pointer.active = false;
+}
+
+function handleWheel(event) {
+  event.preventDefault();
+  const delta = clamp(event.deltaY / 120, -1, 1);
+  baseTempo = clamp(baseTempo - delta * 0.12, 0.25, 3.2);
+  pointer.strength = clamp(pointer.strength + Math.abs(delta) * 0.15, 0, 2);
+}
+
+function installEventListeners() {
+  window.addEventListener("resize", resizeCanvas);
+  window.addEventListener("wheel", handleWheel, { passive: false });
+  window.addEventListener("pointermove", handlePointer, { passive: true });
+  window.addEventListener("pointerdown", handlePointer, { passive: true });
+  window.addEventListener("pointerup", handlePointerEnd, { passive: true });
+  window.addEventListener("pointercancel", handlePointerEnd, { passive: true });
+  window.addEventListener("touchmove", (event) => {
+    if (event.touches && event.touches[0]) {
+      handlePointer(event.touches[0]);
+    }
+  }, { passive: true });
+
+  form.addEventListener("submit", handleFormSubmit);
+  randomButton.addEventListener("click", handleRandomSeed);
+}
+
+function renderAuras() {
+  if (!auraSeeds.length) return;
+  ctx.globalCompositeOperation = "screen";
+  auraSeeds.forEach((aura, index) => {
+    const cx = Math.sin(time * 0.2 + index) * 0.3 + 0.5;
+    const cy = Math.cos(time * 0.25 + aura.phase) * 0.3 + 0.5;
+    const radius = mix(0.2, aura.radius + pointer.strength * 0.05, Math.sin(time * aura.pulse + aura.phase) * 0.5 + 0.5);
+    const px = cx * width;
+    const py = cy * height;
+    const color = palette[index % palette.length];
+    const gradient = ctx.createRadialGradient(px, py, 0, px, py, radius * Math.max(width, height));
+    gradient.addColorStop(0, color.replace(/\d?\.\d+\)/, "0.4)"));
+    gradient.addColorStop(1, color.replace(/\d?\.\d+\)/, "0)"));
+    ctx.fillStyle = gradient;
+    ctx.beginPath();
+    ctx.arc(px, py, radius * Math.max(width, height), 0, Math.PI * 2);
+    ctx.fill();
+  });
+  ctx.globalCompositeOperation = "source-over";
+}
+
+function start() {
+  resizeCanvas();
+  installEventListeners();
+  const seed = parseInitialSeed();
+  setSeed(seed);
+  renderAuras();
+  requestAnimationFrame(animate);
+}
+
+start();
+

--- a/artist/styles.css
+++ b/artist/styles.css
@@ -1,0 +1,148 @@
+:root {
+  color-scheme: dark;
+  font-family: "Pretendard", "Noto Sans KR", "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  overflow: hidden;
+  background: radial-gradient(circle at 20% 20%, #060414, #02010b 60%, #000);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+#dream-canvas {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  display: block;
+}
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  pointer-events: none;
+  padding: clamp(1.5rem, 2vw, 3rem);
+}
+
+.panel {
+  max-width: min(460px, 100%);
+  background: rgba(6, 4, 20, 0.55);
+  backdrop-filter: blur(18px) saturate(140%);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 24px;
+  padding: clamp(1.5rem, 3vw, 3rem);
+  box-shadow: 0 40px 120px rgba(10, 0, 40, 0.35);
+  pointer-events: auto;
+}
+
+.panel h1 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+  letter-spacing: 0.04em;
+}
+
+.panel p {
+  line-height: 1.6;
+  margin: 0 0 1.2rem;
+}
+
+.controls {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 0.6rem;
+  margin-top: 0.4rem;
+}
+
+input[type="number"] {
+  width: 100%;
+  padding: 0.8rem 1rem;
+  font-size: 1rem;
+  color: inherit;
+  background: rgba(14, 10, 40, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 14px;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+input[type="number"]:focus {
+  outline: none;
+  border-color: rgba(255, 255, 255, 0.65);
+  box-shadow: 0 0 0 3px rgba(120, 92, 255, 0.35);
+}
+
+button {
+  padding: 0.8rem 1.4rem;
+  font-size: 1rem;
+  font-weight: 600;
+  border-radius: 14px;
+  border: none;
+  cursor: pointer;
+  background: linear-gradient(130deg, rgba(110, 90, 255, 0.9), rgba(255, 80, 160, 0.85));
+  color: white;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+}
+
+button:hover,
+button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 40px rgba(110, 90, 255, 0.45);
+  filter: saturate(1.2);
+}
+
+button:active {
+  transform: translateY(1px);
+}
+
+.palette {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin: 1rem 0 1.2rem;
+}
+
+.swatches {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.swatch {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  box-shadow: inset 0 0 14px rgba(0, 0, 0, 0.4);
+}
+
+.hint {
+  font-size: 0.9rem;
+  opacity: 0.8;
+}
+
+@media (max-width: 600px) {
+  .overlay {
+    align-items: flex-end;
+  }
+
+  .panel {
+    width: 100%;
+    border-radius: 20px 20px 0 0;
+    padding: 1.6rem 1.4rem 2.4rem;
+  }
+
+  .controls {
+    grid-template-columns: 1fr;
+  }
+
+  button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new artist experience that transforms numeric seeds into generative dreamscapes
- style the artist page with a translucent control panel overlaying a cosmic canvas
- implement seeded animation logic with interactive pointer and scroll responses

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e3df73fc808329b966ecd77e6a27ca