### PR TITLE
Improve arcade responsiveness and add branding

### DIFF
--- a/game/2048/index.html
+++ b/game/2048/index.html
@@ -1,0 +1,341 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>2048 퍼즐</title>
+    <style>
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: clamp(16px, 5vw, 60px);
+            background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
+            color: #fff;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+        }
+        .container {
+            background: rgba(12, 32, 66, 0.85);
+            padding: clamp(22px, 5vw, 36px);
+            border-radius: clamp(20px, 4vw, 28px);
+            width: min(100%, 500px);
+            box-shadow: 0 25px 60px rgba(0, 0, 0, 0.45);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+        }
+        header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 20px;
+            gap: 12px;
+            flex-wrap: wrap;
+        }
+        h1 {
+            margin: 0;
+            font-size: clamp(26px, 5vw, 32px);
+            letter-spacing: 1px;
+        }
+        .signature {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 12px;
+            border-radius: 999px;
+            background: rgba(116, 192, 252, 0.2);
+            color: #9ec5fe;
+            font-weight: 700;
+            font-size: 12px;
+        }
+        .score-board {
+            display: flex;
+            gap: 12px;
+            flex-wrap: wrap;
+            justify-content: flex-end;
+        }
+        .badge {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 12px;
+            padding: 10px 16px;
+            text-align: center;
+            font-weight: 600;
+            line-height: 1.4;
+        }
+        .board {
+            position: relative;
+            background: rgba(6, 16, 36, 0.8);
+            border-radius: 16px;
+            padding: 12px;
+            display: grid;
+            grid-template-columns: repeat(4, 1fr);
+            gap: 12px;
+        }
+        .cell {
+            padding-top: 100%;
+            border-radius: 12px;
+            background: rgba(255,255,255,0.06);
+            position: relative;
+            overflow: hidden;
+        }
+        .tile {
+            position: absolute;
+            inset: 0;
+            display: grid;
+            place-items: center;
+            font-weight: 700;
+            font-size: 28px;
+            border-radius: 12px;
+            transform: scale(0.9);
+            transition: transform 0.1s ease;
+        }
+        .tile.new {
+            animation: pop 0.2s ease-out;
+        }
+        .tile.merged {
+            animation: merge 0.25s ease-out;
+        }
+        @keyframes pop {
+            from { transform: scale(0.2); opacity: 0; }
+            to { transform: scale(1); opacity: 1; }
+        }
+        @keyframes merge {
+            from { transform: scale(1.2); }
+            to { transform: scale(1); }
+        }
+        button {
+            margin-top: 20px;
+            width: 100%;
+            padding: 12px;
+            background: #fbc531;
+            border: none;
+            border-radius: 999px;
+            font-weight: 700;
+            cursor: pointer;
+            color: #273c75;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        button:hover, button:focus-visible {
+            transform: translateY(-2px);
+            box-shadow: 0 15px 25px rgba(251, 197, 49, 0.35);
+            outline: none;
+        }
+        p {
+            margin-top: 16px;
+            font-size: 14px;
+            color: rgba(255,255,255,0.75);
+            line-height: 1.5;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <div style="display:flex;flex-direction:column;gap:6px;">
+                <div class="signature">박은성이 만든 게임</div>
+                <h1>2048</h1>
+            </div>
+            <div class="score-board">
+                <div class="badge">점수<br><span id="score">0</span></div>
+                <div class="badge">최고 기록<br><span id="best">0</span></div>
+            </div>
+        </header>
+        <div class="board" id="board"></div>
+        <button id="restart">새 게임</button>
+        <p>방향키 또는 스와이프(모바일)로 타일을 이동하세요. 같은 숫자가 만나면 합쳐집니다!</p>
+    </div>
+
+    <script>
+        const boardEl = document.getElementById('board');
+        const scoreEl = document.getElementById('score');
+        const bestEl = document.getElementById('best');
+        const restartBtn = document.getElementById('restart');
+        const size = 4;
+        let board, score, bestScore = Number(localStorage.getItem('best-2048')) || 0;
+        bestEl.textContent = bestScore;
+
+        function createBoard() {
+            board = Array.from({ length: size }, () => Array(size).fill(0));
+            score = 0;
+            updateScore();
+            boardEl.innerHTML = '';
+            for (let i = 0; i < size * size; i++) {
+                const cell = document.createElement('div');
+                cell.className = 'cell';
+                boardEl.appendChild(cell);
+            }
+            addRandomTile();
+            addRandomTile();
+            render();
+        }
+
+        function updateScore() {
+            scoreEl.textContent = score;
+            if (score > bestScore) {
+                bestScore = score;
+                localStorage.setItem('best-2048', bestScore);
+                bestEl.textContent = bestScore;
+            }
+        }
+
+        function addRandomTile() {
+            const empty = [];
+            for (let y = 0; y < size; y++) {
+                for (let x = 0; x < size; x++) {
+                    if (board[y][x] === 0) empty.push({ x, y });
+                }
+            }
+            if (!empty.length) return false;
+            const { x, y } = empty[Math.floor(Math.random() * empty.length)];
+            board[y][x] = Math.random() < 0.9 ? 2 : 4;
+            return true;
+        }
+
+        function render() {
+            boardEl.querySelectorAll('.cell').forEach((cell, index) => {
+                cell.innerHTML = '';
+                const x = index % size;
+                const y = Math.floor(index / size);
+                const value = board[y][x];
+                if (value) {
+                    const tile = document.createElement('div');
+                    tile.className = 'tile new tile-' + value;
+                    tile.style.background = getTileColor(value);
+                    tile.style.color = value <= 4 ? '#2f3640' : '#f5f6fa';
+                    tile.textContent = value;
+                    cell.appendChild(tile);
+                    requestAnimationFrame(() => tile.classList.remove('new'));
+                }
+            });
+        }
+
+        function getTileColor(value) {
+            const palette = {
+                2: '#cfe2ff',
+                4: '#9ec5fe',
+                8: '#74c0fc',
+                16: '#4dabf7',
+                32: '#339af0',
+                64: '#1864ab',
+                128: '#ffd43b',
+                256: '#fab005',
+                512: '#f08c00',
+                1024: '#e8590c',
+                2048: '#d9480f'
+            };
+            return palette[value] || '#ad1457';
+        }
+
+        function slide(row) {
+            const filtered = row.filter(v => v !== 0);
+            const merged = [];
+            let skip = false;
+            for (let i = 0; i < filtered.length; i++) {
+                if (skip) {
+                    skip = false;
+                    continue;
+                }
+                if (filtered[i] === filtered[i + 1]) {
+                    const value = filtered[i] * 2;
+                    score += value;
+                    merged.push(value);
+                    skip = true;
+                } else {
+                    merged.push(filtered[i]);
+                }
+            }
+            while (merged.length < size) merged.push(0);
+            return merged;
+        }
+
+        function rowsEqual(a, b) {
+            return a.length === b.length && a.every((v, i) => v === b[i]);
+        }
+
+        function move(direction) {
+            const snapshot = board.map(row => [...row]);
+            if (direction === 'left') {
+                for (let y = 0; y < size; y++) {
+                    board[y] = slide(board[y]);
+                }
+            } else if (direction === 'right') {
+                for (let y = 0; y < size; y++) {
+                    board[y] = slide(board[y].slice().reverse()).reverse();
+                }
+            } else if (direction === 'up') {
+                for (let x = 0; x < size; x++) {
+                    const column = board.map(row => row[x]);
+                    const newColumn = slide(column);
+                    board.forEach((row, y) => row[x] = newColumn[y]);
+                }
+            } else if (direction === 'down') {
+                for (let x = 0; x < size; x++) {
+                    const column = board.map(row => row[x]).reverse();
+                    const newColumn = slide(column).reverse();
+                    board.forEach((row, y) => row[x] = newColumn[y]);
+                }
+            }
+            return !snapshot.every((row, y) => row.every((value, x) => value === board[y][x]));
+        }
+
+        function canMove() {
+            for (let y = 0; y < size; y++) {
+                for (let x = 0; x < size; x++) {
+                    const value = board[y][x];
+                    if (value === 0) return true;
+                    if (x < size - 1 && board[y][x + 1] === value) return true;
+                    if (y < size - 1 && board[y + 1][x] === value) return true;
+                }
+            }
+            return false;
+        }
+
+        function handleMove(direction) {
+            const moved = move(direction);
+            if (!moved) return;
+            updateScore();
+            addRandomTile();
+            render();
+            if (!canMove()) {
+                setTimeout(() => alert('게임 오버! 점수: ' + score), 200);
+            }
+        }
+
+        document.addEventListener('keydown', (e) => {
+            const keyMap = {
+                ArrowLeft: 'left',
+                ArrowRight: 'right',
+                ArrowUp: 'up',
+                ArrowDown: 'down'
+            };
+            if (keyMap[e.key]) {
+                e.preventDefault();
+                handleMove(keyMap[e.key]);
+            }
+        });
+
+        let startX, startY;
+        boardEl.addEventListener('touchstart', e => {
+            const touch = e.touches[0];
+            startX = touch.clientX;
+            startY = touch.clientY;
+        });
+        boardEl.addEventListener('touchend', e => {
+            const touch = e.changedTouches[0];
+            const dx = touch.clientX - startX;
+            const dy = touch.clientY - startY;
+            if (Math.abs(dx) > Math.abs(dy)) {
+                if (Math.abs(dx) > 30) handleMove(dx > 0 ? 'right' : 'left');
+            } else {
+                if (Math.abs(dy) > 30) handleMove(dy > 0 ? 'down' : 'up');
+            }
+        });
+
+        restartBtn.addEventListener('click', createBoard);
+
+        createBoard();
+    </script>
+    <script src="../global-enhancements.js" defer></script>
+</body>
+</html>

--- a/game/2048/index.html
+++ b/game/2048/index.html
@@ -2,7 +2,6 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>2048 퍼즐</title>
     <style>
         body {
@@ -128,6 +127,44 @@
             text-align: center;
         }
     </style>
+
+    <!-- Mobile-friendly viewport -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+    <style>
+      :root { --osc-gap: 10px; --osc-btn: 56px; --osc-z: 9999; }
+      .credit-banner{
+        position:fixed; top:env(safe-area-inset-top,0); left:env(safe-area-inset-left,0);
+        margin:8px; padding:6px 10px; font:600 14px/1.2 system-ui, sans-serif;
+        background:rgba(0,0,0,.55); color:#fff; border-radius:8px; z-index:var(--osc-z);
+        -webkit-backdrop-filter:saturate(150%) blur(6px); backdrop-filter:saturate(150%) blur(6px);
+        user-select:none; pointer-events:none;
+      }
+      .osc-wrap{
+        position:fixed; inset:auto 0 env(safe-area-inset-bottom,0) 0;
+        display:flex; justify-content:center; gap:24px; padding:var(--osc-gap);
+        z-index:var(--osc-z); touch-action:manipulation;
+      }
+      .osc { display:flex; align-items:center; gap:16px; }
+      .osc .dpad{ display:grid; grid-template-areas:
+          ".    up    ."
+          "left  mid  right"
+          ".   down   .";
+        gap:8px; align-items:center; justify-items:center;
+      }
+      .osc .actions{ display:flex; gap:10px; }
+      .osc button{
+        min-width:var(--osc-btn); min-height:var(--osc-btn);
+        border:0; border-radius:12px; font:700 16px system-ui, sans-serif;
+        background:rgba(255,255,255,.9); color:#111; box-shadow:0 2px 10px rgba(0,0,0,.2);
+      }
+      .osc .pause{ min-width:72px; }
+      /* 게임 화면 가려짐 방지 */
+      body{ padding-bottom: calc(env(safe-area-inset-bottom,0) + 110px); }
+      @media (pointer:fine){ /* 데스크톱이면 패드 숨김 */
+        .osc-wrap{ display:none; } body{ padding-bottom:0; }
+      }
+    </style>
+
 </head>
 <body>
     <div class="container">
@@ -337,5 +374,67 @@
         createBoard();
     </script>
     <script src="../global-enhancements.js" defer></script>
+
+    <!-- Creator credit -->
+    <div class="credit-banner" aria-hidden="true">Creator: 박은성</div>
+
+    <!-- On-screen Controls -->
+    <div class="osc-wrap" id="osc-wrap" role="group" aria-label="On-screen game controls">
+      <div class="osc">
+        <div class="dpad">
+          <button data-key="ArrowUp"    style="grid-area:up">▲</button>
+          <button data-key="ArrowLeft"  style="grid-area:left">◀</button>
+          <button data-key="ArrowRight" style="grid-area:right">▶</button>
+          <button data-key="ArrowDown"  style="grid-area:down">▼</button>
+        </div>
+        <div class="actions">
+          <button data-key="Space">A</button>
+          <button data-key="Enter">B</button>
+          <button class="pause" data-key="Escape">⏯︎</button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+(function(){
+  // 일부 게임이 window/document/canvas 등 서로 다른 타깃을 구독하므로, 광범위 전파
+  function send(key, type){
+    const ev = new KeyboardEvent(type, { key, code:key, bubbles:true, cancelable:true });
+    const t = document.activeElement && document.activeElement !== document.body
+      ? document.activeElement : document;
+    t.dispatchEvent(ev); window.dispatchEvent(ev);
+  }
+  function pressStart(key){ send(key,'keydown'); }
+  function pressEnd(key){ send(key,'keyup'); }
+
+  // 버튼 터치/클릭 → 키 이벤트 변환
+  document.getElementById('osc-wrap')?.addEventListener('pointerdown', e=>{
+    const btn = e.target.closest('button[data-key]'); if(!btn) return;
+    e.preventDefault(); btn.setPointerCapture?.(e.pointerId);
+    pressStart(btn.dataset.key);
+    btn.addEventListener('pointerup',  ()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('pointercancel',()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('lostpointercapture',()=>pressEnd(btn.dataset.key), { once:true });
+  });
+
+  // 스와이프 제스처 → 방향키
+  let sx=0, sy=0, tracking=false;
+  const TH=24; // 스와이프 임계값(px)
+  document.addEventListener('touchstart', (e)=>{
+    // 오버레이 위 스와이프는 무시
+    if(e.target.closest('#osc-wrap')) return;
+    tracking=true; const t=e.changedTouches[0]; sx=t.clientX; sy=t.clientY;
+  }, {passive:true});
+  document.addEventListener('touchend', (e)=>{
+    if(!tracking) return; tracking=false;
+    const t=e.changedTouches[0]; const dx=t.clientX-sx, dy=t.clientY-sy;
+    if(Math.abs(dx)<TH && Math.abs(dy)<TH) return;
+    const key = Math.abs(dx)>Math.abs(dy) ? (dx>0?'ArrowRight':'ArrowLeft')
+                                          : (dy>0?'ArrowDown':'ArrowUp');
+    pressStart(key); setTimeout(()=>pressEnd(key), 50);
+  }, {passive:true});
+})();
+    </script>
+
 </body>
 </html>

--- a/game/blackjack/index.html
+++ b/game/blackjack/index.html
@@ -1,0 +1,427 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>네온 블랙잭 라운지</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        * { box-sizing: border-box; }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: clamp(24px, 4vw, 56px);
+            background: radial-gradient(circle at 20% -10%, #2e0b35, #03050f 70%, #01030a 100%);
+            color: #fdf9ff;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+        }
+        main {
+            width: min(100%, 960px);
+            background: rgba(11, 9, 24, 0.86);
+            border-radius: 28px;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            padding: clamp(28px, 4vw, 40px);
+            box-shadow: 0 36px 80px rgba(0, 0, 0, 0.55);
+            display: grid;
+            gap: clamp(24px, 4vw, 40px);
+        }
+        header {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+        header h1 { margin: 0; font-size: clamp(32px, 4.4vw, 46px); letter-spacing: -0.02em; }
+        header p { margin: 0; color: rgba(246, 242, 255, 0.8); line-height: 1.6; }
+        .table {
+            display: grid;
+            gap: 22px;
+        }
+        .hand {
+            background: linear-gradient(160deg, rgba(35, 14, 46, 0.9), rgba(14, 8, 36, 0.92));
+            border-radius: 22px;
+            padding: 20px;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+        }
+        .hand h2 {
+            margin: 0 0 14px;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-size: 20px;
+            letter-spacing: 0.02em;
+        }
+        .cards {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            min-height: 120px;
+        }
+        .card {
+            width: 72px;
+            height: 104px;
+            border-radius: 12px;
+            background: linear-gradient(140deg, rgba(255, 255, 255, 0.95), rgba(229, 232, 255, 0.92));
+            border: 2px solid rgba(255, 255, 255, 0.4);
+            color: #0a0830;
+            font-weight: 700;
+            display: grid;
+            grid-template-rows: auto 1fr auto;
+            padding: 8px;
+            box-shadow: 0 14px 26px rgba(0, 0, 0, 0.35);
+            position: relative;
+        }
+        .card.red { color: #b1203b; }
+        .card .symbol { text-align: center; font-size: 26px; }
+        .card .corner { font-size: 20px; }
+        .card.back {
+            background: repeating-linear-gradient(45deg, #211544, #211544 12px, #432f8a 12px, #432f8a 24px);
+            border-color: rgba(255, 255, 255, 0.18);
+        }
+        .controls {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+        }
+        button {
+            border: none;
+            border-radius: 14px;
+            padding: 12px 20px;
+            font-weight: 700;
+            font-size: 15px;
+            cursor: pointer;
+            background: linear-gradient(135deg, #6b5bff, #32d8ff);
+            color: white;
+            box-shadow: 0 20px 36px rgba(86, 94, 255, 0.32);
+            transition: transform 0.18s ease, box-shadow 0.18s ease;
+        }
+        button:hover:not(:disabled) {
+            transform: translateY(-2px);
+            box-shadow: 0 24px 44px rgba(86, 94, 255, 0.4);
+        }
+        button:disabled { opacity: 0.4; cursor: not-allowed; }
+        .chip {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 999px;
+            padding: 6px 12px;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            font-weight: 600;
+        }
+        .status {
+            min-height: 48px;
+            border-radius: 16px;
+            padding: 14px 18px;
+            background: rgba(109, 253, 204, 0.12);
+            border: 1px solid rgba(109, 253, 204, 0.26);
+            color: #dffef5;
+        }
+        .balance {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            flex-wrap: wrap;
+        }
+        input[type="range"] { width: clamp(160px, 30vw, 320px); }
+    </style>
+</head>
+<body>
+    <main>
+        <header>
+            <h1>네온 블랙잭 라운지</h1>
+            <p>딜러와 맞붙어 21점을 노려보세요. 전략적인 스탠드, 과감한 히트, 타이밍 좋은 더블다운으로 자금을 불려 보세요. 카드 카운팅 없이도 즐겁게 플레이할 수 있도록 라이트한 규칙을 적용했습니다.</p>
+        </header>
+        <div class="balance">
+            <span class="chip">보유 칩: <strong id="chips">1000</strong></span>
+            <label class="chip">베팅: <strong id="bet-value">50</strong>
+                <input type="range" id="bet" min="10" max="300" step="10" value="50" />
+            </label>
+            <button id="deal">딜 시작</button>
+        </div>
+        <div class="table">
+            <div class="hand" id="dealer">
+                <h2>딜러 <span id="dealer-total">0</span></h2>
+                <div class="cards" id="dealer-cards"></div>
+            </div>
+            <div class="hand" id="player">
+                <h2>플레이어 <span id="player-total">0</span></h2>
+                <div class="cards" id="player-cards"></div>
+            </div>
+        </div>
+        <div class="controls">
+            <button id="hit" disabled>히트</button>
+            <button id="stand" disabled>스탠드</button>
+            <button id="double" disabled>더블다운</button>
+            <button id="surrender" disabled>서렌더</button>
+        </div>
+        <div class="status" id="status" role="status">베팅을 설정하고 딜을 시작하세요.</div>
+    </main>
+    <script>
+        const suits = ['♠', '♥', '♦', '♣'];
+        const ranks = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '10', 'J', 'Q', 'K'];
+        let deck = [];
+        let playerHand = [];
+        let dealerHand = [];
+        let chips = Number(localStorage.getItem('blackjack-chips') || '1000');
+        let stake = 50;
+        let currentBet = 0;
+        let roundActive = false;
+        let playerTurn = false;
+        let doubleEligible = false;
+
+        const chipsEl = document.getElementById('chips');
+        const betRange = document.getElementById('bet');
+        const betValueEl = document.getElementById('bet-value');
+        const dealerCardsEl = document.getElementById('dealer-cards');
+        const playerCardsEl = document.getElementById('player-cards');
+        const dealerTotalEl = document.getElementById('dealer-total');
+        const playerTotalEl = document.getElementById('player-total');
+        const statusEl = document.getElementById('status');
+        const hitBtn = document.getElementById('hit');
+        const standBtn = document.getElementById('stand');
+        const doubleBtn = document.getElementById('double');
+        const surrenderBtn = document.getElementById('surrender');
+        const dealBtn = document.getElementById('deal');
+
+        function initDeck() {
+            deck = [];
+            for (let s of suits) {
+                for (let r of ranks) {
+                    deck.push({ suit: s, rank: r });
+                }
+            }
+            for (let i = deck.length - 1; i > 0; i--) {
+                const j = Math.floor(Math.random() * (i + 1));
+                [deck[i], deck[j]] = [deck[j], deck[i]];
+            }
+        }
+
+        function cardValue(card) {
+            if (card.rank === 'A') return 11;
+            if (['K', 'Q', 'J'].includes(card.rank)) return 10;
+            return Number(card.rank);
+        }
+
+        function handValue(hand) {
+            let total = 0;
+            let aces = 0;
+            for (const card of hand) {
+                total += cardValue(card);
+                if (card.rank === 'A') aces += 1;
+            }
+            while (total > 21 && aces > 0) {
+                total -= 10;
+                aces -= 1;
+            }
+            return total;
+        }
+
+        function renderHand(container, hand, hideFirst = false) {
+            container.innerHTML = '';
+            hand.forEach((card, index) => {
+                const div = document.createElement('div');
+                div.className = 'card';
+                const isRed = card.suit === '♥' || card.suit === '♦';
+                if (hideFirst && index === 0) {
+                    div.classList.add('back');
+                    container.appendChild(div);
+                    return;
+                }
+                if (isRed) div.classList.add('red');
+                div.innerHTML = `
+                    <div class="corner">${card.rank}</div>
+                    <div class="symbol">${card.suit}</div>
+                    <div class="corner" style="justify-self: end;">${card.rank}</div>
+                `;
+                container.appendChild(div);
+            });
+        }
+
+        function updateTotals(hideDealer = true) {
+            const playerTotal = handValue(playerHand);
+            const dealerTotal = handValue(dealerHand);
+            playerTotalEl.textContent = playerTotal;
+            dealerTotalEl.textContent = hideDealer && playerTurn ? '?' : dealerTotal;
+        }
+
+        function updateChips() {
+            chipsEl.textContent = chips;
+            localStorage.setItem('blackjack-chips', String(chips));
+        }
+
+        function canDeal() {
+            return !roundActive && stake <= chips && stake >= 10;
+        }
+
+        function setControls(active) {
+            hitBtn.disabled = !active;
+            standBtn.disabled = !active;
+            doubleBtn.disabled = !(active && doubleEligible && chips >= currentBet);
+            surrenderBtn.disabled = !active || playerHand.length !== 2;
+        }
+
+        function deal() {
+            if (!canDeal()) {
+                statusEl.textContent = '베팅이 보유 칩보다 크지 않은지 확인하세요.';
+                return;
+            }
+            roundActive = true;
+            playerTurn = true;
+            doubleEligible = true;
+            currentBet = stake;
+            chips -= currentBet;
+            updateChips();
+            betRange.disabled = true;
+            initDeck();
+            playerHand = [deck.pop(), deck.pop()];
+            dealerHand = [deck.pop(), deck.pop()];
+            renderHand(playerCardsEl, playerHand);
+            renderHand(dealerCardsEl, dealerHand, true);
+            updateTotals(true);
+            statusEl.textContent = '히트 혹은 스탠드를 선택하세요. 서렌더는 초반 두 장일 때만 가능합니다.';
+            dealBtn.disabled = true;
+            setControls(true);
+            renderBetValue();
+            if (handValue(playerHand) === 21) {
+                settle('blackjack');
+            }
+        }
+
+        function hit() {
+            if (!playerTurn) return;
+            doubleEligible = false;
+            playerHand.push(deck.pop());
+            renderHand(playerCardsEl, playerHand);
+            const total = handValue(playerHand);
+            updateTotals(true);
+            if (total > 21) {
+                settle('player-bust');
+            }
+        }
+
+        function stand() {
+            if (!playerTurn) return;
+            playerTurn = false;
+            setControls(false);
+            playDealer();
+        }
+
+        function doubleDown() {
+            if (!playerTurn || !doubleEligible || chips < currentBet) return;
+            chips -= currentBet;
+            currentBet *= 2;
+            updateChips();
+            renderBetValue();
+            playerHand.push(deck.pop());
+            renderHand(playerCardsEl, playerHand);
+            updateTotals(true);
+            doubleEligible = false;
+            playerTurn = false;
+            setControls(false);
+            if (handValue(playerHand) > 21) {
+                settle('player-bust');
+            } else {
+                playDealer();
+            }
+        }
+
+        function surrender() {
+            if (!playerTurn || playerHand.length !== 2) return;
+            playerTurn = false;
+            const refund = Math.floor(currentBet / 2);
+            chips += refund;
+            updateChips();
+            statusEl.textContent = '서렌더! 베팅의 절반을 되찾았습니다.';
+            endRound();
+        }
+
+        function playDealer() {
+            renderHand(dealerCardsEl, dealerHand, false);
+            updateTotals(false);
+            let total = handValue(dealerHand);
+            while (total < 17) {
+                dealerHand.push(deck.pop());
+                renderHand(dealerCardsEl, dealerHand, false);
+                total = handValue(dealerHand);
+            }
+            if (total > 21) {
+                settle('dealer-bust');
+            } else {
+                settle('compare');
+            }
+        }
+
+        function settle(reason) {
+            const playerTotal = handValue(playerHand);
+            const dealerTotal = handValue(dealerHand);
+            let payout = 0;
+            let message = '';
+            switch (reason) {
+                case 'blackjack':
+                    payout = Math.floor(currentBet * 2.5);
+                    message = '블랙잭! 3:2 배당으로 승리했습니다.';
+                    break;
+                case 'player-bust':
+                    payout = 0;
+                    message = '버스트! 21을 초과했습니다.';
+                    break;
+                case 'dealer-bust':
+                    payout = currentBet * 2;
+                    message = '딜러 버스트! 깔끔한 승리입니다.';
+                    break;
+                case 'compare':
+                    if (playerTotal > dealerTotal) {
+                        payout = currentBet * 2;
+                        message = `${playerTotal} vs ${dealerTotal}, 승리!`;
+                    } else if (playerTotal < dealerTotal) {
+                        payout = 0;
+                        message = `${playerTotal} vs ${dealerTotal}, 패배했습니다.`;
+                    } else {
+                        payout = currentBet;
+                        message = '푸시! 베팅이 반환됩니다.';
+                    }
+                    break;
+            }
+            chips += payout;
+            updateChips();
+            statusEl.textContent = message;
+            endRound();
+        }
+
+        function endRound() {
+            roundActive = false;
+            playerTurn = false;
+            dealBtn.disabled = false;
+            setControls(false);
+            currentBet = 0;
+            renderBetValue();
+            betRange.disabled = false;
+        }
+
+        function renderBetValue() {
+            betValueEl.textContent = roundActive ? `${currentBet} (진행 중)` : stake;
+        }
+
+        betRange.addEventListener('input', () => {
+            stake = Number(betRange.value);
+            if (!roundActive) renderBetValue();
+        });
+
+        hitBtn.addEventListener('click', hit);
+        standBtn.addEventListener('click', stand);
+        doubleBtn.addEventListener('click', doubleDown);
+        surrenderBtn.addEventListener('click', surrender);
+        dealBtn.addEventListener('click', deal);
+
+        updateChips();
+        renderBetValue();
+        setControls(false);
+    </script>
+    <script src="../global-enhancements.js" defer></script>
+</body>
+</html>

--- a/game/blackjack/index.html
+++ b/game/blackjack/index.html
@@ -2,7 +2,6 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>네온 블랙잭 라운지</title>
     <style>
         :root {
@@ -129,6 +128,44 @@
         }
         input[type="range"] { width: clamp(160px, 30vw, 320px); }
     </style>
+
+    <!-- Mobile-friendly viewport -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+    <style>
+      :root { --osc-gap: 10px; --osc-btn: 56px; --osc-z: 9999; }
+      .credit-banner{
+        position:fixed; top:env(safe-area-inset-top,0); left:env(safe-area-inset-left,0);
+        margin:8px; padding:6px 10px; font:600 14px/1.2 system-ui, sans-serif;
+        background:rgba(0,0,0,.55); color:#fff; border-radius:8px; z-index:var(--osc-z);
+        -webkit-backdrop-filter:saturate(150%) blur(6px); backdrop-filter:saturate(150%) blur(6px);
+        user-select:none; pointer-events:none;
+      }
+      .osc-wrap{
+        position:fixed; inset:auto 0 env(safe-area-inset-bottom,0) 0;
+        display:flex; justify-content:center; gap:24px; padding:var(--osc-gap);
+        z-index:var(--osc-z); touch-action:manipulation;
+      }
+      .osc { display:flex; align-items:center; gap:16px; }
+      .osc .dpad{ display:grid; grid-template-areas:
+          ".    up    ."
+          "left  mid  right"
+          ".   down   .";
+        gap:8px; align-items:center; justify-items:center;
+      }
+      .osc .actions{ display:flex; gap:10px; }
+      .osc button{
+        min-width:var(--osc-btn); min-height:var(--osc-btn);
+        border:0; border-radius:12px; font:700 16px system-ui, sans-serif;
+        background:rgba(255,255,255,.9); color:#111; box-shadow:0 2px 10px rgba(0,0,0,.2);
+      }
+      .osc .pause{ min-width:72px; }
+      /* 게임 화면 가려짐 방지 */
+      body{ padding-bottom: calc(env(safe-area-inset-bottom,0) + 110px); }
+      @media (pointer:fine){ /* 데스크톱이면 패드 숨김 */
+        .osc-wrap{ display:none; } body{ padding-bottom:0; }
+      }
+    </style>
+
 </head>
 <body>
     <main>
@@ -423,5 +460,67 @@
         setControls(false);
     </script>
     <script src="../global-enhancements.js" defer></script>
+
+    <!-- Creator credit -->
+    <div class="credit-banner" aria-hidden="true">Creator: 박은성</div>
+
+    <!-- On-screen Controls -->
+    <div class="osc-wrap" id="osc-wrap" role="group" aria-label="On-screen game controls">
+      <div class="osc">
+        <div class="dpad">
+          <button data-key="ArrowUp"    style="grid-area:up">▲</button>
+          <button data-key="ArrowLeft"  style="grid-area:left">◀</button>
+          <button data-key="ArrowRight" style="grid-area:right">▶</button>
+          <button data-key="ArrowDown"  style="grid-area:down">▼</button>
+        </div>
+        <div class="actions">
+          <button data-key="Space">A</button>
+          <button data-key="Enter">B</button>
+          <button class="pause" data-key="Escape">⏯︎</button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+(function(){
+  // 일부 게임이 window/document/canvas 등 서로 다른 타깃을 구독하므로, 광범위 전파
+  function send(key, type){
+    const ev = new KeyboardEvent(type, { key, code:key, bubbles:true, cancelable:true });
+    const t = document.activeElement && document.activeElement !== document.body
+      ? document.activeElement : document;
+    t.dispatchEvent(ev); window.dispatchEvent(ev);
+  }
+  function pressStart(key){ send(key,'keydown'); }
+  function pressEnd(key){ send(key,'keyup'); }
+
+  // 버튼 터치/클릭 → 키 이벤트 변환
+  document.getElementById('osc-wrap')?.addEventListener('pointerdown', e=>{
+    const btn = e.target.closest('button[data-key]'); if(!btn) return;
+    e.preventDefault(); btn.setPointerCapture?.(e.pointerId);
+    pressStart(btn.dataset.key);
+    btn.addEventListener('pointerup',  ()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('pointercancel',()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('lostpointercapture',()=>pressEnd(btn.dataset.key), { once:true });
+  });
+
+  // 스와이프 제스처 → 방향키
+  let sx=0, sy=0, tracking=false;
+  const TH=24; // 스와이프 임계값(px)
+  document.addEventListener('touchstart', (e)=>{
+    // 오버레이 위 스와이프는 무시
+    if(e.target.closest('#osc-wrap')) return;
+    tracking=true; const t=e.changedTouches[0]; sx=t.clientX; sy=t.clientY;
+  }, {passive:true});
+  document.addEventListener('touchend', (e)=>{
+    if(!tracking) return; tracking=false;
+    const t=e.changedTouches[0]; const dx=t.clientX-sx, dy=t.clientY-sy;
+    if(Math.abs(dx)<TH && Math.abs(dy)<TH) return;
+    const key = Math.abs(dx)>Math.abs(dy) ? (dx>0?'ArrowRight':'ArrowLeft')
+                                          : (dy>0?'ArrowDown':'ArrowUp');
+    pressStart(key); setTimeout(()=>pressEnd(key), 50);
+  }, {passive:true});
+})();
+    </script>
+
 </body>
 </html>

--- a/game/breakout/index.html
+++ b/game/breakout/index.html
@@ -1,0 +1,512 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>네온 벽돌깨기</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: grid;
+            place-items: center;
+            padding: clamp(16px, 5vw, 60px);
+            background: radial-gradient(circle at 50% 0%, #0f1c2d, #050811 70%);
+            color: #f0f6ff;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+        }
+        .panel {
+            background: rgba(8, 16, 32, 0.88);
+            padding: clamp(22px, 5vw, 36px);
+            border-radius: clamp(20px, 4vw, 30px);
+            box-shadow: 0 32px 70px rgba(0, 0, 0, 0.55);
+            display: flex;
+            flex-direction: column;
+            gap: 18px;
+            align-items: center;
+            width: min(100%, 560px);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+        }
+        canvas {
+            background: radial-gradient(circle at 50% 20%, #0b1a2f, #02060e 80%);
+            border-radius: 20px;
+            border: 6px solid rgba(255, 255, 255, 0.04);
+            width: min(100%, 520px);
+            height: auto;
+        }
+        h1 {
+            margin: 0;
+            font-size: clamp(24px, 5vw, 30px);
+            letter-spacing: 2px;
+            text-align: center;
+        }
+        .signature {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 6px 12px;
+            border-radius: 999px;
+            background: rgba(0, 245, 255, 0.18);
+            color: #67d1ff;
+            font-weight: 700;
+            font-size: 13px;
+        }
+        .stats {
+            display: flex;
+            gap: clamp(12px, 5vw, 24px);
+            font-weight: 600;
+            flex-wrap: wrap;
+            justify-content: center;
+        }
+        .controls {
+            font-size: 14px;
+            color: rgba(255, 255, 255, 0.72);
+            text-align: center;
+            line-height: 1.6;
+        }
+        button {
+            background: linear-gradient(130deg, #00f5ff, #3a7bd5);
+            color: #02162c;
+            border: none;
+            border-radius: 999px;
+            padding: 10px 24px;
+            font-weight: 700;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        button:hover, button:focus-visible {
+            transform: translateY(-2px);
+            box-shadow: 0 20px 30px rgba(0, 245, 255, 0.28);
+            outline: none;
+        }
+        @media (max-width: 540px) {
+            canvas {
+                border-width: 4px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="panel">
+        <div class="signature">박은성이 만든 게임</div>
+        <h1>네온 벽돌깨기</h1>
+        <div class="stats">
+            <div>점수: <span id="score">0</span></div>
+            <div>스테이지: <span id="stage">1</span></div>
+            <div>기회: <span id="lives">3</span></div>
+        </div>
+        <canvas id="game" width="520" height="640"></canvas>
+        <button id="restart">다시 시작</button>
+        <p class="controls">마우스 또는 ← → 키로 패들을 움직여 공을 튕기세요.<br>파워업을 받아 다양한 효과를 활용해 모든 벽돌을 제거하면 다음 스테이지로 진행합니다.</p>
+    </div>
+    <script>
+        const canvas = document.getElementById('game');
+        const ctx = canvas.getContext('2d');
+        const scoreEl = document.getElementById('score');
+        const stageEl = document.getElementById('stage');
+        const livesEl = document.getElementById('lives');
+        const restartBtn = document.getElementById('restart');
+
+        const WIDTH = canvas.width;
+        const HEIGHT = canvas.height;
+        const ROWS = 6;
+        const COLS = 10;
+        const BRICK_WIDTH = (WIDTH - 80) / COLS;
+        const BRICK_HEIGHT = 28;
+
+        let mouseX = WIDTH / 2;
+
+        const POWERUPS = [
+            { type: 'expand', color: '#6c5ce7', duration: 10000 },
+            { type: 'multi', color: '#fd79a8', duration: 0 },
+            { type: 'laser', color: '#74b9ff', duration: 8000 }
+        ];
+
+        const lasers = [];
+
+        class Paddle {
+            constructor() {
+                this.width = 110;
+                this.height = 16;
+                this.x = WIDTH / 2 - this.width / 2;
+                this.y = HEIGHT - 60;
+                this.speed = 9;
+                this.expireAt = 0;
+                this.hasLaser = false;
+            }
+            update(delta) {
+                if (keys.ArrowLeft) this.x -= this.speed;
+                if (keys.ArrowRight) this.x += this.speed;
+                const target = mouseX - this.width / 2;
+                this.x += (target - this.x) * Math.min(1, delta * 0.02);
+                this.x = Math.max(20, Math.min(WIDTH - 20 - this.width, this.x));
+                if (this.expireAt && performance.now() > this.expireAt) {
+                    this.width = 110;
+                    this.expireAt = 0;
+                }
+            }
+            draw() {
+                const grd = ctx.createLinearGradient(this.x, this.y, this.x + this.width, this.y + this.height);
+                grd.addColorStop(0, '#0ff0f7');
+                grd.addColorStop(1, '#3a7bd5');
+                ctx.fillStyle = grd;
+                ctx.fillRect(this.x, this.y, this.width, this.height);
+            }
+        }
+
+        class Ball {
+            constructor(x, y) {
+                this.x = x;
+                this.y = y;
+                this.radius = 9;
+                const angle = (Math.random() * 0.5 + 0.25) * Math.PI;
+                this.dx = Math.cos(angle) * 6;
+                this.dy = -Math.abs(Math.sin(angle) * 6);
+            }
+            update(delta) {
+                this.x += this.dx;
+                this.y += this.dy;
+
+                if (this.x < this.radius + 8 || this.x > WIDTH - this.radius - 8) {
+                    this.dx *= -1;
+                    this.x = Math.max(this.radius + 8, Math.min(WIDTH - this.radius - 8, this.x));
+                }
+                if (this.y < this.radius + 12) {
+                    this.dy *= -1;
+                    this.y = this.radius + 12;
+                }
+            }
+            draw() {
+                ctx.beginPath();
+                ctx.fillStyle = '#ffeaa7';
+                ctx.shadowBlur = 12;
+                ctx.shadowColor = '#ffeaa7aa';
+                ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
+                ctx.fill();
+                ctx.shadowBlur = 0;
+            }
+        }
+
+        class Brick {
+            constructor(x, y, hp) {
+                this.x = x;
+                this.y = y;
+                this.hp = hp;
+                this.width = BRICK_WIDTH;
+                this.height = BRICK_HEIGHT;
+                this.dropChance = Math.random() < 0.18;
+            }
+            draw() {
+                if (this.hp <= 0) return;
+                const colors = ['#1dd1a1', '#54a0ff', '#5f27cd'];
+                const color = colors[this.hp - 1] || '#ff7675';
+                ctx.fillStyle = color;
+                ctx.fillRect(this.x, this.y, this.width - 6, this.height - 6);
+            }
+        }
+
+        class PowerUp {
+            constructor(x, y, def) {
+                this.x = x;
+                this.y = y;
+                this.type = def.type;
+                this.color = def.color;
+                this.duration = def.duration;
+                this.speed = 3.2;
+                this.size = 18;
+            }
+            update() {
+                this.y += this.speed;
+            }
+            draw() {
+                ctx.fillStyle = this.color;
+                ctx.beginPath();
+                ctx.arc(this.x, this.y, this.size / 2, 0, Math.PI * 2);
+                ctx.fill();
+                ctx.fillStyle = '#0b1a2f';
+                ctx.font = 'bold 12px Pretendard';
+                ctx.textAlign = 'center';
+                ctx.fillText(this.type[0].toUpperCase(), this.x, this.y + 4);
+            }
+        }
+
+        class Laser {
+            constructor(x, y) {
+                this.x = x;
+                this.y = y;
+                this.speed = 9;
+            }
+            update() {
+                this.y -= this.speed;
+            }
+            draw() {
+                ctx.fillStyle = '#74b9ff';
+                ctx.fillRect(this.x - 2, this.y, 4, 20);
+            }
+        }
+
+        let paddle;
+        let balls;
+        let bricks;
+        let powerUps;
+        let stage = 1;
+        let score = 0;
+        let lives = 3;
+        let lastTime = 0;
+        let keys = { ArrowLeft: false, ArrowRight: false };
+        let running = true;
+
+        function createStage() {
+            bricks = [];
+            const offsetX = 40;
+            const offsetY = 80;
+            for (let r = 0; r < ROWS + stage - 1; r++) {
+                for (let c = 0; c < COLS; c++) {
+                    const hp = 1 + Math.floor(r / 2);
+                    const brickX = offsetX + c * BRICK_WIDTH;
+                    const brickY = offsetY + r * BRICK_HEIGHT;
+                    bricks.push(new Brick(brickX, brickY, Math.min(4, hp)));
+                }
+            }
+        }
+
+        function resetBall() {
+            balls = [new Ball(paddle.x + paddle.width / 2, paddle.y - 12)];
+            balls[0].dx = 0;
+            balls[0].dy = 0;
+        }
+
+        function resetGame() {
+            paddle = new Paddle();
+            stage = 1;
+            score = 0;
+            lives = 3;
+            powerUps = [];
+            lasers.length = 0;
+            createStage();
+            resetBall();
+            prepareServe();
+            running = true;
+            updateUI();
+        }
+
+        function updateUI() {
+            scoreEl.textContent = score;
+            stageEl.textContent = stage;
+            livesEl.textContent = lives;
+        }
+
+        function spawnPowerUp(brick) {
+            const power = POWERUPS[Math.floor(Math.random() * POWERUPS.length)];
+            powerUps.push(new PowerUp(brick.x + brick.width / 2, brick.y + brick.height / 2, power));
+        }
+
+        function activatePowerUp(power) {
+            if (power.type === 'expand') {
+                paddle.width = 160;
+                paddle.expireAt = performance.now() + power.duration;
+            } else if (power.type === 'multi') {
+                if (balls.length < 5) {
+                    const clones = balls.map(ball => {
+                        const clone = new Ball(ball.x, ball.y);
+                        clone.dx = -ball.dx;
+                        clone.dy = ball.dy;
+                        return clone;
+                    });
+                    balls.push(...clones);
+                }
+            } else if (power.type === 'laser') {
+                paddle.hasLaser = true;
+                paddle.expireAt = performance.now() + power.duration;
+            }
+        }
+
+        function launchBallFromPaddle(ball) {
+            if (ball.dy > 0) return;
+            const hit = (ball.x - paddle.x) / paddle.width - 0.5;
+            const angle = hit * Math.PI / 3;
+            const speed = Math.hypot(ball.dx, ball.dy);
+            ball.dx = Math.sin(angle) * speed * 1.05;
+            ball.dy = -Math.cos(angle) * speed * 1.05;
+        }
+
+        function handleCollisions(ball) {
+            if (ball.y + ball.radius >= paddle.y &&
+                ball.x >= paddle.x && ball.x <= paddle.x + paddle.width &&
+                ball.dy > 0) {
+                ball.y = paddle.y - ball.radius;
+                launchBallFromPaddle(ball);
+                if (paddle.hasLaser) {
+                    lasers.push(new Laser(ball.x - 12, paddle.y));
+                    lasers.push(new Laser(ball.x + 12, paddle.y));
+                }
+            }
+
+            for (const brick of bricks) {
+                if (brick.hp <= 0) continue;
+                if (ball.x + ball.radius < brick.x || ball.x - ball.radius > brick.x + brick.width) continue;
+                if (ball.y + ball.radius < brick.y || ball.y - ball.radius > brick.y + brick.height) continue;
+
+                const overlapX = Math.min(ball.x + ball.radius - brick.x, brick.x + brick.width - (ball.x - ball.radius));
+                const overlapY = Math.min(ball.y + ball.radius - brick.y, brick.y + brick.height - (ball.y - ball.radius));
+                if (overlapX < overlapY) {
+                    ball.dx *= -1;
+                } else {
+                    ball.dy *= -1;
+                }
+                brick.hp--;
+                score += 50;
+                updateUI();
+                if (brick.hp <= 0 && brick.dropChance && Math.random() < 0.6) {
+                    spawnPowerUp(brick);
+                }
+                break;
+            }
+        }
+
+        function update(time = 0) {
+            if (!running) return;
+            const delta = time - lastTime;
+            lastTime = time;
+            ctx.clearRect(0, 0, WIDTH, HEIGHT);
+
+            paddle.update(delta);
+            paddle.draw();
+
+            powerUps = powerUps.filter(power => {
+                power.update();
+                power.draw();
+                if (power.y > HEIGHT) return false;
+                if (power.y + power.size / 2 >= paddle.y && power.x >= paddle.x && power.x <= paddle.x + paddle.width) {
+                    activatePowerUp(power);
+                    return false;
+                }
+                return true;
+            });
+
+            lasers.forEach(laser => laser.update());
+            lasers.forEach(laser => laser.draw());
+            for (const laser of lasers) {
+                for (const brick of bricks) {
+                    if (brick.hp <= 0) continue;
+                    if (laser.x >= brick.x && laser.x <= brick.x + brick.width &&
+                        laser.y <= brick.y + brick.height && laser.y + 20 >= brick.y) {
+                        brick.hp--;
+                        score += 80;
+                        updateUI();
+                        laser.y = -100;
+                        if (brick.hp <= 0 && brick.dropChance && Math.random() < 0.5) {
+                            spawnPowerUp(brick);
+                        }
+                    }
+                }
+            }
+            for (let i = lasers.length - 1; i >= 0; i--) {
+                if (lasers[i].y < -30) lasers.splice(i, 1);
+            }
+
+            for (let i = balls.length - 1; i >= 0; i--) {
+                const ball = balls[i];
+                ball.update(delta);
+                handleCollisions(ball);
+                ball.draw();
+                if (ball.y - ball.radius > HEIGHT) {
+                    balls.splice(i, 1);
+                }
+            }
+
+            if (!balls.length) {
+                lives--;
+                updateUI();
+                paddle.hasLaser = false;
+                paddle.width = 110;
+                if (lives <= 0) {
+                    running = false;
+                    showGameOver();
+                    return;
+                }
+                resetBall();
+                powerUps = [];
+                prepareServe();
+            }
+
+            if (bricks.every(brick => brick.hp <= 0)) {
+                stage++;
+                updateUI();
+                paddle.hasLaser = false;
+                paddle.width = 110;
+                lasers.length = 0;
+                powerUps = [];
+                createStage();
+                resetBall();
+                prepareServe();
+            }
+
+            requestAnimationFrame(update);
+        }
+
+        function showGameOver() {
+            ctx.fillStyle = 'rgba(2, 6, 14, 0.82)';
+            ctx.fillRect(0, 0, WIDTH, HEIGHT);
+            ctx.fillStyle = '#f5f6fa';
+            ctx.font = '32px Pretendard, sans-serif';
+            ctx.textAlign = 'center';
+            ctx.fillText('게임 오버', WIDTH / 2, HEIGHT / 2 - 12);
+            ctx.font = '20px Pretendard, sans-serif';
+            ctx.fillText('다시 시작 버튼을 눌러 재도전하세요!', WIDTH / 2, HEIGHT / 2 + 24);
+        }
+
+        restartBtn.addEventListener('click', () => {
+            resetGame();
+            lastTime = performance.now();
+            requestAnimationFrame(update);
+        });
+
+        document.addEventListener('mousemove', e => {
+            const rect = canvas.getBoundingClientRect();
+            mouseX = e.clientX - rect.left;
+        });
+
+        document.addEventListener('keydown', e => {
+            if (keys.hasOwnProperty(e.key)) keys[e.key] = true;
+            if (e.code === 'Space' && running && balls.length === 1 && balls[0].dy === 0) {
+                balls[0].dy = -6;
+            }
+        });
+        document.addEventListener('keyup', e => {
+            if (keys.hasOwnProperty(e.key)) keys[e.key] = false;
+        });
+
+        canvas.addEventListener('click', () => {
+            if (!running) return;
+            const ball = balls[0];
+            if (ball && ball.dy === 0) {
+                ball.dy = -6;
+            } else if (paddle.hasLaser) {
+                lasers.push(new Laser(paddle.x + 20, paddle.y));
+                lasers.push(new Laser(paddle.x + paddle.width - 20, paddle.y));
+            }
+        });
+
+        function prepareServe() {
+            balls.forEach(ball => {
+                ball.x = paddle.x + paddle.width / 2;
+                ball.y = paddle.y - 12;
+                ball.dx = 0;
+                ball.dy = 0;
+            });
+        }
+
+        canvas.addEventListener('mouseenter', prepareServe);
+        canvas.addEventListener('mouseleave', prepareServe);
+
+        resetGame();
+        prepareServe();
+        requestAnimationFrame(update);
+    </script>
+    <script src="../global-enhancements.js" defer></script>
+</body>
+</html>

--- a/game/breakout/index.html
+++ b/game/breakout/index.html
@@ -2,7 +2,6 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>네온 벽돌깨기</title>
     <style>
         :root {
@@ -88,6 +87,44 @@
             }
         }
     </style>
+
+    <!-- Mobile-friendly viewport -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+    <style>
+      :root { --osc-gap: 10px; --osc-btn: 56px; --osc-z: 9999; }
+      .credit-banner{
+        position:fixed; top:env(safe-area-inset-top,0); left:env(safe-area-inset-left,0);
+        margin:8px; padding:6px 10px; font:600 14px/1.2 system-ui, sans-serif;
+        background:rgba(0,0,0,.55); color:#fff; border-radius:8px; z-index:var(--osc-z);
+        -webkit-backdrop-filter:saturate(150%) blur(6px); backdrop-filter:saturate(150%) blur(6px);
+        user-select:none; pointer-events:none;
+      }
+      .osc-wrap{
+        position:fixed; inset:auto 0 env(safe-area-inset-bottom,0) 0;
+        display:flex; justify-content:center; gap:24px; padding:var(--osc-gap);
+        z-index:var(--osc-z); touch-action:manipulation;
+      }
+      .osc { display:flex; align-items:center; gap:16px; }
+      .osc .dpad{ display:grid; grid-template-areas:
+          ".    up    ."
+          "left  mid  right"
+          ".   down   .";
+        gap:8px; align-items:center; justify-items:center;
+      }
+      .osc .actions{ display:flex; gap:10px; }
+      .osc button{
+        min-width:var(--osc-btn); min-height:var(--osc-btn);
+        border:0; border-radius:12px; font:700 16px system-ui, sans-serif;
+        background:rgba(255,255,255,.9); color:#111; box-shadow:0 2px 10px rgba(0,0,0,.2);
+      }
+      .osc .pause{ min-width:72px; }
+      /* 게임 화면 가려짐 방지 */
+      body{ padding-bottom: calc(env(safe-area-inset-bottom,0) + 110px); }
+      @media (pointer:fine){ /* 데스크톱이면 패드 숨김 */
+        .osc-wrap{ display:none; } body{ padding-bottom:0; }
+      }
+    </style>
+
 </head>
 <body>
     <div class="panel">
@@ -508,5 +545,67 @@
         requestAnimationFrame(update);
     </script>
     <script src="../global-enhancements.js" defer></script>
+
+    <!-- Creator credit -->
+    <div class="credit-banner" aria-hidden="true">Creator: 박은성</div>
+
+    <!-- On-screen Controls -->
+    <div class="osc-wrap" id="osc-wrap" role="group" aria-label="On-screen game controls">
+      <div class="osc">
+        <div class="dpad">
+          <button data-key="ArrowUp"    style="grid-area:up">▲</button>
+          <button data-key="ArrowLeft"  style="grid-area:left">◀</button>
+          <button data-key="ArrowRight" style="grid-area:right">▶</button>
+          <button data-key="ArrowDown"  style="grid-area:down">▼</button>
+        </div>
+        <div class="actions">
+          <button data-key="Space">A</button>
+          <button data-key="Enter">B</button>
+          <button class="pause" data-key="Escape">⏯︎</button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+(function(){
+  // 일부 게임이 window/document/canvas 등 서로 다른 타깃을 구독하므로, 광범위 전파
+  function send(key, type){
+    const ev = new KeyboardEvent(type, { key, code:key, bubbles:true, cancelable:true });
+    const t = document.activeElement && document.activeElement !== document.body
+      ? document.activeElement : document;
+    t.dispatchEvent(ev); window.dispatchEvent(ev);
+  }
+  function pressStart(key){ send(key,'keydown'); }
+  function pressEnd(key){ send(key,'keyup'); }
+
+  // 버튼 터치/클릭 → 키 이벤트 변환
+  document.getElementById('osc-wrap')?.addEventListener('pointerdown', e=>{
+    const btn = e.target.closest('button[data-key]'); if(!btn) return;
+    e.preventDefault(); btn.setPointerCapture?.(e.pointerId);
+    pressStart(btn.dataset.key);
+    btn.addEventListener('pointerup',  ()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('pointercancel',()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('lostpointercapture',()=>pressEnd(btn.dataset.key), { once:true });
+  });
+
+  // 스와이프 제스처 → 방향키
+  let sx=0, sy=0, tracking=false;
+  const TH=24; // 스와이프 임계값(px)
+  document.addEventListener('touchstart', (e)=>{
+    // 오버레이 위 스와이프는 무시
+    if(e.target.closest('#osc-wrap')) return;
+    tracking=true; const t=e.changedTouches[0]; sx=t.clientX; sy=t.clientY;
+  }, {passive:true});
+  document.addEventListener('touchend', (e)=>{
+    if(!tracking) return; tracking=false;
+    const t=e.changedTouches[0]; const dx=t.clientX-sx, dy=t.clientY-sy;
+    if(Math.abs(dx)<TH && Math.abs(dy)<TH) return;
+    const key = Math.abs(dx)>Math.abs(dy) ? (dx>0?'ArrowRight':'ArrowLeft')
+                                          : (dy>0?'ArrowDown':'ArrowUp');
+    pressStart(key); setTimeout(()=>pressEnd(key), 50);
+  }, {passive:true});
+})();
+    </script>
+
 </body>
 </html>

--- a/game/flappy/index.html
+++ b/game/flappy/index.html
@@ -2,7 +2,6 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>플래피 비행</title>
     <style>
         :root {
@@ -78,6 +77,44 @@
             line-height: 1.6;
         }
     </style>
+
+    <!-- Mobile-friendly viewport -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+    <style>
+      :root { --osc-gap: 10px; --osc-btn: 56px; --osc-z: 9999; }
+      .credit-banner{
+        position:fixed; top:env(safe-area-inset-top,0); left:env(safe-area-inset-left,0);
+        margin:8px; padding:6px 10px; font:600 14px/1.2 system-ui, sans-serif;
+        background:rgba(0,0,0,.55); color:#fff; border-radius:8px; z-index:var(--osc-z);
+        -webkit-backdrop-filter:saturate(150%) blur(6px); backdrop-filter:saturate(150%) blur(6px);
+        user-select:none; pointer-events:none;
+      }
+      .osc-wrap{
+        position:fixed; inset:auto 0 env(safe-area-inset-bottom,0) 0;
+        display:flex; justify-content:center; gap:24px; padding:var(--osc-gap);
+        z-index:var(--osc-z); touch-action:manipulation;
+      }
+      .osc { display:flex; align-items:center; gap:16px; }
+      .osc .dpad{ display:grid; grid-template-areas:
+          ".    up    ."
+          "left  mid  right"
+          ".   down   .";
+        gap:8px; align-items:center; justify-items:center;
+      }
+      .osc .actions{ display:flex; gap:10px; }
+      .osc button{
+        min-width:var(--osc-btn); min-height:var(--osc-btn);
+        border:0; border-radius:12px; font:700 16px system-ui, sans-serif;
+        background:rgba(255,255,255,.9); color:#111; box-shadow:0 2px 10px rgba(0,0,0,.2);
+      }
+      .osc .pause{ min-width:72px; }
+      /* 게임 화면 가려짐 방지 */
+      body{ padding-bottom: calc(env(safe-area-inset-bottom,0) + 110px); }
+      @media (pointer:fine){ /* 데스크톱이면 패드 숨김 */
+        .osc-wrap{ display:none; } body{ padding-bottom:0; }
+      }
+    </style>
+
 </head>
 <body>
     <div class="container">
@@ -336,5 +373,67 @@
         ctx.fillText('화면을 클릭하거나 스페이스 키로 시작하세요!', WIDTH / 2, 280);
     </script>
     <script src="../global-enhancements.js" defer></script>
+
+    <!-- Creator credit -->
+    <div class="credit-banner" aria-hidden="true">Creator: 박은성</div>
+
+    <!-- On-screen Controls -->
+    <div class="osc-wrap" id="osc-wrap" role="group" aria-label="On-screen game controls">
+      <div class="osc">
+        <div class="dpad">
+          <button data-key="ArrowUp"    style="grid-area:up">▲</button>
+          <button data-key="ArrowLeft"  style="grid-area:left">◀</button>
+          <button data-key="ArrowRight" style="grid-area:right">▶</button>
+          <button data-key="ArrowDown"  style="grid-area:down">▼</button>
+        </div>
+        <div class="actions">
+          <button data-key="Space">A</button>
+          <button data-key="Enter">B</button>
+          <button class="pause" data-key="Escape">⏯︎</button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+(function(){
+  // 일부 게임이 window/document/canvas 등 서로 다른 타깃을 구독하므로, 광범위 전파
+  function send(key, type){
+    const ev = new KeyboardEvent(type, { key, code:key, bubbles:true, cancelable:true });
+    const t = document.activeElement && document.activeElement !== document.body
+      ? document.activeElement : document;
+    t.dispatchEvent(ev); window.dispatchEvent(ev);
+  }
+  function pressStart(key){ send(key,'keydown'); }
+  function pressEnd(key){ send(key,'keyup'); }
+
+  // 버튼 터치/클릭 → 키 이벤트 변환
+  document.getElementById('osc-wrap')?.addEventListener('pointerdown', e=>{
+    const btn = e.target.closest('button[data-key]'); if(!btn) return;
+    e.preventDefault(); btn.setPointerCapture?.(e.pointerId);
+    pressStart(btn.dataset.key);
+    btn.addEventListener('pointerup',  ()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('pointercancel',()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('lostpointercapture',()=>pressEnd(btn.dataset.key), { once:true });
+  });
+
+  // 스와이프 제스처 → 방향키
+  let sx=0, sy=0, tracking=false;
+  const TH=24; // 스와이프 임계값(px)
+  document.addEventListener('touchstart', (e)=>{
+    // 오버레이 위 스와이프는 무시
+    if(e.target.closest('#osc-wrap')) return;
+    tracking=true; const t=e.changedTouches[0]; sx=t.clientX; sy=t.clientY;
+  }, {passive:true});
+  document.addEventListener('touchend', (e)=>{
+    if(!tracking) return; tracking=false;
+    const t=e.changedTouches[0]; const dx=t.clientX-sx, dy=t.clientY-sy;
+    if(Math.abs(dx)<TH && Math.abs(dy)<TH) return;
+    const key = Math.abs(dx)>Math.abs(dy) ? (dx>0?'ArrowRight':'ArrowLeft')
+                                          : (dy>0?'ArrowDown':'ArrowUp');
+    pressStart(key); setTimeout(()=>pressEnd(key), 50);
+  }, {passive:true});
+})();
+    </script>
+
 </body>
 </html>

--- a/game/flappy/index.html
+++ b/game/flappy/index.html
@@ -1,0 +1,340 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>플래피 비행</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: grid;
+            place-items: center;
+            padding: clamp(16px, 5vw, 48px);
+            background: linear-gradient(180deg, #0f2027, #203a43, #2c5364);
+            color: #f5f6fa;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+        }
+        .container {
+            background: rgba(10, 25, 36, 0.88);
+            padding: clamp(22px, 5vw, 34px);
+            border-radius: clamp(20px, 4vw, 28px);
+            box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
+            text-align: center;
+            display: flex;
+            flex-direction: column;
+            gap: 18px;
+            align-items: center;
+            width: min(100%, 520px);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+        }
+        canvas {
+            border-radius: 18px;
+            border: 6px solid rgba(255, 255, 255, 0.08);
+            background: linear-gradient(180deg, #3c73d3 0%, #5ad0ff 40%, #98e4ff 60%, #fefefe 100%);
+            width: min(100%, 420px);
+            height: auto;
+        }
+        .stats {
+            display: flex;
+            gap: clamp(12px, 4vw, 20px);
+            font-weight: 600;
+            flex-wrap: wrap;
+            justify-content: center;
+        }
+        .signature {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 6px 12px;
+            border-radius: 999px;
+            background: rgba(255, 204, 51, 0.16);
+            color: #ffe07d;
+            font-weight: 700;
+            font-size: 13px;
+        }
+        button {
+            background: linear-gradient(135deg, #ffb347, #ffcc33);
+            color: #1f2933;
+            border: none;
+            padding: 10px 24px;
+            border-radius: 999px;
+            cursor: pointer;
+            font-weight: 700;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        button:hover, button:focus-visible {
+            transform: translateY(-2px);
+            box-shadow: 0 18px 26px rgba(255, 204, 51, 0.35);
+            outline: none;
+        }
+        p {
+            margin: 0;
+            font-size: 14px;
+            color: rgba(255, 255, 255, 0.75);
+            line-height: 1.6;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="signature">박은성이 만든 게임</div>
+        <h1 style="margin:0;font-size:clamp(24px,5vw,30px);letter-spacing:1px;">플래피 비행</h1>
+        <div class="stats">
+            <div>점수: <span id="score">0</span></div>
+            <div>최고: <span id="best">0</span></div>
+        </div>
+        <canvas id="game" width="420" height="560"></canvas>
+        <button id="restart">다시 시작</button>
+        <p>탭/클릭 또는 스페이스, ↑ 키로 상승하세요. 파이프 사이를 통과해 점수를 올려 보세요!</p>
+    </div>
+
+    <script>
+        const canvas = document.getElementById('game');
+        const ctx = canvas.getContext('2d');
+        const scoreEl = document.getElementById('score');
+        const bestEl = document.getElementById('best');
+        const restartBtn = document.getElementById('restart');
+
+        const WIDTH = canvas.width;
+        const HEIGHT = canvas.height;
+        const GRAVITY = 0.0028;
+        const JUMP = -0.72;
+        const GAP = 150;
+
+        let bird;
+        let pipes;
+        let particles;
+        let score;
+        let best = Number(localStorage.getItem('flappy-best')) || 0;
+        let running = false;
+        let lastTime = 0;
+
+        bestEl.textContent = best;
+
+        function resetGame() {
+            bird = {
+                x: WIDTH * 0.25,
+                y: HEIGHT / 2,
+                radius: 18,
+                velocity: 0,
+                rotation: 0
+            };
+            pipes = [];
+            particles = [];
+            score = 0;
+            scoreEl.textContent = score;
+            running = true;
+            lastTime = performance.now();
+        }
+
+        function spawnPipe() {
+            const margin = 70;
+            const topHeight = margin + Math.random() * (HEIGHT - GAP - margin * 2);
+            pipes.push({
+                x: WIDTH + 40,
+                width: 64,
+                top: topHeight,
+                bottom: topHeight + GAP,
+                passed: false
+            });
+        }
+
+        function drawBackground() {
+            ctx.fillStyle = '#87ceeb';
+            ctx.fillRect(0, 0, WIDTH, HEIGHT);
+            ctx.fillStyle = '#fefefe';
+            for (let i = 0; i < 6; i++) {
+                ctx.globalAlpha = 0.25;
+                const radius = 40 + i * 12;
+                const cx = 60 + i * 50;
+                ctx.beginPath();
+                ctx.arc(cx, 90, radius, Math.PI * 0.5, Math.PI * 1.5);
+                ctx.arc(cx + radius, 90, radius, Math.PI * 1.5, Math.PI * 0.5);
+                ctx.fill();
+            }
+            ctx.globalAlpha = 1;
+            ctx.fillStyle = '#48a868';
+            ctx.fillRect(0, HEIGHT - 80, WIDTH, 80);
+            ctx.fillStyle = '#3b8b5d';
+            ctx.fillRect(0, HEIGHT - 70, WIDTH, 70);
+        }
+
+        function drawBird() {
+            ctx.save();
+            ctx.translate(bird.x, bird.y);
+            ctx.rotate(bird.rotation);
+            ctx.fillStyle = '#ffe066';
+            ctx.beginPath();
+            ctx.ellipse(0, 0, bird.radius + 4, bird.radius, 0, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.fillStyle = '#ff922b';
+            ctx.beginPath();
+            ctx.arc(bird.radius + 6, 0, 10, -0.5, 0.5);
+            ctx.fill();
+            ctx.fillStyle = '#1e272e';
+            ctx.beginPath();
+            ctx.arc(6, -5, 5, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.fillStyle = '#fff';
+            ctx.beginPath();
+            ctx.arc(7, -6, 2.5, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.restore();
+        }
+
+        function drawPipes(delta) {
+            const speed = 0.22 + Math.min(score * 0.012, 0.18);
+            for (const pipe of pipes) {
+                pipe.x -= speed * delta;
+                ctx.fillStyle = '#2d3436';
+                ctx.fillRect(pipe.x - 3, 0, pipe.width + 6, pipe.top);
+                ctx.fillRect(pipe.x - 3, pipe.bottom, pipe.width + 6, HEIGHT - pipe.bottom);
+                ctx.fillStyle = '#55efc4';
+                ctx.fillRect(pipe.x, 0, pipe.width, pipe.top - 10);
+                ctx.fillRect(pipe.x, pipe.bottom + 10, pipe.width, HEIGHT - pipe.bottom - 10);
+                ctx.fillStyle = '#81ecec';
+                ctx.fillRect(pipe.x - 5, pipe.top - 10, pipe.width + 10, 12);
+                ctx.fillRect(pipe.x - 5, pipe.bottom - 2, pipe.width + 10, 12);
+            }
+            while (pipes.length && pipes[0].x + pipes[0].width < -60) {
+                pipes.shift();
+            }
+        }
+
+        function drawParticles(delta) {
+            particles = particles.filter(p => {
+                p.life -= delta;
+                if (p.life <= 0) return false;
+                p.x += p.vx * delta * 0.06;
+                p.y += p.vy * delta * 0.06;
+                p.vy += GRAVITY * 0.2;
+                ctx.fillStyle = `rgba(255, 255, 255, ${p.life / 600})`;
+                ctx.fillRect(p.x, p.y, 3, 3);
+                return true;
+            });
+        }
+
+        let spawnTimer = 0;
+
+        function update(time = 0) {
+            if (!running) return;
+            const delta = time - lastTime;
+            lastTime = time;
+            spawnTimer += delta;
+
+            drawBackground();
+            drawPipes(delta);
+            drawParticles(delta);
+
+            if (spawnTimer > 1600) {
+                spawnPipe();
+                spawnTimer = 0;
+            }
+
+            bird.velocity += GRAVITY * delta;
+            bird.y += bird.velocity * delta;
+            bird.rotation = Math.min(1.2, Math.max(-0.45, bird.velocity / 8));
+
+            if (bird.y + bird.radius > HEIGHT - 70) {
+                bird.y = HEIGHT - 70 - bird.radius;
+                endGame();
+            }
+            if (bird.y - bird.radius < 0) {
+                bird.y = bird.radius;
+                bird.velocity = 0;
+            }
+
+            for (const pipe of pipes) {
+                if (!pipe.passed && bird.x > pipe.x + pipe.width) {
+                    pipe.passed = true;
+                    score++;
+                    scoreEl.textContent = score;
+                    if (score > best) {
+                        best = score;
+                        localStorage.setItem('flappy-best', best);
+                        bestEl.textContent = best;
+                    }
+                }
+                if (bird.x + bird.radius > pipe.x && bird.x - bird.radius < pipe.x + pipe.width) {
+                    if (bird.y - bird.radius < pipe.top || bird.y + bird.radius > pipe.bottom) {
+                        endGame();
+                    }
+                }
+            }
+
+            drawBird();
+            requestAnimationFrame(update);
+        }
+
+        function flap() {
+            if (!running) {
+                resetGame();
+                spawnTimer = 0;
+                spawnPipe();
+                requestAnimationFrame(update);
+            }
+            bird.velocity = JUMP;
+            bird.rotation = -0.6;
+            for (let i = 0; i < 6; i++) {
+                particles.push({
+                    x: bird.x - 10,
+                    y: bird.y + 6,
+                    vx: -Math.random() * 0.12,
+                    vy: (Math.random() - 0.5) * 0.4,
+                    life: 600
+                });
+            }
+        }
+
+        function endGame() {
+            if (!running) return;
+            running = false;
+            ctx.fillStyle = 'rgba(2, 6, 14, 0.75)';
+            ctx.fillRect(0, 0, WIDTH, HEIGHT);
+            ctx.fillStyle = '#f5f6fa';
+            ctx.font = '28px Pretendard, sans-serif';
+            ctx.textAlign = 'center';
+            ctx.fillText('게임 오버!', WIDTH / 2, HEIGHT / 2 - 16);
+            ctx.font = '18px Pretendard, sans-serif';
+            ctx.fillText('다시 시작 버튼이나 화면을 눌러 재도전하세요.', WIDTH / 2, HEIGHT / 2 + 22);
+        }
+
+        function handleInput(e) {
+            e.preventDefault();
+            flap();
+        }
+
+        canvas.addEventListener('mousedown', handleInput);
+        canvas.addEventListener('touchstart', handleInput, { passive: false });
+        document.addEventListener('keydown', e => {
+            if (e.code === 'Space' || e.code === 'ArrowUp') {
+                handleInput(e);
+            }
+        });
+
+        restartBtn.addEventListener('click', () => {
+            resetGame();
+            spawnTimer = 0;
+            pipes = [];
+            spawnPipe();
+            requestAnimationFrame(update);
+        });
+
+        resetGame();
+        running = false;
+        drawBackground();
+        drawBird();
+        ctx.fillStyle = 'rgba(0, 0, 0, 0.45)';
+        ctx.fillRect(40, 220, WIDTH - 80, 120);
+        ctx.fillStyle = '#f5f6fa';
+        ctx.font = '20px Pretendard, sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillText('화면을 클릭하거나 스페이스 키로 시작하세요!', WIDTH / 2, 280);
+    </script>
+    <script src="../global-enhancements.js" defer></script>
+</body>
+</html>

--- a/game/frogger/index.html
+++ b/game/frogger/index.html
@@ -2,7 +2,6 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>레트로 개구리 건너기</title>
     <style>
         :root {
@@ -103,6 +102,44 @@
             background: linear-gradient(140deg, #8ef18a, #2fe191);
         }
     </style>
+
+    <!-- Mobile-friendly viewport -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+    <style>
+      :root { --osc-gap: 10px; --osc-btn: 56px; --osc-z: 9999; }
+      .credit-banner{
+        position:fixed; top:env(safe-area-inset-top,0); left:env(safe-area-inset-left,0);
+        margin:8px; padding:6px 10px; font:600 14px/1.2 system-ui, sans-serif;
+        background:rgba(0,0,0,.55); color:#fff; border-radius:8px; z-index:var(--osc-z);
+        -webkit-backdrop-filter:saturate(150%) blur(6px); backdrop-filter:saturate(150%) blur(6px);
+        user-select:none; pointer-events:none;
+      }
+      .osc-wrap{
+        position:fixed; inset:auto 0 env(safe-area-inset-bottom,0) 0;
+        display:flex; justify-content:center; gap:24px; padding:var(--osc-gap);
+        z-index:var(--osc-z); touch-action:manipulation;
+      }
+      .osc { display:flex; align-items:center; gap:16px; }
+      .osc .dpad{ display:grid; grid-template-areas:
+          ".    up    ."
+          "left  mid  right"
+          ".   down   .";
+        gap:8px; align-items:center; justify-items:center;
+      }
+      .osc .actions{ display:flex; gap:10px; }
+      .osc button{
+        min-width:var(--osc-btn); min-height:var(--osc-btn);
+        border:0; border-radius:12px; font:700 16px system-ui, sans-serif;
+        background:rgba(255,255,255,.9); color:#111; box-shadow:0 2px 10px rgba(0,0,0,.2);
+      }
+      .osc .pause{ min-width:72px; }
+      /* 게임 화면 가려짐 방지 */
+      body{ padding-bottom: calc(env(safe-area-inset-bottom,0) + 110px); }
+      @media (pointer:fine){ /* 데스크톱이면 패드 숨김 */
+        .osc-wrap{ display:none; } body{ padding-bottom:0; }
+      }
+    </style>
+
 </head>
 <body>
     <main>
@@ -464,5 +501,67 @@
         startGame(true);
     </script>
     <script src="../global-enhancements.js" defer></script>
+
+    <!-- Creator credit -->
+    <div class="credit-banner" aria-hidden="true">Creator: 박은성</div>
+
+    <!-- On-screen Controls -->
+    <div class="osc-wrap" id="osc-wrap" role="group" aria-label="On-screen game controls">
+      <div class="osc">
+        <div class="dpad">
+          <button data-key="ArrowUp"    style="grid-area:up">▲</button>
+          <button data-key="ArrowLeft"  style="grid-area:left">◀</button>
+          <button data-key="ArrowRight" style="grid-area:right">▶</button>
+          <button data-key="ArrowDown"  style="grid-area:down">▼</button>
+        </div>
+        <div class="actions">
+          <button data-key="Space">A</button>
+          <button data-key="Enter">B</button>
+          <button class="pause" data-key="Escape">⏯︎</button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+(function(){
+  // 일부 게임이 window/document/canvas 등 서로 다른 타깃을 구독하므로, 광범위 전파
+  function send(key, type){
+    const ev = new KeyboardEvent(type, { key, code:key, bubbles:true, cancelable:true });
+    const t = document.activeElement && document.activeElement !== document.body
+      ? document.activeElement : document;
+    t.dispatchEvent(ev); window.dispatchEvent(ev);
+  }
+  function pressStart(key){ send(key,'keydown'); }
+  function pressEnd(key){ send(key,'keyup'); }
+
+  // 버튼 터치/클릭 → 키 이벤트 변환
+  document.getElementById('osc-wrap')?.addEventListener('pointerdown', e=>{
+    const btn = e.target.closest('button[data-key]'); if(!btn) return;
+    e.preventDefault(); btn.setPointerCapture?.(e.pointerId);
+    pressStart(btn.dataset.key);
+    btn.addEventListener('pointerup',  ()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('pointercancel',()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('lostpointercapture',()=>pressEnd(btn.dataset.key), { once:true });
+  });
+
+  // 스와이프 제스처 → 방향키
+  let sx=0, sy=0, tracking=false;
+  const TH=24; // 스와이프 임계값(px)
+  document.addEventListener('touchstart', (e)=>{
+    // 오버레이 위 스와이프는 무시
+    if(e.target.closest('#osc-wrap')) return;
+    tracking=true; const t=e.changedTouches[0]; sx=t.clientX; sy=t.clientY;
+  }, {passive:true});
+  document.addEventListener('touchend', (e)=>{
+    if(!tracking) return; tracking=false;
+    const t=e.changedTouches[0]; const dx=t.clientX-sx, dy=t.clientY-sy;
+    if(Math.abs(dx)<TH && Math.abs(dy)<TH) return;
+    const key = Math.abs(dx)>Math.abs(dy) ? (dx>0?'ArrowRight':'ArrowLeft')
+                                          : (dy>0?'ArrowDown':'ArrowUp');
+    pressStart(key); setTimeout(()=>pressEnd(key), 50);
+  }, {passive:true});
+})();
+    </script>
+
 </body>
 </html>

--- a/game/frogger/index.html
+++ b/game/frogger/index.html
@@ -1,0 +1,468 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>레트로 개구리 건너기</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            background: radial-gradient(circle at top, #091729 0%, #03060c 65%, #000 100%);
+            color: #f8fbff;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: clamp(16px, 3vw, 48px);
+        }
+        main {
+            width: min(100%, 960px);
+            display: grid;
+            gap: 24px;
+            grid-template-columns: minmax(0, 480px) minmax(0, 1fr);
+            align-items: start;
+        }
+        @media (max-width: 980px) {
+            main {
+                grid-template-columns: 1fr;
+                justify-items: center;
+            }
+        }
+        canvas {
+            width: 100%;
+            max-width: 480px;
+            border-radius: 18px;
+            background: linear-gradient(#071c34 0%, #0b101c 100%);
+            border: 3px solid rgba(255, 255, 255, 0.1);
+            box-shadow: 0 24px 64px rgba(0, 0, 0, 0.55);
+        }
+        section {
+            background: rgba(10, 24, 46, 0.76);
+            border-radius: 18px;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            padding: clamp(20px, 3vw, 32px);
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+            backdrop-filter: blur(14px);
+        }
+        h1 {
+            margin: 0;
+            font-size: clamp(28px, 3.6vw, 38px);
+            letter-spacing: -0.02em;
+        }
+        .stats {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px 20px;
+            font-weight: 600;
+        }
+        .chip {
+            background: rgba(255, 255, 255, 0.08);
+            border-radius: 999px;
+            padding: 6px 14px;
+        }
+        ul {
+            margin: 0;
+            padding-left: 20px;
+            color: rgba(240, 244, 255, 0.82);
+            line-height: 1.6;
+        }
+        button {
+            border: none;
+            border-radius: 12px;
+            padding: 12px 16px;
+            font-weight: 600;
+            background: linear-gradient(135deg, #1d5de7, #36b8ff);
+            color: white;
+            cursor: pointer;
+            transition: transform 0.18s ease, box-shadow 0.18s ease;
+        }
+        button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 14px 24px rgba(21, 89, 224, 0.35);
+        }
+        .goals {
+            display: flex;
+            gap: 6px;
+        }
+        .goals span {
+            width: 18px;
+            height: 18px;
+            border-radius: 4px;
+            background: rgba(255, 255, 255, 0.2);
+        }
+        .goals span.reached {
+            background: linear-gradient(140deg, #8ef18a, #2fe191);
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <canvas id="game" width="480" height="560" aria-label="게임 화면"></canvas>
+        <section>
+            <h1>레트로 개구리 건너기</h1>
+            <div class="stats">
+                <span class="chip">레벨 <strong id="level">1</strong></span>
+                <span class="chip">점수 <strong id="score">0</strong></span>
+                <span class="chip">남은 생명 <strong id="lives">3</strong></span>
+            </div>
+            <div class="goals" aria-live="polite" id="goal-tracker"></div>
+            <p>방향키 또는 WASD로 개구리를 조작해 강과 도로를 건너 목적지에 도착하세요. 통나무 위에 올라타 이동하고, 차와 물에 닿지 않도록 조심하세요. 모든 홈을 채우면 다음 레벨로 진행합니다.</p>
+            <ul>
+                <li>레벨이 오를수록 차량과 통나무 속도가 빨라집니다.</li>
+                <li>구급차는 매우 빠르며, 강물에 빠지면 생명이 줄어듭니다.</li>
+                <li>스페이스 키로 현재 라운드를 포기하고 시작 지점으로 돌아갈 수 있지만 점수가 감소합니다.</li>
+            </ul>
+            <button id="restart">다시 시작</button>
+        </section>
+    </main>
+    <script>
+        const canvas = document.getElementById('game');
+        const ctx = canvas.getContext('2d');
+        const tile = 40;
+        const cols = 12;
+        const rows = 14;
+        const levelEl = document.getElementById('level');
+        const scoreEl = document.getElementById('score');
+        const livesEl = document.getElementById('lives');
+        const restartBtn = document.getElementById('restart');
+        const goalTracker = document.getElementById('goal-tracker');
+
+        const lanes = [
+            { type: 'goal' },
+            { type: 'river', speed: 1.6, spawnDelay: 2.4, size: 140 },
+            { type: 'river', speed: -1.9, spawnDelay: 2.0, size: 120 },
+            { type: 'river', speed: 1.8, spawnDelay: 1.8, size: 100 },
+            { type: 'river', speed: -2.1, spawnDelay: 1.9, size: 150 },
+            { type: 'safe' },
+            { type: 'road', speed: 2.6, spawnDelay: 1.6, size: 80 },
+            { type: 'road', speed: -3.0, spawnDelay: 1.6, size: 70 },
+            { type: 'road', speed: 3.3, spawnDelay: 1.3, size: 90 },
+            { type: 'road', speed: -4.1, spawnDelay: 1.1, size: 90 },
+            { type: 'road', speed: 5.0, spawnDelay: 1.0, size: 80, aggressive: true },
+            { type: 'safe' },
+            { type: 'start' }
+        ];
+
+        const palette = {
+            river: '#123a55',
+            road: '#1b1f2c',
+            safe: '#14233a',
+            goal: '#1a3144',
+            text: '#f5f8ff'
+        };
+
+        const goalPositions = [0.8, 2.8, 4.8, 6.8, 8.8];
+
+        let player;
+        let logs = [];
+        let cars = [];
+        let spawnTimers = new Array(lanes.length).fill(0);
+        let lives = 3;
+        let score = 0;
+        let level = 1;
+        let reachedGoals = goalPositions.map(() => false);
+        let lastTime = 0;
+        let gameOver = false;
+
+        const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+        function playBeep(freq, duration = 0.12) {
+            const now = audioCtx.currentTime;
+            const osc = audioCtx.createOscillator();
+            const gain = audioCtx.createGain();
+            osc.frequency.value = freq;
+            osc.type = 'square';
+            gain.gain.setValueAtTime(0.18, now);
+            gain.gain.exponentialRampToValueAtTime(0.001, now + duration);
+            osc.connect(gain).connect(audioCtx.destination);
+            osc.start(now);
+            osc.stop(now + duration);
+        }
+
+        const input = {
+            up: false,
+            down: false,
+            left: false,
+            right: false,
+            reset: false
+        };
+
+        window.addEventListener('keydown', (e) => {
+            if (audioCtx.state === 'suspended') {
+                audioCtx.resume().catch(() => {});
+            }
+            if (['ArrowUp', 'w', 'W'].includes(e.key)) input.up = true;
+            if (['ArrowDown', 's', 'S'].includes(e.key)) input.down = true;
+            if (['ArrowLeft', 'a', 'A'].includes(e.key)) input.left = true;
+            if (['ArrowRight', 'd', 'D'].includes(e.key)) input.right = true;
+            if (e.code === 'Space') input.reset = true;
+        });
+        window.addEventListener('keyup', (e) => {
+            if (['ArrowUp', 'w', 'W'].includes(e.key)) input.up = false;
+            if (['ArrowDown', 's', 'S'].includes(e.key)) input.down = false;
+            if (['ArrowLeft', 'a', 'A'].includes(e.key)) input.left = false;
+            if (['ArrowRight', 'd', 'D'].includes(e.key)) input.right = false;
+            if (e.code === 'Space') input.reset = false;
+        });
+
+        restartBtn.addEventListener('click', () => startGame(true));
+
+        function startGame(full = false) {
+            player = { x: 5, y: lanes.length - 1, offsetX: 0 };
+            logs = [];
+            cars = [];
+            spawnTimers = new Array(lanes.length).fill(0);
+            gameOver = false;
+            if (full) {
+                lives = 3;
+                score = 0;
+                level = 1;
+                reachedGoals = reachedGoals.map(() => false);
+            }
+            updateHUD();
+            requestAnimationFrame(loop);
+        }
+
+        function updateHUD() {
+            levelEl.textContent = level;
+            scoreEl.textContent = score;
+            livesEl.textContent = lives;
+            goalTracker.innerHTML = '';
+            reachedGoals.forEach((reached) => {
+                const span = document.createElement('span');
+                span.className = reached ? 'reached' : '';
+                goalTracker.appendChild(span);
+            });
+        }
+
+        function spawnEntity(laneIndex, dt) {
+            const lane = lanes[laneIndex];
+            if (lane.type !== 'river' && lane.type !== 'road') return;
+            spawnTimers[laneIndex] -= dt;
+            const levelModifier = 1 + (level - 1) * 0.12;
+            if (spawnTimers[laneIndex] <= 0) {
+                const direction = Math.sign(lane.speed);
+                const speed = lane.speed * levelModifier;
+                const y = laneIndex * tile;
+                const size = lane.size;
+                if (lane.type === 'river') {
+                    logs.push({
+                        x: direction > 0 ? -size : canvas.width + size,
+                        y,
+                        w: size,
+                        speed
+                    });
+                } else {
+                    const color = lane.aggressive ? '#ff3567' : '#f7b733';
+                    cars.push({
+                        x: direction > 0 ? -size : canvas.width + size,
+                        y,
+                        w: size,
+                        speed,
+                        color
+                    });
+                }
+                const baseDelay = lane.spawnDelay / levelModifier;
+                spawnTimers[laneIndex] = baseDelay * (0.7 + Math.random() * 0.6);
+            }
+        }
+
+        function updateEntities(dt) {
+            logs.forEach((log) => {
+                log.x += log.speed * dt;
+            });
+            cars.forEach((car) => {
+                car.x += car.speed * dt;
+            });
+            logs = logs.filter((log) => log.x + log.w > -80 && log.x < canvas.width + 80);
+            cars = cars.filter((car) => car.x + car.w > -80 && car.x < canvas.width + 80);
+        }
+
+        function movePlayer() {
+            let moved = false;
+            if (input.up) {
+                player.y = Math.max(0, player.y - 1);
+                moved = true;
+            } else if (input.down) {
+                player.y = Math.min(lanes.length - 1, player.y + 1);
+                moved = true;
+            } else if (input.left) {
+                player.x = Math.max(0, player.x - 1);
+                moved = true;
+            } else if (input.right) {
+                player.x = Math.min(cols - 1, player.x + 1);
+                moved = true;
+            }
+            if (moved) {
+                playBeep(880);
+                input.up = input.down = input.left = input.right = false;
+            }
+            if (input.reset) {
+                score = Math.max(0, score - 50);
+                resetPlayer();
+                input.reset = false;
+            }
+        }
+
+        function resetPlayer() {
+            player.x = 5;
+            player.y = lanes.length - 1;
+            player.offsetX = 0;
+        }
+
+        function handleRiver(dt) {
+            const laneIndex = player.y;
+            const lane = lanes[laneIndex];
+            if (lane.type !== 'river') {
+                player.offsetX = 0;
+                return;
+            }
+            const frogY = laneIndex * tile;
+            const frogX = player.x * tile + player.offsetX;
+            const ride = logs.find((log) => frogY === log.y && frogX + tile > log.x && frogX < log.x + log.w);
+            if (ride) {
+                player.offsetX += ride.speed * dt;
+                const newX = player.x * tile + player.offsetX;
+                if (newX < 0 || newX + tile > canvas.width) {
+                    loseLife();
+                }
+            } else {
+                loseLife();
+            }
+        }
+
+        function handleRoad() {
+            const laneIndex = player.y;
+            const lane = lanes[laneIndex];
+            if (lane.type !== 'road') return;
+            const frogY = laneIndex * tile;
+            const frogX = player.x * tile + player.offsetX;
+            const hit = cars.find((car) => frogY === car.y && frogX + tile - 6 > car.x && frogX + 6 < car.x + car.w);
+            if (hit) {
+                loseLife();
+            }
+        }
+
+        function handleGoal() {
+            if (player.y !== 0) return;
+            const frogX = player.x + player.offsetX / tile;
+            const goalIndex = goalPositions.findIndex((pos) => Math.abs(pos - frogX) < 0.4);
+            if (goalIndex >= 0 && !reachedGoals[goalIndex]) {
+                reachedGoals[goalIndex] = true;
+                score += 200 + level * 50;
+                playBeep(1320, 0.3);
+                if (reachedGoals.every(Boolean)) {
+                    level += 1;
+                    reachedGoals = reachedGoals.map(() => false);
+                    score += 500;
+                }
+                updateHUD();
+                resetPlayer();
+            } else {
+                loseLife();
+            }
+        }
+
+        function loseLife() {
+            if (gameOver) return;
+            lives -= 1;
+            playBeep(220, 0.25);
+            if (lives <= 0) {
+                gameOver = true;
+                lives = 0;
+                updateHUD();
+                ctx.fillStyle = 'rgba(0,0,0,0.68)';
+                ctx.fillRect(0, 0, canvas.width, canvas.height);
+                ctx.fillStyle = '#ff5d73';
+                ctx.font = 'bold 40px Pretendard, sans-serif';
+                ctx.textAlign = 'center';
+                ctx.fillText('GAME OVER', canvas.width / 2, canvas.height / 2);
+                ctx.font = '20px Pretendard, sans-serif';
+                ctx.fillText('다시 시작 버튼을 눌러 재도전하세요', canvas.width / 2, canvas.height / 2 + 40);
+                return;
+            }
+            score = Math.max(0, score - 100);
+            resetPlayer();
+            updateHUD();
+        }
+
+        function renderBackground() {
+            ctx.fillStyle = '#030b16';
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+            lanes.forEach((lane, i) => {
+                let color = palette.safe;
+                if (lane.type === 'river') color = palette.river;
+                if (lane.type === 'road') color = palette.road;
+                if (lane.type === 'goal') color = palette.goal;
+                ctx.fillStyle = color;
+                ctx.fillRect(0, i * tile, canvas.width, tile);
+            });
+            ctx.fillStyle = '#0b111d';
+            ctx.fillRect(0, (lanes.length - 1) * tile, canvas.width, tile);
+            ctx.strokeStyle = 'rgba(255,255,255,0.2)';
+            ctx.lineWidth = 2;
+            for (let i = 1; i < cols; i++) {
+                ctx.beginPath();
+                ctx.moveTo(i * tile, 0);
+                ctx.lineTo(i * tile, canvas.height);
+                ctx.stroke();
+            }
+        }
+
+        function renderEntities() {
+            logs.forEach((log) => {
+                const gradient = ctx.createLinearGradient(log.x, 0, log.x + log.w, 0);
+                gradient.addColorStop(0, '#2f6a4c');
+                gradient.addColorStop(1, '#79c594');
+                ctx.fillStyle = gradient;
+                ctx.fillRect(log.x, log.y + 6, log.w, tile - 12);
+            });
+            cars.forEach((car) => {
+                ctx.fillStyle = car.color;
+                ctx.fillRect(car.x + 6, car.y + 8, car.w - 12, tile - 16);
+                ctx.fillStyle = 'rgba(0,0,0,0.25)';
+                ctx.fillRect(car.x + 12, car.y + tile / 2 - 8, car.w - 24, 16);
+            });
+            const frogX = player.x * tile + player.offsetX;
+            const frogY = player.y * tile;
+            ctx.fillStyle = '#7fffa7';
+            ctx.beginPath();
+            ctx.arc(frogX + tile / 2, frogY + tile / 2, tile / 2.4, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.fillStyle = '#053017';
+            ctx.beginPath();
+            ctx.arc(frogX + tile / 2 - 6, frogY + tile / 2 - 4, 6, 0, Math.PI * 2);
+            ctx.arc(frogX + tile / 2 + 6, frogY + tile / 2 - 4, 6, 0, Math.PI * 2);
+            ctx.fill();
+        }
+
+        function loop(timestamp) {
+            if (gameOver) return;
+            const dt = Math.min(0.2, (timestamp - lastTime) / 1000 || 0);
+            lastTime = timestamp;
+            movePlayer();
+            for (let i = 0; i < lanes.length; i++) {
+                spawnEntity(i, dt);
+            }
+            updateEntities(dt * 120);
+            handleRiver(dt * 120);
+            handleRoad();
+            handleGoal();
+            renderBackground();
+            renderEntities();
+            requestAnimationFrame(loop);
+        }
+
+        startGame(true);
+    </script>
+    <script src="../global-enhancements.js" defer></script>
+</body>
+</html>

--- a/game/global-enhancements.js
+++ b/game/global-enhancements.js
@@ -1,0 +1,115 @@
+(function () {
+  const doc = document;
+  const body = doc.body;
+  if (!body) return;
+
+  const style = doc.createElement('style');
+  style.textContent = `
+    .global-signature {
+      position: fixed;
+      inset: 18px 18px auto auto;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 14px;
+      border-radius: 999px;
+      background: rgba(255, 165, 74, 0.9);
+      color: #1f1206;
+      font-weight: 700;
+      font-size: 13px;
+      letter-spacing: 0.01em;
+      box-shadow: 0 18px 35px rgba(255, 165, 74, 0.35);
+      transform: translateY(-12px);
+      opacity: 0;
+      transition: opacity 0.35s ease, transform 0.35s ease;
+      z-index: 9999;
+    }
+    .global-signature span {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 2px 10px;
+      border-radius: 999px;
+      background: rgba(0, 0, 0, 0.12);
+    }
+    .global-signature.visible {
+      transform: translateY(0);
+      opacity: 1;
+    }
+    @media (max-width: 640px) {
+      .global-signature {
+        inset: auto 16px 16px 16px;
+        justify-content: center;
+        text-align: center;
+      }
+    }
+  `;
+  doc.head.appendChild(style);
+
+  if (!doc.querySelector('.signature') && !doc.querySelector('.global-signature')) {
+    const badge = doc.createElement('div');
+    badge.className = 'global-signature';
+    badge.innerHTML = `<span>박은성</span>이 만든 특별한 게임`; 
+    body.appendChild(badge);
+    requestAnimationFrame(() => badge.classList.add('visible'));
+  }
+
+  const computed = window.getComputedStyle(body);
+  if (computed.overflow !== 'hidden') {
+    const padLeft = parseFloat(computed.paddingLeft);
+    const padRight = parseFloat(computed.paddingRight);
+    if (padLeft < 12 && padRight < 12) {
+      body.style.padding = 'clamp(16px, 5vw, 56px)';
+    }
+  }
+
+  const wrappers = Array.from(doc.querySelectorAll('.panel, .container, .wrapper, .frame, main, .game-shell, .hud, .board-shell, .playfield, .game-card'));
+  const resizeWrappers = () => {
+    if (window.innerWidth <= 768) {
+      wrappers.forEach(el => {
+        if (!el) return;
+        if (!el.style.maxWidth) {
+          el.style.maxWidth = 'min(100%, 720px)';
+        }
+        if (!el.style.width) {
+          el.style.width = 'min(100%, 720px)';
+        }
+        if (!el.style.marginLeft) {
+          el.style.marginLeft = 'auto';
+          el.style.marginRight = 'auto';
+        }
+        if (!el.style.boxSizing) {
+          el.style.boxSizing = 'border-box';
+        }
+      });
+    } else {
+      wrappers.forEach(el => {
+        if (!el) return;
+        el.style.removeProperty('max-width');
+        el.style.removeProperty('width');
+        el.style.removeProperty('margin-left');
+        el.style.removeProperty('margin-right');
+      });
+    }
+  };
+
+  const adjustCanvases = () => {
+    const canvases = doc.querySelectorAll('canvas');
+    canvases.forEach(canvas => {
+      if (window.innerWidth <= 768) {
+        canvas.style.width = '100%';
+        canvas.style.height = 'auto';
+      } else {
+        canvas.style.removeProperty('width');
+        canvas.style.removeProperty('height');
+      }
+    });
+  };
+
+  resizeWrappers();
+  adjustCanvases();
+  window.addEventListener('resize', () => {
+    resizeWrappers();
+    adjustCanvases();
+  });
+})();

--- a/game/index.html
+++ b/game/index.html
@@ -1,0 +1,309 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>브라우저 미니 게임 아케이드</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+            margin: 0;
+            min-height: 100vh;
+            background: radial-gradient(circle at 10% 15%, #314867, #0b1521 58%, #04070b 100%);
+            color: #f5f6fa;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: clamp(24px, 6vw, 72px) clamp(12px, 4vw, 56px);
+        }
+        .container {
+            width: min(100%, 1160px);
+            background: rgba(10, 18, 32, 0.82);
+            border-radius: clamp(18px, 4vw, 32px);
+            box-shadow: 0 30px 90px rgba(0, 0, 0, 0.45);
+            padding: clamp(28px, 4.5vw, 60px);
+            backdrop-filter: blur(16px);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+        }
+        header {
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+            margin-bottom: clamp(28px, 6vw, 40px);
+        }
+        header h1 {
+            font-size: clamp(30px, 5vw, 46px);
+            font-weight: 700;
+            margin: 0;
+            letter-spacing: -0.02em;
+        }
+        header p {
+            margin: 0;
+            color: rgba(245, 246, 250, 0.78);
+            line-height: 1.6;
+        }
+        .signature {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 8px 14px;
+            background: linear-gradient(135deg, rgba(255, 94, 98, 0.9), rgba(255, 149, 58, 0.85));
+            color: #1b0f16;
+            border-radius: 999px;
+            font-size: 14px;
+            font-weight: 700;
+            width: fit-content;
+            box-shadow: 0 12px 24px rgba(255, 120, 62, 0.35);
+            letter-spacing: 0.01em;
+        }
+        .signature span {
+            display: inline-block;
+            padding: 2px 10px;
+            border-radius: 999px;
+            background: rgba(27, 15, 22, 0.18);
+        }
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: clamp(16px, 3vw, 26px);
+        }
+        a {
+            text-decoration: none;
+            color: inherit;
+        }
+        .card {
+            background: linear-gradient(150deg, rgba(40, 66, 102, 0.94), rgba(16, 30, 50, 0.92));
+            border-radius: 20px;
+            padding: clamp(20px, 3vw, 28px);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            transition: transform 0.24s ease, box-shadow 0.24s ease, border-color 0.24s ease;
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+        .card:hover {
+            transform: translateY(-8px) scale(1.02);
+            box-shadow: 0 22px 38px rgba(0, 0, 0, 0.45);
+            border-color: rgba(255, 255, 255, 0.18);
+        }
+        .card h2 {
+            margin: 0;
+            font-size: 22px;
+        }
+        .card p {
+            margin: 0;
+            font-size: 15px;
+            color: rgba(255, 255, 255, 0.76);
+            line-height: 1.5;
+        }
+        .tag {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 10px;
+            border-radius: 999px;
+            font-size: 12px;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+            background: rgba(255, 255, 255, 0.12);
+            color: rgba(255, 255, 255, 0.85);
+        }
+        footer {
+            margin-top: 36px;
+            font-size: 14px;
+            color: rgba(255, 255, 255, 0.55);
+            text-align: center;
+            line-height: 1.6;
+        }
+        .devices {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+            gap: 12px;
+            margin-top: clamp(28px, 6vw, 40px);
+        }
+        .devices div {
+            background: rgba(255, 255, 255, 0.08);
+            border-radius: 18px;
+            padding: 14px 16px;
+            font-size: 14px;
+            color: rgba(245, 246, 250, 0.85);
+            text-align: center;
+        }
+        @media (max-width: 600px) {
+            body {
+                padding: 16px;
+            }
+            .container {
+                border-radius: 20px;
+            }
+            header {
+                align-items: flex-start;
+            }
+            header h1 {
+                font-size: clamp(26px, 9vw, 34px);
+            }
+            .card {
+                border-radius: 18px;
+            }
+            footer {
+                font-size: 13px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <main class="container">
+        <header>
+            <div class="signature">박은성이 만든 <span>ALL-IN-ONE</span> 아케이드</div>
+            <h1>브라우저 미니 게임 아케이드</h1>
+            <p>클래식 아케이드부터 퍼즐, 전략, 카드, 단어 게임까지! 설치 없이 즐길 수 있는 미니 게임을 계속해서 확장 중입니다. 총 18가지의 미니 게임을 한 곳에서 만나보세요.</p>
+            <p style="margin:0;color:rgba(245,246,250,0.7);font-size:15px;">컴퓨터, 태블릿, 스마트폰 어디서든 부드럽게 플레이할 수 있도록 인터페이스를 새롭게 다듬었습니다.</p>
+        </header>
+        <section class="grid">
+            <a href="./snake/">
+                <article class="card">
+                    <span class="tag">캐주얼</span>
+                    <h2>지렁이 게임</h2>
+                    <p>방향키로 지렁이를 조작해 사과를 먹고 성장하세요. 속도가 점점 빨라지는 클래식 스네이크!</p>
+                </article>
+            </a>
+            <a href="./tetris/">
+                <article class="card">
+                    <span class="tag">퍼즐</span>
+                    <h2>테트리스</h2>
+                    <p>떨어지는 블록을 회전하고 쌓아 라인을 지워 보세요. 레벨이 오를수록 속도가 빨라집니다.</p>
+                </article>
+            </a>
+            <a href="./2048/">
+                <article class="card">
+                    <span class="tag">두뇌</span>
+                    <h2>2048 퍼즐</h2>
+                    <p>같은 숫자 타일을 합쳐 2048에 도전하세요. 차분하지만 중독성 있는 퍼즐입니다.</p>
+                </article>
+            </a>
+            <a href="./sand-tetris/">
+                <article class="card">
+                    <span class="tag">샌드박스</span>
+                    <h2>모래 실험실</h2>
+                    <p>자유롭게 모래와 블록을 떨어뜨리고 쌓으며 물리 퍼즐을 해결해 보세요.</p>
+                </article>
+            </a>
+            <a href="./nebulous/">
+                <article class="card">
+                    <span class="tag">아케이드</span>
+                    <h2>세포 성장 게임</h2>
+                    <p>작은 입자를 흡수해 세포를 키우고 함정을 피해 생존하세요. 네뷸러스 스타일의 액션.</p>
+                </article>
+            </a>
+            <a href="./pong/">
+                <article class="card">
+                    <span class="tag">대전</span>
+                    <h2>레이저 핑퐁</h2>
+                    <p>마우스로 패들을 조작해 공을 반사하고 득점을 노려 보세요. 10점을 먼저 얻으면 승리!</p>
+                </article>
+            </a>
+            <a href="./frogger/">
+                <article class="card">
+                    <span class="tag">아케이드</span>
+                    <h2>레트로 개구리</h2>
+                    <p>도로와 강을 건너 목적지에 도착하세요. 통나무를 이용하고, 차량을 피해 생존해야 합니다.</p>
+                </article>
+            </a>
+            <a href="./breakout/">
+                <article class="card">
+                    <span class="tag">아케이드</span>
+                    <h2>네온 벽돌깨기</h2>
+                    <p>발판으로 공을 튕겨 벽돌을 모두 제거하세요. 콤보와 파워업으로 하이 스코어에 도전!</p>
+                </article>
+            </a>
+            <a href="./flappy/">
+                <article class="card">
+                    <span class="tag">반사신경</span>
+                    <h2>플래피 비행</h2>
+                    <p>탭/스페이스로 새를 조작해 장애물을 통과하세요. 속도감 있는 점프 액션 게임입니다.</p>
+                </article>
+            </a>
+            <a href="./minesweeper/">
+                <article class="card">
+                    <span class="tag">전략</span>
+                    <h2>지뢰찾기</h2>
+                    <p>논리와 추리로 지뢰의 위치를 찾아 플래그를 꽂아 보세요. 난이도를 선택할 수 있습니다.</p>
+                </article>
+            </a>
+            <a href="./memory-match/">
+                <article class="card">
+                    <span class="tag">기억력</span>
+                    <h2>카드 매칭</h2>
+                    <p>뒤집힌 카드를 두 장씩 선택해 짝을 맞추세요. 짧은 플레이로 집중력을 시험해 보세요.</p>
+                </article>
+            </a>
+            <a href="./sokoban/">
+                <article class="card">
+                    <span class="tag">퍼즐</span>
+                    <h2>소코반 창고지기</h2>
+                    <p>상자를 목표 지점으로 밀어 넣는 클래식 퍼즐. 되돌리기와 여러 레벨로 깊이 있게 즐겨보세요.</p>
+                </article>
+            </a>
+            <a href="./space-shooter/">
+                <article class="card">
+                    <span class="tag">슈팅</span>
+                    <h2>우주 방위전</h2>
+                    <p>적 함대를 피하고 격추하며 보스를 방어하세요. 파워업을 모아 강력한 레이저를 발사!</p>
+                </article>
+            </a>
+            <a href="./runner/">
+                <article class="card">
+                    <span class="tag">러너</span>
+                    <h2>스카이 러너</h2>
+                    <p>장애물을 점프와 슬라이드로 피하며 더 멀리 달려 보세요. 속도는 계속 빨라집니다.</p>
+                </article>
+            </a>
+            <a href="./whack-a-mole/">
+                <article class="card">
+                    <span class="tag">반사신경</span>
+                    <h2>두더지 팡팡</h2>
+                    <p>두더지가 머리를 내밀 때 빠르게 클릭해 점수를 얻으세요. 난이도별 폭탄과 콤보를 조심!</p>
+                </article>
+            </a>
+            <a href="./blackjack/">
+                <article class="card">
+                    <span class="tag">카드</span>
+                    <h2>네온 블랙잭</h2>
+                    <p>보유 칩을 관리하며 21에 도전하세요. 더블다운, 서렌더 등 핵심 전략을 구현했습니다.</p>
+                </article>
+            </a>
+            <a href="./wordle/">
+                <article class="card">
+                    <span class="tag">단어</span>
+                    <h2>코드 워들</h2>
+                    <p>5글자 영어 단어를 6번 안에 추리하세요. 키보드와 색상 힌트로 논리력을 발휘해 보세요.</p>
+                </article>
+            </a>
+            <a href="./tower-defense/">
+                <article class="card">
+                    <span class="tag">전략</span>
+                    <h2>하늘길 디펜스</h2>
+                    <p>펄스와 냉기 타워를 배치해 웨이브를 방어하세요. 에너지를 관리하며 최적의 방어선을 구축하세요.</p>
+                </article>
+            </a>
+        </section>
+        <section class="devices" aria-label="지원 기기 안내">
+            <div>💻 데스크톱 &amp; 노트북 풀 화면 대응</div>
+            <div>📱 스마트폰 터치 조작 최적화</div>
+            <div>📟 태블릿 가로·세로 자동 레이아웃</div>
+        </section>
+        <footer>
+            계속해서 새로운 게임을 추가하고 오류를 수정하고 있습니다. 제안하고 싶은 게임이 있다면 알려주세요!
+            <br>모든 콘텐츠는 <strong>박은성</strong>이 직접 기획하고 제작했습니다.
+        </footer>
+    </main>
+    <script src="./global-enhancements.js" defer></script>
+</body>
+</html>

--- a/game/index.html
+++ b/game/index.html
@@ -2,7 +2,7 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
     <title>브라우저 미니 게임 아케이드</title>
     <style>
         :root {
@@ -160,6 +160,13 @@
 </head>
 <body>
     <main class="container">
+        <section style="padding:64px 20px; text-align:center">
+            <h1 style="margin:0 0 12px">Arcade by <strong>박은성</strong></h1>
+            <p style="margin:0 0 20px; font-size:1.1rem">
+                키보드 · 스와이프 · 온스크린 패드까지, 모든 기기에서 바로 플레이하세요.
+            </p>
+            <div style="opacity:.8; font-size:.95rem">Mobile · Tablet · Desktop</div>
+        </section>
         <header>
             <div class="signature">박은성이 만든 <span>ALL-IN-ONE</span> 아케이드</div>
             <h1>브라우저 미니 게임 아케이드</h1>

--- a/game/memory-match/index.html
+++ b/game/memory-match/index.html
@@ -2,7 +2,6 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>카드 매칭</title>
     <style>
         :root {
@@ -129,6 +128,44 @@
             color: rgba(255, 255, 255, 0.75);
         }
     </style>
+
+    <!-- Mobile-friendly viewport -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+    <style>
+      :root { --osc-gap: 10px; --osc-btn: 56px; --osc-z: 9999; }
+      .credit-banner{
+        position:fixed; top:env(safe-area-inset-top,0); left:env(safe-area-inset-left,0);
+        margin:8px; padding:6px 10px; font:600 14px/1.2 system-ui, sans-serif;
+        background:rgba(0,0,0,.55); color:#fff; border-radius:8px; z-index:var(--osc-z);
+        -webkit-backdrop-filter:saturate(150%) blur(6px); backdrop-filter:saturate(150%) blur(6px);
+        user-select:none; pointer-events:none;
+      }
+      .osc-wrap{
+        position:fixed; inset:auto 0 env(safe-area-inset-bottom,0) 0;
+        display:flex; justify-content:center; gap:24px; padding:var(--osc-gap);
+        z-index:var(--osc-z); touch-action:manipulation;
+      }
+      .osc { display:flex; align-items:center; gap:16px; }
+      .osc .dpad{ display:grid; grid-template-areas:
+          ".    up    ."
+          "left  mid  right"
+          ".   down   .";
+        gap:8px; align-items:center; justify-items:center;
+      }
+      .osc .actions{ display:flex; gap:10px; }
+      .osc button{
+        min-width:var(--osc-btn); min-height:var(--osc-btn);
+        border:0; border-radius:12px; font:700 16px system-ui, sans-serif;
+        background:rgba(255,255,255,.9); color:#111; box-shadow:0 2px 10px rgba(0,0,0,.2);
+      }
+      .osc .pause{ min-width:72px; }
+      /* 게임 화면 가려짐 방지 */
+      body{ padding-bottom: calc(env(safe-area-inset-bottom,0) + 110px); }
+      @media (pointer:fine){ /* 데스크톱이면 패드 숨김 */
+        .osc-wrap{ display:none; } body{ padding-bottom:0; }
+      }
+    </style>
+
 </head>
 <body>
     <div class="container">
@@ -265,5 +302,67 @@
         resetGame();
     </script>
     <script src="../global-enhancements.js" defer></script>
+
+    <!-- Creator credit -->
+    <div class="credit-banner" aria-hidden="true">Creator: 박은성</div>
+
+    <!-- On-screen Controls -->
+    <div class="osc-wrap" id="osc-wrap" role="group" aria-label="On-screen game controls">
+      <div class="osc">
+        <div class="dpad">
+          <button data-key="ArrowUp"    style="grid-area:up">▲</button>
+          <button data-key="ArrowLeft"  style="grid-area:left">◀</button>
+          <button data-key="ArrowRight" style="grid-area:right">▶</button>
+          <button data-key="ArrowDown"  style="grid-area:down">▼</button>
+        </div>
+        <div class="actions">
+          <button data-key="Space">A</button>
+          <button data-key="Enter">B</button>
+          <button class="pause" data-key="Escape">⏯︎</button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+(function(){
+  // 일부 게임이 window/document/canvas 등 서로 다른 타깃을 구독하므로, 광범위 전파
+  function send(key, type){
+    const ev = new KeyboardEvent(type, { key, code:key, bubbles:true, cancelable:true });
+    const t = document.activeElement && document.activeElement !== document.body
+      ? document.activeElement : document;
+    t.dispatchEvent(ev); window.dispatchEvent(ev);
+  }
+  function pressStart(key){ send(key,'keydown'); }
+  function pressEnd(key){ send(key,'keyup'); }
+
+  // 버튼 터치/클릭 → 키 이벤트 변환
+  document.getElementById('osc-wrap')?.addEventListener('pointerdown', e=>{
+    const btn = e.target.closest('button[data-key]'); if(!btn) return;
+    e.preventDefault(); btn.setPointerCapture?.(e.pointerId);
+    pressStart(btn.dataset.key);
+    btn.addEventListener('pointerup',  ()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('pointercancel',()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('lostpointercapture',()=>pressEnd(btn.dataset.key), { once:true });
+  });
+
+  // 스와이프 제스처 → 방향키
+  let sx=0, sy=0, tracking=false;
+  const TH=24; // 스와이프 임계값(px)
+  document.addEventListener('touchstart', (e)=>{
+    // 오버레이 위 스와이프는 무시
+    if(e.target.closest('#osc-wrap')) return;
+    tracking=true; const t=e.changedTouches[0]; sx=t.clientX; sy=t.clientY;
+  }, {passive:true});
+  document.addEventListener('touchend', (e)=>{
+    if(!tracking) return; tracking=false;
+    const t=e.changedTouches[0]; const dx=t.clientX-sx, dy=t.clientY-sy;
+    if(Math.abs(dx)<TH && Math.abs(dy)<TH) return;
+    const key = Math.abs(dx)>Math.abs(dy) ? (dx>0?'ArrowRight':'ArrowLeft')
+                                          : (dy>0?'ArrowDown':'ArrowUp');
+    pressStart(key); setTimeout(()=>pressEnd(key), 50);
+  }, {passive:true});
+})();
+    </script>
+
 </body>
 </html>

--- a/game/memory-match/index.html
+++ b/game/memory-match/index.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>카드 매칭</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: linear-gradient(135deg, #373b44, #4286f4);
+            color: #f5f6fa;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+            padding: clamp(20px, 5vw, 48px);
+        }
+        .container {
+            width: min(92vw, 620px);
+            background: rgba(16, 28, 48, 0.92);
+            border-radius: 28px;
+            padding: clamp(24px, 5vw, 48px);
+            box-shadow: 0 24px 70px rgba(0, 0, 0, 0.55);
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+        }
+        header {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: space-between;
+            gap: 16px;
+            align-items: center;
+        }
+        h1 {
+            margin: 0;
+            font-size: clamp(26px, 5vw, 34px);
+        }
+        .signature {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 6px 12px;
+            border-radius: 999px;
+            background: rgba(66, 134, 244, 0.18);
+            color: #9ebdff;
+            font-weight: 700;
+            font-size: 13px;
+        }
+        .stats {
+            display: flex;
+            gap: 16px;
+            font-weight: 600;
+            flex-wrap: wrap;
+        }
+        #board {
+            display: grid;
+            grid-template-columns: repeat(4, minmax(80px, 1fr));
+            gap: clamp(12px, 3vw, 18px);
+        }
+        button.card {
+            position: relative;
+            width: 100%;
+            aspect-ratio: 3 / 4;
+            border-radius: 18px;
+            border: none;
+            cursor: pointer;
+            perspective: 800px;
+            background: transparent;
+        }
+        .card-face {
+            position: absolute;
+            inset: 0;
+            display: grid;
+            place-items: center;
+            border-radius: 18px;
+            font-size: clamp(24px, 7vw, 44px);
+            font-weight: 700;
+            backface-visibility: hidden;
+            transition: transform 0.4s ease;
+        }
+        .card-front {
+            background: rgba(255, 255, 255, 0.09);
+            border: 2px solid rgba(255, 255, 255, 0.2);
+        }
+        .card-back {
+            background: linear-gradient(135deg, #ff9a9e, #fad0c4);
+            color: #222;
+            transform: rotateY(180deg);
+        }
+        .card.revealed .card-front {
+            transform: rotateY(180deg);
+        }
+        .card.revealed .card-back {
+            transform: rotateY(360deg);
+        }
+        .card.matched .card-back {
+            background: linear-gradient(135deg, #6ee7b7, #3b82f6);
+            color: #0b1726;
+        }
+        .controls {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            align-items: center;
+        }
+        button.action {
+            background: linear-gradient(135deg, #fdfbfb, #ebedee);
+            color: #0f172a;
+            border: none;
+            padding: 10px 22px;
+            border-radius: 999px;
+            font-weight: 700;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        button.action:hover, button.action:focus-visible {
+            transform: translateY(-2px);
+            box-shadow: 0 16px 24px rgba(255, 255, 255, 0.2);
+            outline: none;
+        }
+        .message {
+            font-size: 14px;
+            color: rgba(255, 255, 255, 0.75);
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <div style="display:flex;flex-direction:column;gap:6px;">
+                <div class="signature">박은성이 만든 게임</div>
+                <h1>카드 매칭</h1>
+            </div>
+            <div class="stats">
+                <div>턴: <span id="turns">0</span></div>
+                <div>시간: <span id="time">0</span>s</div>
+            </div>
+        </header>
+        <div id="board"></div>
+        <div class="controls">
+            <button class="action" id="restart">다시 섞기</button>
+            <span class="message" id="message">두 장의 카드를 뒤집어 짝을 찾아보세요.</span>
+        </div>
+    </div>
+
+    <script>
+        const icons = ['🍎','🍉','🍓','🍊','🥝','🍇','🍍','🥕','🍒','🍅','🌽','🥑'];
+        const boardEl = document.getElementById('board');
+        const turnsEl = document.getElementById('turns');
+        const timeEl = document.getElementById('time');
+        const restartBtn = document.getElementById('restart');
+        const messageEl = document.getElementById('message');
+
+        let deck = [];
+        let flipped = [];
+        let matched = 0;
+        let turns = 0;
+        let startTime = null;
+        let timer = null;
+        let lock = false;
+
+        function shuffle(array) {
+            for (let i = array.length - 1; i > 0; i--) {
+                const j = Math.floor(Math.random() * (i + 1));
+                [array[i], array[j]] = [array[j], array[i]];
+            }
+            return array;
+        }
+
+        function buildDeck() {
+            const pairs = shuffle([...icons]).slice(0, 8);
+            deck = shuffle([...pairs, ...pairs]).map((icon, index) => ({ id: index, icon, matched: false }));
+        }
+
+        function startTimer() {
+            if (timer) return;
+            startTime = Date.now();
+            timer = setInterval(() => {
+                const elapsed = Math.floor((Date.now() - startTime) / 1000);
+                timeEl.textContent = elapsed;
+            }, 1000);
+        }
+
+        function stopTimer() {
+            clearInterval(timer);
+            timer = null;
+        }
+
+        function renderBoard() {
+            boardEl.innerHTML = '';
+            deck.forEach(card => {
+                const button = document.createElement('button');
+                button.className = 'card';
+                button.dataset.id = card.id;
+                button.innerHTML = `
+                    <div class="card-face card-front"></div>
+                    <div class="card-face card-back">${card.icon}</div>
+                `;
+                button.addEventListener('click', onCardClick);
+                boardEl.appendChild(button);
+                card.element = button;
+            });
+            turnsEl.textContent = turns;
+            timeEl.textContent = '0';
+        }
+
+        function onCardClick(e) {
+            const id = Number(e.currentTarget.dataset.id);
+            const card = deck[id];
+            if (lock || card.matched || flipped.includes(card) || flipped.length === 2) return;
+            card.element.classList.add('revealed');
+            flipped.push(card);
+            if (!startTime) startTimer();
+
+            if (flipped.length === 2) {
+                turns++;
+                turnsEl.textContent = turns;
+                if (flipped[0].icon === flipped[1].icon) {
+                    flipped.forEach(c => {
+                        c.matched = true;
+                        c.element.classList.add('matched');
+                    });
+                    matched += 2;
+                    flipped = [];
+                    checkVictory();
+                } else {
+                    lock = true;
+                    setTimeout(() => {
+                        flipped.forEach(c => c.element.classList.remove('revealed'));
+                        flipped = [];
+                        lock = false;
+                    }, 750);
+                }
+            }
+        }
+
+        function checkVictory() {
+            if (matched === deck.length) {
+                stopTimer();
+                const timeTaken = timeEl.textContent;
+                messageEl.textContent = `완벽합니다! ${turns}턴, ${timeTaken}초 만에 모든 카드를 맞췄어요.`;
+            }
+        }
+
+        function resetGame() {
+            stopTimer();
+            startTime = null;
+            turns = 0;
+            matched = 0;
+            flipped = [];
+            lock = false;
+            messageEl.textContent = '두 장의 카드를 뒤집어 짝을 찾아보세요.';
+            buildDeck();
+            renderBoard();
+        }
+
+        restartBtn.addEventListener('click', resetGame);
+
+        resetGame();
+    </script>
+    <script src="../global-enhancements.js" defer></script>
+</body>
+</html>

--- a/game/minesweeper/index.html
+++ b/game/minesweeper/index.html
@@ -1,0 +1,395 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>지뢰찾기</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: clamp(16px, 5vw, 56px);
+            background: radial-gradient(circle at 30% 20%, #102840, #050d18 70%);
+            color: #f0f6ff;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+        }
+        .wrapper {
+            width: min(94vw, 680px);
+            background: rgba(8, 18, 32, 0.92);
+            border-radius: 28px;
+            padding: 32px clamp(20px, 4vw, 40px);
+            box-shadow: 0 28px 70px rgba(0, 0, 0, 0.55);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+        }
+        header {
+            display: flex;
+            flex-direction: column;
+            gap: 14px;
+            margin-bottom: 24px;
+        }
+        h1 {
+            margin: 0;
+            font-size: clamp(26px, 5vw, 34px);
+        }
+        .signature {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 6px 14px;
+            border-radius: 999px;
+            background: rgba(0, 114, 255, 0.18);
+            color: #7ab7ff;
+            font-weight: 700;
+            font-size: 13px;
+            width: fit-content;
+        }
+        .status-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 16px;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .status {
+            font-weight: 600;
+            display: flex;
+            gap: 16px;
+            align-items: center;
+        }
+        .status span {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+        }
+        select, button.toggle {
+            background: rgba(255, 255, 255, 0.12);
+            border: 1px solid rgba(255, 255, 255, 0.18);
+            color: #f0f6ff;
+            padding: 10px 16px;
+            border-radius: 999px;
+            font-weight: 600;
+            cursor: pointer;
+        }
+        select:focus-visible, button.toggle:focus-visible {
+            outline: 2px solid rgba(0, 198, 255, 0.7);
+            outline-offset: 2px;
+        }
+        button.toggle.active {
+            background: linear-gradient(135deg, #00c6ff, #0072ff);
+            border-color: transparent;
+        }
+        #board {
+            display: grid;
+            gap: 6px;
+            justify-content: center;
+        }
+        .cell {
+            width: clamp(32px, 6vw, 42px);
+            height: clamp(32px, 6vw, 42px);
+            border-radius: 10px;
+            display: grid;
+            place-items: center;
+            font-weight: 700;
+            cursor: pointer;
+            user-select: none;
+            transition: transform 0.15s ease, background 0.15s ease;
+            background: rgba(255, 255, 255, 0.08);
+            border: 1px solid rgba(255, 255, 255, 0.12);
+        }
+        .cell.revealed {
+            cursor: default;
+            background: rgba(255, 255, 255, 0.18);
+            border-color: rgba(255, 255, 255, 0.25);
+            transform: none;
+        }
+        .cell.mine {
+            background: linear-gradient(135deg, #ef4444, #b91c1c);
+            border-color: rgba(255, 255, 255, 0.4);
+        }
+        .cell.flagged {
+            background: rgba(255, 176, 67, 0.3);
+            border-color: rgba(255, 176, 67, 0.6);
+        }
+        .cell:active:not(.revealed) {
+            transform: translateY(1px) scale(0.98);
+        }
+        footer {
+            margin-top: 20px;
+            color: rgba(255, 255, 255, 0.65);
+            font-size: 14px;
+            line-height: 1.6;
+            text-align: center;
+        }
+        @media (max-width: 520px) {
+            .status-row {
+                flex-direction: column;
+                align-items: stretch;
+            }
+            .status {
+                justify-content: space-between;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="wrapper">
+        <header>
+            <div class="signature">박은성이 만든 게임</div>
+            <h1>지뢰찾기</h1>
+            <div class="status-row">
+                <div class="status">
+                    <span>⛏️ 남은 지뢰: <strong id="mines">0</strong></span>
+                    <span>⏱️ 시간: <strong id="time">0</strong>s</span>
+                </div>
+                <div style="display:flex; gap:12px;">
+                    <select id="difficulty" aria-label="난이도">
+                        <option value="easy">쉬움 (9×9)</option>
+                        <option value="normal" selected>보통 (16×16)</option>
+                        <option value="hard">어려움 (22×22)</option>
+                    </select>
+                    <button class="toggle" id="flagMode" type="button">🚩 플래그</button>
+                </div>
+            </div>
+        </header>
+        <div id="board" aria-label="게임판"></div>
+        <footer>
+            셀을 클릭하여 열고, 오른쪽 클릭 또는 플래그 모드에서 지뢰라고 생각되는 칸에 깃발을 꽂으세요.<br>
+            모든 안전한 칸을 열면 승리합니다!
+        </footer>
+    </div>
+
+    <script>
+        const boardEl = document.getElementById('board');
+        const minesEl = document.getElementById('mines');
+        const timeEl = document.getElementById('time');
+        const difficultyEl = document.getElementById('difficulty');
+        const flagButton = document.getElementById('flagMode');
+
+        const configs = {
+            easy: { size: 9, mines: 10 },
+            normal: { size: 16, mines: 40 },
+            hard: { size: 22, mines: 80 }
+        };
+
+        let config = configs[difficultyEl.value];
+        let board = [];
+        let mineLocations = new Set();
+        let revealedCount = 0;
+        let flagsPlaced = 0;
+        let startTime = null;
+        let timerInterval = null;
+        let flagMode = false;
+        let gameOver = false;
+
+        function buildBoard() {
+            board = [];
+            mineLocations = new Set();
+            revealedCount = 0;
+            flagsPlaced = 0;
+            gameOver = false;
+            clearInterval(timerInterval);
+            timeEl.textContent = '0';
+            startTime = null;
+            boardEl.style.gridTemplateColumns = `repeat(${config.size}, 1fr)`;
+            boardEl.innerHTML = '';
+
+            const totalCells = config.size * config.size;
+            const mines = config.mines;
+            const positions = Array.from({ length: totalCells }, (_, i) => i);
+            for (let i = positions.length - 1; i > 0; i--) {
+                const j = Math.floor(Math.random() * (i + 1));
+                [positions[i], positions[j]] = [positions[j], positions[i]];
+            }
+            positions.slice(0, mines).forEach(pos => mineLocations.add(pos));
+
+            for (let y = 0; y < config.size; y++) {
+                const row = [];
+                for (let x = 0; x < config.size; x++) {
+                    const index = y * config.size + x;
+                    const cell = document.createElement('button');
+                    cell.className = 'cell';
+                    cell.dataset.x = x;
+                    cell.dataset.y = y;
+                    cell.setAttribute('aria-label', '감춰진 칸');
+                    cell.addEventListener('click', onCellClick);
+                    cell.addEventListener('contextmenu', onCellRightClick);
+                    boardEl.appendChild(cell);
+                    row.push({
+                        element: cell,
+                        revealed: false,
+                        flagged: false,
+                        mine: mineLocations.has(index),
+                        adjacent: 0
+                    });
+                }
+                board.push(row);
+            }
+
+            for (let y = 0; y < config.size; y++) {
+                for (let x = 0; x < config.size; x++) {
+                    board[y][x].adjacent = countAdjacentMines(x, y);
+                }
+            }
+
+            updateMineCounter();
+        }
+
+        function countAdjacentMines(x, y) {
+            let count = 0;
+            for (let dy = -1; dy <= 1; dy++) {
+                for (let dx = -1; dx <= 1; dx++) {
+                    if (!dx && !dy) continue;
+                    const nx = x + dx;
+                    const ny = y + dy;
+                    if (nx >= 0 && nx < config.size && ny >= 0 && ny < config.size) {
+                        if (board[ny][nx].mine) count++;
+                    }
+                }
+            }
+            return count;
+        }
+
+        function startTimer() {
+            if (startTime) return;
+            startTime = Date.now();
+            timerInterval = setInterval(() => {
+                const elapsed = Math.floor((Date.now() - startTime) / 1000);
+                timeEl.textContent = elapsed;
+            }, 1000);
+        }
+
+        function revealCell(x, y) {
+            const cell = board[y][x];
+            if (cell.revealed || cell.flagged || gameOver) return;
+            if (!startTime) startTimer();
+
+            cell.revealed = true;
+            revealedCount++;
+            cell.element.classList.add('revealed');
+            cell.element.setAttribute('aria-label', '열린 칸');
+            cell.element.disabled = true;
+
+            if (cell.mine) {
+                cell.element.classList.add('mine');
+                cell.element.textContent = '💣';
+                triggerGameOver(false);
+                return;
+            }
+
+            if (cell.adjacent > 0) {
+                cell.element.textContent = cell.adjacent;
+                cell.element.style.color = ['#cddc39', '#4dd0e1', '#29b6f6', '#ff7043', '#ef5350', '#ab47bc', '#ffa726', '#ffca28'][cell.adjacent - 1];
+            } else {
+                floodReveal(x, y);
+            }
+
+            if (revealedCount === config.size * config.size - config.mines) {
+                triggerGameOver(true);
+            }
+        }
+
+        function floodReveal(x, y) {
+            const queue = [[x, y]];
+            while (queue.length) {
+                const [cx, cy] = queue.shift();
+                for (let dy = -1; dy <= 1; dy++) {
+                for (let dx = -1; dx <= 1; dx++) {
+                    if (!dx && !dy) continue;
+                    const nx = cx + dx;
+                    const ny = cy + dy;
+                        if (nx < 0 || ny < 0 || nx >= config.size || ny >= config.size) continue;
+                        const neighbor = board[ny][nx];
+                        if (neighbor.revealed || neighbor.flagged || neighbor.mine) continue;
+                        neighbor.revealed = true;
+                        neighbor.element.classList.add('revealed');
+                        neighbor.element.disabled = true;
+                        revealedCount++;
+                        if (neighbor.adjacent > 0) {
+                            neighbor.element.textContent = neighbor.adjacent;
+                            neighbor.element.style.color = ['#cddc39', '#4dd0e1', '#29b6f6', '#ff7043', '#ef5350', '#ab47bc', '#ffa726', '#ffca28'][neighbor.adjacent - 1];
+                        } else {
+                            queue.push([nx, ny]);
+                        }
+                    }
+                }
+            }
+        }
+
+        function toggleFlag(x, y) {
+            const cell = board[y][x];
+            if (cell.revealed || gameOver) return;
+            if (!cell.flagged && flagsPlaced >= config.mines) return;
+
+            cell.flagged = !cell.flagged;
+            cell.element.classList.toggle('flagged', cell.flagged);
+            cell.element.textContent = cell.flagged ? '🚩' : '';
+            flagsPlaced += cell.flagged ? 1 : -1;
+            updateMineCounter();
+        }
+
+        function updateMineCounter() {
+            minesEl.textContent = Math.max(0, config.mines - flagsPlaced);
+        }
+
+        function onCellClick(event) {
+            const x = Number(this.dataset.x);
+            const y = Number(this.dataset.y);
+            if (flagMode || event.shiftKey) {
+                toggleFlag(x, y);
+            } else {
+                revealCell(x, y);
+            }
+        }
+
+        function onCellRightClick(event) {
+            event.preventDefault();
+            const x = Number(this.dataset.x);
+            const y = Number(this.dataset.y);
+            toggleFlag(x, y);
+        }
+
+        function triggerGameOver(win) {
+            gameOver = true;
+            clearInterval(timerInterval);
+            board.flat().forEach(cell => {
+                cell.element.disabled = true;
+                if (cell.mine && !cell.revealed) {
+                    cell.element.textContent = '💣';
+                    cell.element.classList.add('mine');
+                }
+            });
+            setTimeout(() => {
+                alert(win ? `축하합니다! ${timeEl.textContent}초 만에 승리했습니다.` : '지뢰를 밟았습니다! 다시 도전해 보세요.');
+            }, 50);
+        }
+
+        difficultyEl.addEventListener('change', () => {
+            config = configs[difficultyEl.value];
+            buildBoard();
+        });
+
+        flagButton.addEventListener('click', () => {
+            flagMode = !flagMode;
+            flagButton.classList.toggle('active', flagMode);
+        });
+
+        document.addEventListener('keydown', e => {
+            if (e.key === 'r') {
+                buildBoard();
+            }
+        });
+
+        buildBoard();
+    </script>
+    <script src="../global-enhancements.js" defer></script>
+</body>
+</html>

--- a/game/minesweeper/index.html
+++ b/game/minesweeper/index.html
@@ -2,7 +2,6 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>지뢰찾기</title>
     <style>
         :root {
@@ -139,6 +138,44 @@
             }
         }
     </style>
+
+    <!-- Mobile-friendly viewport -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+    <style>
+      :root { --osc-gap: 10px; --osc-btn: 56px; --osc-z: 9999; }
+      .credit-banner{
+        position:fixed; top:env(safe-area-inset-top,0); left:env(safe-area-inset-left,0);
+        margin:8px; padding:6px 10px; font:600 14px/1.2 system-ui, sans-serif;
+        background:rgba(0,0,0,.55); color:#fff; border-radius:8px; z-index:var(--osc-z);
+        -webkit-backdrop-filter:saturate(150%) blur(6px); backdrop-filter:saturate(150%) blur(6px);
+        user-select:none; pointer-events:none;
+      }
+      .osc-wrap{
+        position:fixed; inset:auto 0 env(safe-area-inset-bottom,0) 0;
+        display:flex; justify-content:center; gap:24px; padding:var(--osc-gap);
+        z-index:var(--osc-z); touch-action:manipulation;
+      }
+      .osc { display:flex; align-items:center; gap:16px; }
+      .osc .dpad{ display:grid; grid-template-areas:
+          ".    up    ."
+          "left  mid  right"
+          ".   down   .";
+        gap:8px; align-items:center; justify-items:center;
+      }
+      .osc .actions{ display:flex; gap:10px; }
+      .osc button{
+        min-width:var(--osc-btn); min-height:var(--osc-btn);
+        border:0; border-radius:12px; font:700 16px system-ui, sans-serif;
+        background:rgba(255,255,255,.9); color:#111; box-shadow:0 2px 10px rgba(0,0,0,.2);
+      }
+      .osc .pause{ min-width:72px; }
+      /* 게임 화면 가려짐 방지 */
+      body{ padding-bottom: calc(env(safe-area-inset-bottom,0) + 110px); }
+      @media (pointer:fine){ /* 데스크톱이면 패드 숨김 */
+        .osc-wrap{ display:none; } body{ padding-bottom:0; }
+      }
+    </style>
+
 </head>
 <body>
     <div class="wrapper">
@@ -391,5 +428,67 @@
         buildBoard();
     </script>
     <script src="../global-enhancements.js" defer></script>
+
+    <!-- Creator credit -->
+    <div class="credit-banner" aria-hidden="true">Creator: 박은성</div>
+
+    <!-- On-screen Controls -->
+    <div class="osc-wrap" id="osc-wrap" role="group" aria-label="On-screen game controls">
+      <div class="osc">
+        <div class="dpad">
+          <button data-key="ArrowUp"    style="grid-area:up">▲</button>
+          <button data-key="ArrowLeft"  style="grid-area:left">◀</button>
+          <button data-key="ArrowRight" style="grid-area:right">▶</button>
+          <button data-key="ArrowDown"  style="grid-area:down">▼</button>
+        </div>
+        <div class="actions">
+          <button data-key="Space">A</button>
+          <button data-key="Enter">B</button>
+          <button class="pause" data-key="Escape">⏯︎</button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+(function(){
+  // 일부 게임이 window/document/canvas 등 서로 다른 타깃을 구독하므로, 광범위 전파
+  function send(key, type){
+    const ev = new KeyboardEvent(type, { key, code:key, bubbles:true, cancelable:true });
+    const t = document.activeElement && document.activeElement !== document.body
+      ? document.activeElement : document;
+    t.dispatchEvent(ev); window.dispatchEvent(ev);
+  }
+  function pressStart(key){ send(key,'keydown'); }
+  function pressEnd(key){ send(key,'keyup'); }
+
+  // 버튼 터치/클릭 → 키 이벤트 변환
+  document.getElementById('osc-wrap')?.addEventListener('pointerdown', e=>{
+    const btn = e.target.closest('button[data-key]'); if(!btn) return;
+    e.preventDefault(); btn.setPointerCapture?.(e.pointerId);
+    pressStart(btn.dataset.key);
+    btn.addEventListener('pointerup',  ()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('pointercancel',()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('lostpointercapture',()=>pressEnd(btn.dataset.key), { once:true });
+  });
+
+  // 스와이프 제스처 → 방향키
+  let sx=0, sy=0, tracking=false;
+  const TH=24; // 스와이프 임계값(px)
+  document.addEventListener('touchstart', (e)=>{
+    // 오버레이 위 스와이프는 무시
+    if(e.target.closest('#osc-wrap')) return;
+    tracking=true; const t=e.changedTouches[0]; sx=t.clientX; sy=t.clientY;
+  }, {passive:true});
+  document.addEventListener('touchend', (e)=>{
+    if(!tracking) return; tracking=false;
+    const t=e.changedTouches[0]; const dx=t.clientX-sx, dy=t.clientY-sy;
+    if(Math.abs(dx)<TH && Math.abs(dy)<TH) return;
+    const key = Math.abs(dx)>Math.abs(dy) ? (dx>0?'ArrowRight':'ArrowLeft')
+                                          : (dy>0?'ArrowDown':'ArrowUp');
+    pressStart(key); setTimeout(()=>pressEnd(key), 50);
+  }, {passive:true});
+})();
+    </script>
+
 </body>
 </html>

--- a/game/nebulous/index.html
+++ b/game/nebulous/index.html
@@ -1,0 +1,293 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>세포 성장 실험 (Nebulous)</title>
+    <style>
+        body {
+            margin: 0;
+            overflow: hidden;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+            background: radial-gradient(circle at center, #1a2a6c 0%, #16213e 45%, #0f172a 100%);
+            color: #e0f2ff;
+        }
+        header {
+            position: fixed;
+            top: 16px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: rgba(13, 26, 45, 0.75);
+            padding: 12px 24px;
+            border-radius: 22px;
+            backdrop-filter: blur(8px);
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px 18px;
+            align-items: center;
+            justify-content: center;
+            box-shadow: 0 15px 35px rgba(0,0,0,0.4);
+            width: min(92vw, 640px);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+        }
+        header strong {
+            font-size: clamp(16px, 4vw, 20px);
+        }
+        .signature {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 12px;
+            border-radius: 999px;
+            background: rgba(34, 211, 238, 0.18);
+            color: #67e8f9;
+            font-weight: 700;
+            font-size: 12px;
+        }
+        #game {
+            display: block;
+        }
+        .hint {
+            position: fixed;
+            bottom: 24px;
+            left: 50%;
+            transform: translateX(-50%);
+            font-size: 14px;
+            color: rgba(224, 242, 255, 0.75);
+            background: rgba(15, 23, 42, 0.65);
+            padding: 10px 16px;
+            border-radius: 999px;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="signature">박은성이 만든 게임</div>
+        <strong>세포 성장 실험</strong>
+        <span>크기: <span id="size">10</span></span>
+        <span>흡수한 입자: <span id="score">0</span></span>
+        <span>위험 세포: <span id="danger">0</span> / <span id="danger-total">0</span></span>
+    </header>
+    <canvas id="game"></canvas>
+    <div class="hint">마우스를 움직여 세포를 조종하고 작은 입자를 흡수하세요. 큰 세포를 피하세요!</div>
+
+    <script>
+        const canvas = document.getElementById('game');
+        const ctx = canvas.getContext('2d');
+        const sizeEl = document.getElementById('size');
+        const scoreEl = document.getElementById('score');
+        const dangerEl = document.getElementById('danger');
+        const dangerTotalEl = document.getElementById('danger-total');
+
+        const WORLD_SIZE = 2800;
+        const pelletCount = 250;
+        const enemyCount = 8;
+        const pellets = [];
+        const enemies = [];
+        const colors = ['#22d3ee', '#fb7185', '#a855f7', '#34d399', '#fbbf24'];
+
+        const player = {
+            x: WORLD_SIZE / 2,
+            y: WORLD_SIZE / 2,
+            radius: 24,
+            speed: 2.2,
+            mass: 24
+        };
+        let score = 0;
+        let pointer = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+
+        function resize() {
+            canvas.width = window.innerWidth;
+            canvas.height = window.innerHeight;
+        }
+
+        window.addEventListener('resize', resize);
+        resize();
+
+        function spawnPellets() {
+            pellets.length = 0;
+            for (let i = 0; i < pelletCount; i++) {
+                pellets.push({
+                    x: Math.random() * WORLD_SIZE,
+                    y: Math.random() * WORLD_SIZE,
+                    radius: 6,
+                    color: colors[Math.floor(Math.random() * colors.length)]
+                });
+            }
+        }
+
+        function spawnEnemies() {
+            enemies.length = 0;
+            for (let i = 0; i < enemyCount; i++) {
+                const radius = 20 + Math.random() * 120;
+                enemies.push({
+                    x: Math.random() * WORLD_SIZE,
+                    y: Math.random() * WORLD_SIZE,
+                    radius,
+                    color: colors[Math.floor(Math.random() * colors.length)],
+                    speed: Math.max(0.4, 2.4 - radius / 80),
+                    angle: Math.random() * Math.PI * 2
+                });
+            }
+            dangerTotalEl.textContent = enemyCount;
+        }
+
+        function movePlayer() {
+            const targetX = pointer.x - canvas.width / 2;
+            const targetY = pointer.y - canvas.height / 2;
+            const len = Math.hypot(targetX, targetY);
+            const maxSpeed = Math.max(1.2, 4 - player.radius / 30);
+            if (len > 5) {
+                const vx = (targetX / len) * maxSpeed;
+                const vy = (targetY / len) * maxSpeed;
+                player.x += vx;
+                player.y += vy;
+            }
+            player.x = Math.max(player.radius, Math.min(WORLD_SIZE - player.radius, player.x));
+            player.y = Math.max(player.radius, Math.min(WORLD_SIZE - player.radius, player.y));
+        }
+
+        function moveEnemies() {
+            let dangerous = 0;
+            enemies.forEach(enemy => {
+                enemy.angle += (Math.random() - 0.5) * 0.2;
+                enemy.x += Math.cos(enemy.angle) * enemy.speed;
+                enemy.y += Math.sin(enemy.angle) * enemy.speed;
+                enemy.x = (enemy.x + WORLD_SIZE) % WORLD_SIZE;
+                enemy.y = (enemy.y + WORLD_SIZE) % WORLD_SIZE;
+                const dist = Math.hypot(enemy.x - player.x, enemy.y - player.y);
+                if (enemy.radius > player.radius * 1.15 && dist < 480) {
+                    enemy.angle = Math.atan2(player.y - enemy.y, player.x - enemy.x);
+                    dangerous++;
+                } else if (enemy.radius < player.radius && dist < 420) {
+                    enemy.angle = Math.atan2(enemy.y - player.y, enemy.x - player.x);
+                }
+            });
+            dangerEl.textContent = dangerous;
+        }
+
+        function handleCollisions() {
+            for (let i = pellets.length - 1; i >= 0; i--) {
+                const pellet = pellets[i];
+                if (Math.hypot(pellet.x - player.x, pellet.y - player.y) < player.radius) {
+                    pellets.splice(i, 1);
+                    score++;
+                    player.radius = Math.min(player.radius + 0.3, 180);
+                    updateHUD();
+                }
+            }
+            for (let i = enemies.length - 1; i >= 0; i--) {
+                const enemy = enemies[i];
+                const dist = Math.hypot(enemy.x - player.x, enemy.y - player.y);
+                if (dist < player.radius) {
+                    if (enemy.radius < player.radius * 0.85) {
+                        player.radius += enemy.radius * 0.2;
+                        enemies.splice(i, 1);
+                        score += Math.floor(enemy.radius);
+                        updateHUD();
+                    } else {
+                        alert('더 큰 세포에 흡수당했습니다! 점수: ' + score);
+                        resetGame();
+                        return;
+                    }
+                }
+            }
+            if (pellets.length < pelletCount) {
+                spawnPellets();
+            }
+            if (enemies.length < enemyCount) {
+                spawnEnemies();
+            }
+        }
+
+        function drawWorld() {
+            ctx.save();
+            const offsetX = canvas.width / 2 - player.x;
+            const offsetY = canvas.height / 2 - player.y;
+            ctx.translate(offsetX, offsetY);
+
+            const gridSize = 120;
+            ctx.strokeStyle = 'rgba(148, 163, 184, 0.15)';
+            ctx.lineWidth = 1;
+            for (let x = 0; x <= WORLD_SIZE; x += gridSize) {
+                ctx.beginPath();
+                ctx.moveTo(x, 0);
+                ctx.lineTo(x, WORLD_SIZE);
+                ctx.stroke();
+            }
+            for (let y = 0; y <= WORLD_SIZE; y += gridSize) {
+                ctx.beginPath();
+                ctx.moveTo(0, y);
+                ctx.lineTo(WORLD_SIZE, y);
+                ctx.stroke();
+            }
+
+            pellets.forEach(pellet => {
+                ctx.fillStyle = pellet.color;
+                ctx.beginPath();
+                ctx.arc(pellet.x, pellet.y, pellet.radius, 0, Math.PI * 2);
+                ctx.fill();
+            });
+
+            enemies.forEach(enemy => {
+                const gradient = ctx.createRadialGradient(enemy.x, enemy.y, enemy.radius * 0.3, enemy.x, enemy.y, enemy.radius);
+                gradient.addColorStop(0, enemy.color);
+                gradient.addColorStop(1, 'rgba(15, 23, 42, 0.8)');
+                ctx.fillStyle = gradient;
+                ctx.beginPath();
+                ctx.arc(enemy.x, enemy.y, enemy.radius, 0, Math.PI * 2);
+                ctx.fill();
+            });
+
+            const gradient = ctx.createRadialGradient(player.x, player.y, player.radius * 0.4, player.x, player.y, player.radius);
+            gradient.addColorStop(0, '#38bdf8');
+            gradient.addColorStop(1, '#0ea5e9');
+            ctx.fillStyle = gradient;
+            ctx.beginPath();
+            ctx.arc(player.x, player.y, player.radius, 0, Math.PI * 2);
+            ctx.fill();
+
+            ctx.restore();
+        }
+
+        function updateHUD() {
+            sizeEl.textContent = Math.round(player.radius);
+            scoreEl.textContent = score;
+        }
+
+        function resetGame() {
+            player.x = WORLD_SIZE / 2;
+            player.y = WORLD_SIZE / 2;
+            player.radius = 24;
+            score = 0;
+            spawnPellets();
+            spawnEnemies();
+            updateHUD();
+        }
+
+        canvas.addEventListener('mousemove', (e) => {
+            pointer = { x: e.clientX, y: e.clientY };
+        });
+
+        canvas.addEventListener('touchmove', (e) => {
+            const touch = e.touches[0];
+            pointer = { x: touch.clientX, y: touch.clientY };
+            e.preventDefault();
+        }, { passive: false });
+        canvas.style.touchAction = 'none';
+
+        function loop() {
+            movePlayer();
+            moveEnemies();
+            handleCollisions();
+            drawWorld();
+            requestAnimationFrame(loop);
+        }
+
+        resetGame();
+        updateHUD();
+        loop();
+    </script>
+    <script src="../global-enhancements.js" defer></script>
+</body>
+</html>

--- a/game/nebulous/index.html
+++ b/game/nebulous/index.html
@@ -2,7 +2,6 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>세포 성장 실험 (Nebulous)</title>
     <style>
         body {
@@ -59,6 +58,44 @@
             border-radius: 999px;
         }
     </style>
+
+    <!-- Mobile-friendly viewport -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+    <style>
+      :root { --osc-gap: 10px; --osc-btn: 56px; --osc-z: 9999; }
+      .credit-banner{
+        position:fixed; top:env(safe-area-inset-top,0); left:env(safe-area-inset-left,0);
+        margin:8px; padding:6px 10px; font:600 14px/1.2 system-ui, sans-serif;
+        background:rgba(0,0,0,.55); color:#fff; border-radius:8px; z-index:var(--osc-z);
+        -webkit-backdrop-filter:saturate(150%) blur(6px); backdrop-filter:saturate(150%) blur(6px);
+        user-select:none; pointer-events:none;
+      }
+      .osc-wrap{
+        position:fixed; inset:auto 0 env(safe-area-inset-bottom,0) 0;
+        display:flex; justify-content:center; gap:24px; padding:var(--osc-gap);
+        z-index:var(--osc-z); touch-action:manipulation;
+      }
+      .osc { display:flex; align-items:center; gap:16px; }
+      .osc .dpad{ display:grid; grid-template-areas:
+          ".    up    ."
+          "left  mid  right"
+          ".   down   .";
+        gap:8px; align-items:center; justify-items:center;
+      }
+      .osc .actions{ display:flex; gap:10px; }
+      .osc button{
+        min-width:var(--osc-btn); min-height:var(--osc-btn);
+        border:0; border-radius:12px; font:700 16px system-ui, sans-serif;
+        background:rgba(255,255,255,.9); color:#111; box-shadow:0 2px 10px rgba(0,0,0,.2);
+      }
+      .osc .pause{ min-width:72px; }
+      /* 게임 화면 가려짐 방지 */
+      body{ padding-bottom: calc(env(safe-area-inset-bottom,0) + 110px); }
+      @media (pointer:fine){ /* 데스크톱이면 패드 숨김 */
+        .osc-wrap{ display:none; } body{ padding-bottom:0; }
+      }
+    </style>
+
 </head>
 <body>
     <header>
@@ -289,5 +326,67 @@
         loop();
     </script>
     <script src="../global-enhancements.js" defer></script>
+
+    <!-- Creator credit -->
+    <div class="credit-banner" aria-hidden="true">Creator: 박은성</div>
+
+    <!-- On-screen Controls -->
+    <div class="osc-wrap" id="osc-wrap" role="group" aria-label="On-screen game controls">
+      <div class="osc">
+        <div class="dpad">
+          <button data-key="ArrowUp"    style="grid-area:up">▲</button>
+          <button data-key="ArrowLeft"  style="grid-area:left">◀</button>
+          <button data-key="ArrowRight" style="grid-area:right">▶</button>
+          <button data-key="ArrowDown"  style="grid-area:down">▼</button>
+        </div>
+        <div class="actions">
+          <button data-key="Space">A</button>
+          <button data-key="Enter">B</button>
+          <button class="pause" data-key="Escape">⏯︎</button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+(function(){
+  // 일부 게임이 window/document/canvas 등 서로 다른 타깃을 구독하므로, 광범위 전파
+  function send(key, type){
+    const ev = new KeyboardEvent(type, { key, code:key, bubbles:true, cancelable:true });
+    const t = document.activeElement && document.activeElement !== document.body
+      ? document.activeElement : document;
+    t.dispatchEvent(ev); window.dispatchEvent(ev);
+  }
+  function pressStart(key){ send(key,'keydown'); }
+  function pressEnd(key){ send(key,'keyup'); }
+
+  // 버튼 터치/클릭 → 키 이벤트 변환
+  document.getElementById('osc-wrap')?.addEventListener('pointerdown', e=>{
+    const btn = e.target.closest('button[data-key]'); if(!btn) return;
+    e.preventDefault(); btn.setPointerCapture?.(e.pointerId);
+    pressStart(btn.dataset.key);
+    btn.addEventListener('pointerup',  ()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('pointercancel',()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('lostpointercapture',()=>pressEnd(btn.dataset.key), { once:true });
+  });
+
+  // 스와이프 제스처 → 방향키
+  let sx=0, sy=0, tracking=false;
+  const TH=24; // 스와이프 임계값(px)
+  document.addEventListener('touchstart', (e)=>{
+    // 오버레이 위 스와이프는 무시
+    if(e.target.closest('#osc-wrap')) return;
+    tracking=true; const t=e.changedTouches[0]; sx=t.clientX; sy=t.clientY;
+  }, {passive:true});
+  document.addEventListener('touchend', (e)=>{
+    if(!tracking) return; tracking=false;
+    const t=e.changedTouches[0]; const dx=t.clientX-sx, dy=t.clientY-sy;
+    if(Math.abs(dx)<TH && Math.abs(dy)<TH) return;
+    const key = Math.abs(dx)>Math.abs(dy) ? (dx>0?'ArrowRight':'ArrowLeft')
+                                          : (dy>0?'ArrowDown':'ArrowUp');
+    pressStart(key); setTimeout(()=>pressEnd(key), 50);
+  }, {passive:true});
+})();
+    </script>
+
 </body>
 </html>

--- a/game/pong/index.html
+++ b/game/pong/index.html
@@ -2,7 +2,6 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>레이저 핑퐁</title>
     <style>
         body {
@@ -61,6 +60,44 @@
             justify-self: center;
         }
     </style>
+
+    <!-- Mobile-friendly viewport -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+    <style>
+      :root { --osc-gap: 10px; --osc-btn: 56px; --osc-z: 9999; }
+      .credit-banner{
+        position:fixed; top:env(safe-area-inset-top,0); left:env(safe-area-inset-left,0);
+        margin:8px; padding:6px 10px; font:600 14px/1.2 system-ui, sans-serif;
+        background:rgba(0,0,0,.55); color:#fff; border-radius:8px; z-index:var(--osc-z);
+        -webkit-backdrop-filter:saturate(150%) blur(6px); backdrop-filter:saturate(150%) blur(6px);
+        user-select:none; pointer-events:none;
+      }
+      .osc-wrap{
+        position:fixed; inset:auto 0 env(safe-area-inset-bottom,0) 0;
+        display:flex; justify-content:center; gap:24px; padding:var(--osc-gap);
+        z-index:var(--osc-z); touch-action:manipulation;
+      }
+      .osc { display:flex; align-items:center; gap:16px; }
+      .osc .dpad{ display:grid; grid-template-areas:
+          ".    up    ."
+          "left  mid  right"
+          ".   down   .";
+        gap:8px; align-items:center; justify-items:center;
+      }
+      .osc .actions{ display:flex; gap:10px; }
+      .osc button{
+        min-width:var(--osc-btn); min-height:var(--osc-btn);
+        border:0; border-radius:12px; font:700 16px system-ui, sans-serif;
+        background:rgba(255,255,255,.9); color:#111; box-shadow:0 2px 10px rgba(0,0,0,.2);
+      }
+      .osc .pause{ min-width:72px; }
+      /* 게임 화면 가려짐 방지 */
+      body{ padding-bottom: calc(env(safe-area-inset-bottom,0) + 110px); }
+      @media (pointer:fine){ /* 데스크톱이면 패드 숨김 */
+        .osc-wrap{ display:none; } body{ padding-bottom:0; }
+      }
+    </style>
+
 </head>
 <body>
     <div class="frame">
@@ -200,5 +237,67 @@
         loop();
     </script>
     <script src="../global-enhancements.js" defer></script>
+
+    <!-- Creator credit -->
+    <div class="credit-banner" aria-hidden="true">Creator: 박은성</div>
+
+    <!-- On-screen Controls -->
+    <div class="osc-wrap" id="osc-wrap" role="group" aria-label="On-screen game controls">
+      <div class="osc">
+        <div class="dpad">
+          <button data-key="ArrowUp"    style="grid-area:up">▲</button>
+          <button data-key="ArrowLeft"  style="grid-area:left">◀</button>
+          <button data-key="ArrowRight" style="grid-area:right">▶</button>
+          <button data-key="ArrowDown"  style="grid-area:down">▼</button>
+        </div>
+        <div class="actions">
+          <button data-key="Space">A</button>
+          <button data-key="Enter">B</button>
+          <button class="pause" data-key="Escape">⏯︎</button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+(function(){
+  // 일부 게임이 window/document/canvas 등 서로 다른 타깃을 구독하므로, 광범위 전파
+  function send(key, type){
+    const ev = new KeyboardEvent(type, { key, code:key, bubbles:true, cancelable:true });
+    const t = document.activeElement && document.activeElement !== document.body
+      ? document.activeElement : document;
+    t.dispatchEvent(ev); window.dispatchEvent(ev);
+  }
+  function pressStart(key){ send(key,'keydown'); }
+  function pressEnd(key){ send(key,'keyup'); }
+
+  // 버튼 터치/클릭 → 키 이벤트 변환
+  document.getElementById('osc-wrap')?.addEventListener('pointerdown', e=>{
+    const btn = e.target.closest('button[data-key]'); if(!btn) return;
+    e.preventDefault(); btn.setPointerCapture?.(e.pointerId);
+    pressStart(btn.dataset.key);
+    btn.addEventListener('pointerup',  ()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('pointercancel',()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('lostpointercapture',()=>pressEnd(btn.dataset.key), { once:true });
+  });
+
+  // 스와이프 제스처 → 방향키
+  let sx=0, sy=0, tracking=false;
+  const TH=24; // 스와이프 임계값(px)
+  document.addEventListener('touchstart', (e)=>{
+    // 오버레이 위 스와이프는 무시
+    if(e.target.closest('#osc-wrap')) return;
+    tracking=true; const t=e.changedTouches[0]; sx=t.clientX; sy=t.clientY;
+  }, {passive:true});
+  document.addEventListener('touchend', (e)=>{
+    if(!tracking) return; tracking=false;
+    const t=e.changedTouches[0]; const dx=t.clientX-sx, dy=t.clientY-sy;
+    if(Math.abs(dx)<TH && Math.abs(dy)<TH) return;
+    const key = Math.abs(dx)>Math.abs(dy) ? (dx>0?'ArrowRight':'ArrowLeft')
+                                          : (dy>0?'ArrowDown':'ArrowUp');
+    pressStart(key); setTimeout(()=>pressEnd(key), 50);
+  }, {passive:true});
+})();
+    </script>
+
 </body>
 </html>

--- a/game/pong/index.html
+++ b/game/pong/index.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>레이저 핑퐁</title>
+    <style>
+        body {
+            margin: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            padding: clamp(16px, 5vw, 48px);
+            background: conic-gradient(from 120deg, #111827, #1f2937, #111827);
+            color: #f3f4f6;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+        }
+        .frame {
+            background: rgba(11, 22, 34, 0.88);
+            border-radius: 22px;
+            padding: clamp(20px, 5vw, 32px);
+            box-shadow: 0 25px 60px rgba(0,0,0,0.55);
+            display: grid;
+            gap: 16px;
+            width: min(100%, 640px);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+        }
+        canvas {
+            background: rgba(2, 6, 14, 0.94);
+            border-radius: 16px;
+            border: 4px solid rgba(255,255,255,0.08);
+            image-rendering: pixelated;
+            width: min(100%, 640px);
+            height: auto;
+        }
+        .info {
+            display: flex;
+            justify-content: space-between;
+            font-size: 16px;
+            color: rgba(243, 244, 246, 0.85);
+            flex-wrap: wrap;
+            gap: 8px 16px;
+        }
+        .hint {
+            font-size: 14px;
+            color: rgba(209, 213, 219, 0.7);
+            text-align: center;
+            line-height: 1.6;
+        }
+        .signature {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 12px;
+            border-radius: 999px;
+            background: rgba(56, 189, 248, 0.2);
+            color: #93c5fd;
+            font-weight: 700;
+            font-size: 12px;
+            justify-self: center;
+        }
+    </style>
+</head>
+<body>
+    <div class="frame">
+        <div class="signature">박은성이 만든 게임</div>
+        <div class="info">
+            <span>플레이어: <strong id="player-score">0</strong></span>
+            <span>AI: <strong id="ai-score">0</strong></span>
+        </div>
+        <canvas id="game" width="640" height="360"></canvas>
+        <p class="hint">마우스나 터치로 패들을 움직여 공을 튕겨내세요. 10점을 먼저 획득하면 승리!</p>
+    </div>
+
+    <script>
+        const canvas = document.getElementById('game');
+        const ctx = canvas.getContext('2d');
+        const playerScoreEl = document.getElementById('player-score');
+        const aiScoreEl = document.getElementById('ai-score');
+
+        const paddle = { width: 14, height: 90 };
+        const player = { x: 20, y: canvas.height / 2 - paddle.height / 2, score: 0 };
+        const ai = { x: canvas.width - 20 - paddle.width, y: canvas.height / 2 - paddle.height / 2, score: 0, speed: 4 };
+        const ball = { x: canvas.width / 2, y: canvas.height / 2, radius: 8, speed: 5, vx: 4, vy: 3 };
+
+        let targetY = player.y;
+
+        canvas.addEventListener('mousemove', e => {
+            const rect = canvas.getBoundingClientRect();
+            targetY = e.clientY - rect.top - paddle.height / 2;
+        });
+        canvas.addEventListener('touchmove', e => {
+            const rect = canvas.getBoundingClientRect();
+            targetY = e.touches[0].clientY - rect.top - paddle.height / 2;
+            e.preventDefault();
+        }, { passive: false });
+        canvas.style.touchAction = 'none';
+
+        function clamp(value, min, max) {
+            return Math.max(min, Math.min(max, value));
+        }
+
+        function resetBall(direction = 1) {
+            ball.x = canvas.width / 2;
+            ball.y = canvas.height / 2;
+            const angle = (Math.random() * Math.PI / 3) - Math.PI / 6;
+            const speed = 5 + Math.random() * 1.5;
+            ball.vx = Math.cos(angle) * speed * direction;
+            ball.vy = Math.sin(angle) * speed;
+        }
+
+        function update() {
+            player.y += (targetY - player.y) * 0.2;
+            player.y = clamp(player.y, 0, canvas.height - paddle.height);
+
+            const aiCenter = ai.y + paddle.height / 2;
+            if (ball.y < aiCenter - 20) ai.y -= ai.speed;
+            else if (ball.y > aiCenter + 20) ai.y += ai.speed;
+            ai.y = clamp(ai.y, 0, canvas.height - paddle.height);
+
+            ball.x += ball.vx;
+            ball.y += ball.vy;
+
+            if (ball.y - ball.radius <= 0 || ball.y + ball.radius >= canvas.height) {
+                ball.vy *= -1;
+            }
+
+            function paddleCollision(p) {
+                if (
+                    ball.x - ball.radius < p.x + paddle.width &&
+                    ball.x + ball.radius > p.x &&
+                    ball.y + ball.radius > p.y &&
+                    ball.y - ball.radius < p.y + paddle.height
+                ) {
+                    const relativeIntersectY = (ball.y - (p.y + paddle.height / 2)) / (paddle.height / 2);
+                    const bounceAngle = relativeIntersectY * (Math.PI / 3);
+                    const direction = p === player ? 1 : -1;
+                    const speed = Math.min(10, Math.hypot(ball.vx, ball.vy) + 0.4);
+                    ball.vx = Math.cos(bounceAngle) * speed * direction;
+                    ball.vy = Math.sin(bounceAngle) * speed;
+                    ball.x = p === player ? p.x + paddle.width + ball.radius : p.x - ball.radius;
+                }
+            }
+
+            paddleCollision(player);
+            paddleCollision(ai);
+
+            if (ball.x < 0) {
+                ai.score++;
+                aiScoreEl.textContent = ai.score;
+                resetBall(1);
+            } else if (ball.x > canvas.width) {
+                player.score++;
+                playerScoreEl.textContent = player.score;
+                resetBall(-1);
+            }
+
+            if (player.score >= 10 || ai.score >= 10) {
+                alert((player.score > ai.score ? '플레이어 승리!' : 'AI 승리!') + ` (플레이어 ${player.score} : ${ai.score} AI)`);
+                player.score = 0;
+                ai.score = 0;
+                playerScoreEl.textContent = player.score;
+                aiScoreEl.textContent = ai.score;
+                resetBall(Math.random() < 0.5 ? 1 : -1);
+            }
+        }
+
+        function draw() {
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            const gradient = ctx.createLinearGradient(0, 0, canvas.width, canvas.height);
+            gradient.addColorStop(0, 'rgba(59, 130, 246, 0.2)');
+            gradient.addColorStop(1, 'rgba(236, 72, 153, 0.2)');
+            ctx.fillStyle = gradient;
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+            ctx.fillStyle = 'rgba(148, 163, 184, 0.35)';
+            for (let y = 0; y < canvas.height; y += 24) {
+                ctx.fillRect(canvas.width / 2 - 2, y, 4, 12);
+            }
+
+            ctx.fillStyle = '#38bdf8';
+            ctx.fillRect(player.x, player.y, paddle.width, paddle.height);
+            ctx.fillStyle = '#f472b6';
+            ctx.fillRect(ai.x, ai.y, paddle.width, paddle.height);
+
+            ctx.beginPath();
+            ctx.fillStyle = '#f8fafc';
+            ctx.arc(ball.x, ball.y, ball.radius, 0, Math.PI * 2);
+            ctx.fill();
+        }
+
+        function loop() {
+            update();
+            draw();
+            requestAnimationFrame(loop);
+        }
+
+        resetBall(Math.random() < 0.5 ? 1 : -1);
+        loop();
+    </script>
+    <script src="../global-enhancements.js" defer></script>
+</body>
+</html>

--- a/game/runner/index.html
+++ b/game/runner/index.html
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>스카이 러너</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: linear-gradient(180deg, #0c1445 0%, #1b2b6b 40%, #0b1329 100%);
+            color: #f5f6fa;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+        }
+        .container {
+            background: rgba(10, 16, 36, 0.9);
+            padding: 30px;
+            border-radius: 28px;
+            box-shadow: 0 28px 70px rgba(0, 0, 0, 0.55);
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+            align-items: center;
+        }
+        canvas {
+            border-radius: 20px;
+            border: 6px solid rgba(255, 255, 255, 0.08);
+            background: linear-gradient(180deg, #2f80ed 0%, #56ccf2 55%, #ecf8ff 56%, #f3f9ff 100%);
+        }
+        h1 {
+            margin: 0;
+            font-size: 28px;
+        }
+        .stats {
+            display: flex;
+            gap: 20px;
+            font-weight: 600;
+        }
+        button {
+            background: linear-gradient(135deg, #c471ed, #f7797d);
+            color: #1f0b2f;
+            border: none;
+            border-radius: 999px;
+            padding: 10px 24px;
+            font-weight: 700;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 18px 28px rgba(247, 121, 125, 0.35);
+        }
+        p {
+            margin: 0;
+            font-size: 14px;
+            color: rgba(255, 255, 255, 0.75);
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>스카이 러너</h1>
+        <div class="stats">
+            <div>거리: <span id="distance">0</span>m</div>
+            <div>최고: <span id="best">0</span>m</div>
+            <div>속도: <span id="speed">0</span>m/s</div>
+        </div>
+        <canvas id="game" width="640" height="360"></canvas>
+        <button id="restart">다시 시작</button>
+        <p>스페이스/위 키로 점프, 아래 키로 구르기. 장애물을 피하며 더 멀리 달려 보세요!</p>
+    </div>
+
+    <script>
+        const canvas = document.getElementById('game');
+        const ctx = canvas.getContext('2d');
+        const distanceEl = document.getElementById('distance');
+        const bestEl = document.getElementById('best');
+        const speedEl = document.getElementById('speed');
+        const restartBtn = document.getElementById('restart');
+
+        const WIDTH = canvas.width;
+        const HEIGHT = canvas.height;
+
+        const GROUND = HEIGHT - 60;
+        const GRAVITY = 0.0022;
+        const JUMP_FORCE = -0.95;
+
+        let player;
+        let obstacles;
+        let clouds;
+        let distance;
+        let speed;
+        let best = Number(localStorage.getItem('runner-best')) || 0;
+        let running = false;
+        let lastTime = 0;
+        let slideTimer = 0;
+
+        const keys = new Set();
+
+        bestEl.textContent = best;
+
+        function resetGame() {
+            player = { x: 120, y: GROUND, vy: 0, width: 44, height: 64, sliding: false };
+            obstacles = [];
+            clouds = Array.from({ length: 5 }, () => ({
+                x: Math.random() * WIDTH,
+                y: 40 + Math.random() * 120,
+                speed: 0.02 + Math.random() * 0.05
+            }));
+            distance = 0;
+            speed = 0.25;
+            running = true;
+            lastTime = performance.now();
+            slideTimer = 0;
+            updateObstacles.nextSpawn = 600;
+            updateUI();
+        }
+
+        function updateUI() {
+            distanceEl.textContent = Math.floor(distance);
+            speedEl.textContent = speed.toFixed(2);
+        }
+
+        function spawnObstacle() {
+            const types = [
+                { width: 30, height: 60, yOffset: 0 },
+                { width: 54, height: 40, yOffset: 20 },
+                { width: 40, height: 32, yOffset: 28 }
+            ];
+            const type = types[Math.floor(Math.random() * types.length)];
+            obstacles.push({
+                x: WIDTH + 40,
+                width: type.width,
+                height: type.height,
+                y: GROUND - type.height + type.yOffset,
+                scored: false
+            });
+        }
+
+        function updateClouds(delta) {
+            clouds.forEach(cloud => {
+                cloud.x -= cloud.speed * delta;
+                if (cloud.x < -80) {
+                    cloud.x = WIDTH + Math.random() * 80;
+                    cloud.y = 40 + Math.random() * 120;
+                    cloud.speed = 0.02 + Math.random() * 0.05;
+                }
+            });
+        }
+
+        function updateObstacles(delta) {
+            const spawnInterval = Math.max(900 - distance * 2, 360);
+            if (!updateObstacles.nextSpawn) updateObstacles.nextSpawn = spawnInterval;
+            updateObstacles.nextSpawn -= delta;
+            if (updateObstacles.nextSpawn <= 0) {
+                spawnObstacle();
+                updateObstacles.nextSpawn = spawnInterval;
+            }
+            obstacles = obstacles.filter(obs => {
+                obs.x -= speed * delta * 1.4;
+                if (!obs.scored && obs.x + obs.width < player.x) {
+                    obs.scored = true;
+                    distance += 5;
+                }
+                return obs.x + obs.width > -20;
+            });
+        }
+
+        function handleInput(delta) {
+            if ((keys.has(' ') || keys.has('Space') || keys.has('ArrowUp')) && player.y >= GROUND) {
+                player.vy = JUMP_FORCE;
+                player.y = GROUND - 1;
+            }
+            if (keys.has('ArrowDown') && player.y >= GROUND - 1) {
+                player.sliding = true;
+                slideTimer += delta;
+                if (slideTimer > 600) {
+                    slideTimer = 0;
+                    player.sliding = false;
+                }
+            } else {
+                player.sliding = false;
+                slideTimer = 0;
+            }
+        }
+
+        function updatePlayer(delta) {
+            handleInput(delta);
+            player.vy += GRAVITY * delta;
+            player.y += player.vy * delta;
+            if (player.y >= GROUND) {
+                player.y = GROUND;
+                player.vy = 0;
+            }
+            updateUI();
+        }
+
+        function detectCollision(obstacle) {
+            const playerHeight = player.sliding ? player.height * 0.55 : player.height;
+            const playerTop = player.y - playerHeight;
+            const playerBottom = player.y;
+            const playerLeft = player.x - player.width / 2;
+            const playerRight = player.x + player.width / 2;
+            const obstacleTop = obstacle.y - obstacle.height;
+            const obstacleBottom = obstacle.y;
+            const obstacleLeft = obstacle.x;
+            const obstacleRight = obstacle.x + obstacle.width;
+            return !(playerRight < obstacleLeft || playerLeft > obstacleRight || playerBottom < obstacleTop || playerTop > obstacleBottom);
+        }
+
+        function drawBackground() {
+            ctx.fillStyle = '#90e0ff';
+            ctx.fillRect(0, 0, WIDTH, HEIGHT);
+            ctx.fillStyle = '#fff';
+            clouds.forEach(cloud => {
+                ctx.globalAlpha = 0.6;
+                ctx.beginPath();
+                ctx.arc(cloud.x, cloud.y, 24, Math.PI, 0);
+                ctx.arc(cloud.x + 24, cloud.y, 24, Math.PI, 0);
+                ctx.arc(cloud.x + 48, cloud.y, 24, Math.PI, 0);
+                ctx.fill();
+                ctx.globalAlpha = 1;
+            });
+            ctx.fillStyle = '#0f3d66';
+            ctx.fillRect(0, HEIGHT - 60, WIDTH, 60);
+            ctx.fillStyle = '#1f5a8a';
+            ctx.fillRect(0, HEIGHT - 56, WIDTH, 4);
+        }
+
+        function drawPlayer() {
+            ctx.save();
+            ctx.translate(player.x, player.y);
+            const height = player.sliding ? player.height * 0.55 : player.height;
+            ctx.fillStyle = '#f8cdda';
+            ctx.fillRect(-player.width / 2, -height, player.width, height);
+            ctx.fillStyle = '#ff5f6d';
+            ctx.fillRect(-player.width / 2, -height, player.width, 16);
+            ctx.restore();
+        }
+
+        function drawObstacles() {
+            ctx.fillStyle = '#ffd166';
+            obstacles.forEach(obs => {
+                ctx.fillRect(obs.x, obs.y - obs.height, obs.width, obs.height);
+                ctx.fillStyle = '#f8961e';
+                ctx.fillRect(obs.x, obs.y - 8, obs.width, 8);
+                ctx.fillStyle = '#ffd166';
+            });
+        }
+
+        function update(time = 0) {
+            if (!running) return;
+            const delta = time - lastTime;
+            lastTime = time;
+            speed += delta * 0.00002;
+            distance += speed * delta * 0.01;
+            updateClouds(delta);
+            updateObstacles(delta);
+            updatePlayer(delta);
+            drawBackground();
+            drawObstacles();
+            drawPlayer();
+            if (obstacles.some(detectCollision)) {
+                endGame();
+                return;
+            }
+            requestAnimationFrame(update);
+        }
+
+        function endGame() {
+            running = false;
+            best = Math.max(best, Math.floor(distance));
+            localStorage.setItem('runner-best', best);
+            bestEl.textContent = best;
+            ctx.fillStyle = 'rgba(0, 0, 0, 0.55)';
+            ctx.fillRect(0, 0, WIDTH, HEIGHT);
+            ctx.fillStyle = '#f5f6fa';
+            ctx.font = '28px Pretendard, sans-serif';
+            ctx.textAlign = 'center';
+            ctx.fillText('게임 오버', WIDTH / 2, HEIGHT / 2 - 12);
+            ctx.font = '18px Pretendard, sans-serif';
+            ctx.fillText(`거리: ${Math.floor(distance)}m`, WIDTH / 2, HEIGHT / 2 + 20);
+        }
+
+        restartBtn.addEventListener('click', () => {
+            resetGame();
+            requestAnimationFrame(update);
+        });
+
+        document.addEventListener('keydown', e => {
+            keys.add(e.key);
+            if (e.key === ' ') e.preventDefault();
+            if (!running) {
+                resetGame();
+                requestAnimationFrame(update);
+            }
+        });
+        document.addEventListener('keyup', e => {
+            keys.delete(e.key);
+        });
+
+        resetGame();
+        running = false;
+        drawBackground();
+        drawObstacles();
+        drawPlayer();
+    </script>
+    <script src="../global-enhancements.js" defer></script>
+</body>
+</html>

--- a/game/runner/index.html
+++ b/game/runner/index.html
@@ -2,7 +2,6 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>스카이 러너</title>
     <style>
         :root {
@@ -63,6 +62,44 @@
             text-align: center;
         }
     </style>
+
+    <!-- Mobile-friendly viewport -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+    <style>
+      :root { --osc-gap: 10px; --osc-btn: 56px; --osc-z: 9999; }
+      .credit-banner{
+        position:fixed; top:env(safe-area-inset-top,0); left:env(safe-area-inset-left,0);
+        margin:8px; padding:6px 10px; font:600 14px/1.2 system-ui, sans-serif;
+        background:rgba(0,0,0,.55); color:#fff; border-radius:8px; z-index:var(--osc-z);
+        -webkit-backdrop-filter:saturate(150%) blur(6px); backdrop-filter:saturate(150%) blur(6px);
+        user-select:none; pointer-events:none;
+      }
+      .osc-wrap{
+        position:fixed; inset:auto 0 env(safe-area-inset-bottom,0) 0;
+        display:flex; justify-content:center; gap:24px; padding:var(--osc-gap);
+        z-index:var(--osc-z); touch-action:manipulation;
+      }
+      .osc { display:flex; align-items:center; gap:16px; }
+      .osc .dpad{ display:grid; grid-template-areas:
+          ".    up    ."
+          "left  mid  right"
+          ".   down   .";
+        gap:8px; align-items:center; justify-items:center;
+      }
+      .osc .actions{ display:flex; gap:10px; }
+      .osc button{
+        min-width:var(--osc-btn); min-height:var(--osc-btn);
+        border:0; border-radius:12px; font:700 16px system-ui, sans-serif;
+        background:rgba(255,255,255,.9); color:#111; box-shadow:0 2px 10px rgba(0,0,0,.2);
+      }
+      .osc .pause{ min-width:72px; }
+      /* 게임 화면 가려짐 방지 */
+      body{ padding-bottom: calc(env(safe-area-inset-bottom,0) + 110px); }
+      @media (pointer:fine){ /* 데스크톱이면 패드 숨김 */
+        .osc-wrap{ display:none; } body{ padding-bottom:0; }
+      }
+    </style>
+
 </head>
 <body>
     <div class="container">
@@ -313,5 +350,67 @@
         drawPlayer();
     </script>
     <script src="../global-enhancements.js" defer></script>
+
+    <!-- Creator credit -->
+    <div class="credit-banner" aria-hidden="true">Creator: 박은성</div>
+
+    <!-- On-screen Controls -->
+    <div class="osc-wrap" id="osc-wrap" role="group" aria-label="On-screen game controls">
+      <div class="osc">
+        <div class="dpad">
+          <button data-key="ArrowUp"    style="grid-area:up">▲</button>
+          <button data-key="ArrowLeft"  style="grid-area:left">◀</button>
+          <button data-key="ArrowRight" style="grid-area:right">▶</button>
+          <button data-key="ArrowDown"  style="grid-area:down">▼</button>
+        </div>
+        <div class="actions">
+          <button data-key="Space">A</button>
+          <button data-key="Enter">B</button>
+          <button class="pause" data-key="Escape">⏯︎</button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+(function(){
+  // 일부 게임이 window/document/canvas 등 서로 다른 타깃을 구독하므로, 광범위 전파
+  function send(key, type){
+    const ev = new KeyboardEvent(type, { key, code:key, bubbles:true, cancelable:true });
+    const t = document.activeElement && document.activeElement !== document.body
+      ? document.activeElement : document;
+    t.dispatchEvent(ev); window.dispatchEvent(ev);
+  }
+  function pressStart(key){ send(key,'keydown'); }
+  function pressEnd(key){ send(key,'keyup'); }
+
+  // 버튼 터치/클릭 → 키 이벤트 변환
+  document.getElementById('osc-wrap')?.addEventListener('pointerdown', e=>{
+    const btn = e.target.closest('button[data-key]'); if(!btn) return;
+    e.preventDefault(); btn.setPointerCapture?.(e.pointerId);
+    pressStart(btn.dataset.key);
+    btn.addEventListener('pointerup',  ()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('pointercancel',()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('lostpointercapture',()=>pressEnd(btn.dataset.key), { once:true });
+  });
+
+  // 스와이프 제스처 → 방향키
+  let sx=0, sy=0, tracking=false;
+  const TH=24; // 스와이프 임계값(px)
+  document.addEventListener('touchstart', (e)=>{
+    // 오버레이 위 스와이프는 무시
+    if(e.target.closest('#osc-wrap')) return;
+    tracking=true; const t=e.changedTouches[0]; sx=t.clientX; sy=t.clientY;
+  }, {passive:true});
+  document.addEventListener('touchend', (e)=>{
+    if(!tracking) return; tracking=false;
+    const t=e.changedTouches[0]; const dx=t.clientX-sx, dy=t.clientY-sy;
+    if(Math.abs(dx)<TH && Math.abs(dy)<TH) return;
+    const key = Math.abs(dx)>Math.abs(dy) ? (dx>0?'ArrowRight':'ArrowLeft')
+                                          : (dy>0?'ArrowDown':'ArrowUp');
+    pressStart(key); setTimeout(()=>pressEnd(key), 50);
+  }, {passive:true});
+})();
+    </script>
+
 </body>
 </html>

--- a/game/sand-tetris/index.html
+++ b/game/sand-tetris/index.html
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>모래 테트리스 실험실</title>
+    <style>
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: radial-gradient(circle at 30% 20%, #0f2027, #203a43 60%, #2c5364);
+            color: #eaf6ff;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+        }
+        .layout {
+            display: grid;
+            gap: 24px;
+            background: rgba(5, 18, 26, 0.9);
+            padding: 32px;
+            border-radius: 24px;
+            box-shadow: 0 25px 50px rgba(0,0,0,0.5);
+        }
+        canvas {
+            border-radius: 18px;
+            border: 6px solid rgba(255,255,255,0.08);
+            background: linear-gradient(180deg, rgba(12,26,35,0.8), rgba(6,14,20,0.95));
+            image-rendering: pixelated;
+        }
+        .controls {
+            display: flex;
+            gap: 12px;
+            flex-wrap: wrap;
+        }
+        button {
+            background: linear-gradient(135deg, #00b4db, #0083b0);
+            color: #021218;
+            border: none;
+            border-radius: 999px;
+            padding: 10px 20px;
+            font-weight: 700;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 12px 20px rgba(0, 132, 176, 0.35);
+        }
+        .info {
+            max-width: 420px;
+            line-height: 1.6;
+            font-size: 14px;
+            color: rgba(234, 246, 255, 0.8);
+        }
+        strong { color: #9be7ff; }
+    </style>
+</head>
+<body>
+    <div class="layout">
+        <canvas id="board" width="320" height="480"></canvas>
+        <div class="controls">
+            <button id="dropShape">랜덤 블록 떨어뜨리기</button>
+            <button id="clear">초기화</button>
+        </div>
+        <div class="info">
+            <p><strong>사용 방법</strong></p>
+            <ul>
+                <li>마우스로 화면을 드래그하면 모래를 뿌릴 수 있습니다.</li>
+                <li>랜덤 블록 버튼을 누르면 테트리스 모양의 굳은 블록이 등장합니다.</li>
+                <li>모래는 중력에 따라 흘러내리고, 굳은 블록은 지형을 지탱합니다.</li>
+                <li>공간을 창의적으로 채우며 지형을 만들어 보세요!</li>
+            </ul>
+        </div>
+    </div>
+
+    <script>
+        const canvas = document.getElementById('board');
+        const ctx = canvas.getContext('2d');
+        const gridWidth = 32;
+        const gridHeight = 48;
+        const cellSize = canvas.width / gridWidth;
+        const sandColor = '#f1c27d';
+        const blockColor = '#4dd0e1';
+        const settledColor = '#80cbc4';
+
+        const grid = Array.from({ length: gridHeight }, () => Array(gridWidth).fill(0));
+        let dragging = false;
+        let currentShape = null;
+
+        const SHAPES = [
+            [[1, 1, 1, 1]],
+            [[1, 0, 0], [1, 1, 1]],
+            [[0, 0, 1], [1, 1, 1]],
+            [[1, 1], [1, 1]],
+            [[0, 1, 1], [1, 1, 0]],
+            [[0, 1, 0], [1, 1, 1]],
+            [[1, 1, 0], [0, 1, 1]]
+        ];
+
+        function spawnShape() {
+            const matrix = SHAPES[Math.floor(Math.random() * SHAPES.length)];
+            currentShape = {
+                matrix: matrix.map(row => [...row]),
+                x: Math.floor((gridWidth - matrix[0].length) / 2),
+                y: -matrix.length,
+                settled: false
+            };
+        }
+
+        function addSand(x, y) {
+            if (x < 0 || x >= gridWidth || y < 0 || y >= gridHeight) return;
+            grid[y][x] = 1;
+        }
+
+        canvas.addEventListener('mousedown', (e) => {
+            dragging = true;
+            addSandFromEvent(e);
+        });
+        window.addEventListener('mouseup', () => dragging = false);
+        canvas.addEventListener('mousemove', (e) => {
+            if (dragging) addSandFromEvent(e);
+        });
+
+        function addSandFromEvent(e) {
+            const rect = canvas.getBoundingClientRect();
+            const x = Math.floor((e.clientX - rect.left) / cellSize);
+            const y = Math.floor((e.clientY - rect.top) / cellSize);
+            for (let dy = -1; dy <= 1; dy++) {
+                for (let dx = -1; dx <= 1; dx++) {
+                    addSand(x + dx, y + dy);
+                }
+            }
+        }
+
+        document.getElementById('dropShape').addEventListener('click', () => {
+            if (!currentShape) spawnShape();
+        });
+
+        document.getElementById('clear').addEventListener('click', () => {
+            for (let y = 0; y < gridHeight; y++) {
+                grid[y].fill(0);
+            }
+            currentShape = null;
+        });
+
+        function updateSand() {
+            for (let y = gridHeight - 2; y >= 0; y--) {
+                for (let x = 0; x < gridWidth; x++) {
+                    if (grid[y][x] === 1) {
+                        if (grid[y + 1][x] === 0) {
+                            grid[y + 1][x] = 1;
+                            grid[y][x] = 0;
+                        } else {
+                            const dir = Math.random() < 0.5 ? -1 : 1;
+                            if (x + dir >= 0 && x + dir < gridWidth && grid[y + 1][x + dir] === 0) {
+                                grid[y + 1][x + dir] = 1;
+                                grid[y][x] = 0;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        function canPlace(matrix, offsetX, offsetY) {
+            for (let y = 0; y < matrix.length; y++) {
+                for (let x = 0; x < matrix[y].length; x++) {
+                    if (!matrix[y][x]) continue;
+                    const gridX = offsetX + x;
+                    const gridY = offsetY + y;
+                    if (gridX < 0 || gridX >= gridWidth) return false;
+                    if (gridY >= gridHeight) return false;
+                    if (gridY >= 0 && grid[gridY][gridX]) return false;
+                }
+            }
+            return true;
+        }
+
+        function settleShape(shape) {
+            shape.matrix.forEach((row, y) => {
+                row.forEach((value, x) => {
+                    if (value) {
+                        const gridX = shape.x + x;
+                        const gridY = shape.y + y;
+                        if (gridY >= 0 && gridY < gridHeight) {
+                            grid[gridY][gridX] = 2;
+                        }
+                    }
+                });
+            });
+        }
+
+        function updateShape() {
+            if (!currentShape) return;
+            if (canPlace(currentShape.matrix, currentShape.x, currentShape.y + 1)) {
+                currentShape.y += 1;
+            } else {
+                settleShape(currentShape);
+                currentShape = null;
+            }
+        }
+
+        function draw() {
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            for (let y = 0; y < gridHeight; y++) {
+                for (let x = 0; x < gridWidth; x++) {
+                    const value = grid[y][x];
+                    if (value) {
+                        ctx.fillStyle = value === 1 ? sandColor : settledColor;
+                        ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize);
+                    }
+                }
+            }
+            if (currentShape) {
+                ctx.fillStyle = blockColor;
+                currentShape.matrix.forEach((row, y) => {
+                    row.forEach((value, x) => {
+                        if (value) {
+                            const drawX = (currentShape.x + x) * cellSize;
+                            const drawY = (currentShape.y + y) * cellSize;
+                            ctx.fillRect(drawX, drawY, cellSize, cellSize);
+                        }
+                    });
+                });
+            }
+        }
+
+        function loop() {
+            updateSand();
+            updateShape();
+            draw();
+            requestAnimationFrame(loop);
+        }
+
+        loop();
+    </script>
+    <script src="../global-enhancements.js" defer></script>
+</body>
+</html>

--- a/game/sand-tetris/index.html
+++ b/game/sand-tetris/index.html
@@ -2,7 +2,6 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>모래 테트리스 실험실</title>
     <style>
         body {
@@ -56,6 +55,44 @@
         }
         strong { color: #9be7ff; }
     </style>
+
+    <!-- Mobile-friendly viewport -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+    <style>
+      :root { --osc-gap: 10px; --osc-btn: 56px; --osc-z: 9999; }
+      .credit-banner{
+        position:fixed; top:env(safe-area-inset-top,0); left:env(safe-area-inset-left,0);
+        margin:8px; padding:6px 10px; font:600 14px/1.2 system-ui, sans-serif;
+        background:rgba(0,0,0,.55); color:#fff; border-radius:8px; z-index:var(--osc-z);
+        -webkit-backdrop-filter:saturate(150%) blur(6px); backdrop-filter:saturate(150%) blur(6px);
+        user-select:none; pointer-events:none;
+      }
+      .osc-wrap{
+        position:fixed; inset:auto 0 env(safe-area-inset-bottom,0) 0;
+        display:flex; justify-content:center; gap:24px; padding:var(--osc-gap);
+        z-index:var(--osc-z); touch-action:manipulation;
+      }
+      .osc { display:flex; align-items:center; gap:16px; }
+      .osc .dpad{ display:grid; grid-template-areas:
+          ".    up    ."
+          "left  mid  right"
+          ".   down   .";
+        gap:8px; align-items:center; justify-items:center;
+      }
+      .osc .actions{ display:flex; gap:10px; }
+      .osc button{
+        min-width:var(--osc-btn); min-height:var(--osc-btn);
+        border:0; border-radius:12px; font:700 16px system-ui, sans-serif;
+        background:rgba(255,255,255,.9); color:#111; box-shadow:0 2px 10px rgba(0,0,0,.2);
+      }
+      .osc .pause{ min-width:72px; }
+      /* 게임 화면 가려짐 방지 */
+      body{ padding-bottom: calc(env(safe-area-inset-bottom,0) + 110px); }
+      @media (pointer:fine){ /* 데스크톱이면 패드 숨김 */
+        .osc-wrap{ display:none; } body{ padding-bottom:0; }
+      }
+    </style>
+
 </head>
 <body>
     <div class="layout">
@@ -237,5 +274,67 @@
         loop();
     </script>
     <script src="../global-enhancements.js" defer></script>
+
+    <!-- Creator credit -->
+    <div class="credit-banner" aria-hidden="true">Creator: 박은성</div>
+
+    <!-- On-screen Controls -->
+    <div class="osc-wrap" id="osc-wrap" role="group" aria-label="On-screen game controls">
+      <div class="osc">
+        <div class="dpad">
+          <button data-key="ArrowUp"    style="grid-area:up">▲</button>
+          <button data-key="ArrowLeft"  style="grid-area:left">◀</button>
+          <button data-key="ArrowRight" style="grid-area:right">▶</button>
+          <button data-key="ArrowDown"  style="grid-area:down">▼</button>
+        </div>
+        <div class="actions">
+          <button data-key="Space">A</button>
+          <button data-key="Enter">B</button>
+          <button class="pause" data-key="Escape">⏯︎</button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+(function(){
+  // 일부 게임이 window/document/canvas 등 서로 다른 타깃을 구독하므로, 광범위 전파
+  function send(key, type){
+    const ev = new KeyboardEvent(type, { key, code:key, bubbles:true, cancelable:true });
+    const t = document.activeElement && document.activeElement !== document.body
+      ? document.activeElement : document;
+    t.dispatchEvent(ev); window.dispatchEvent(ev);
+  }
+  function pressStart(key){ send(key,'keydown'); }
+  function pressEnd(key){ send(key,'keyup'); }
+
+  // 버튼 터치/클릭 → 키 이벤트 변환
+  document.getElementById('osc-wrap')?.addEventListener('pointerdown', e=>{
+    const btn = e.target.closest('button[data-key]'); if(!btn) return;
+    e.preventDefault(); btn.setPointerCapture?.(e.pointerId);
+    pressStart(btn.dataset.key);
+    btn.addEventListener('pointerup',  ()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('pointercancel',()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('lostpointercapture',()=>pressEnd(btn.dataset.key), { once:true });
+  });
+
+  // 스와이프 제스처 → 방향키
+  let sx=0, sy=0, tracking=false;
+  const TH=24; // 스와이프 임계값(px)
+  document.addEventListener('touchstart', (e)=>{
+    // 오버레이 위 스와이프는 무시
+    if(e.target.closest('#osc-wrap')) return;
+    tracking=true; const t=e.changedTouches[0]; sx=t.clientX; sy=t.clientY;
+  }, {passive:true});
+  document.addEventListener('touchend', (e)=>{
+    if(!tracking) return; tracking=false;
+    const t=e.changedTouches[0]; const dx=t.clientX-sx, dy=t.clientY-sy;
+    if(Math.abs(dx)<TH && Math.abs(dy)<TH) return;
+    const key = Math.abs(dx)>Math.abs(dy) ? (dx>0?'ArrowRight':'ArrowLeft')
+                                          : (dy>0?'ArrowDown':'ArrowUp');
+    pressStart(key); setTimeout(()=>pressEnd(key), 50);
+  }, {passive:true});
+})();
+    </script>
+
 </body>
 </html>

--- a/game/snake/index.html
+++ b/game/snake/index.html
@@ -2,7 +2,6 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>지렁이 게임</title>
     <style>
         body {
@@ -84,6 +83,43 @@
                 border-width: 4px;
             }
         }
+</style>
+
+    <!-- Mobile-friendly viewport -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+    <style>
+      :root { --osc-gap: 10px; --osc-btn: 56px; --osc-z: 9999; }
+      .credit-banner{
+        position:fixed; top:env(safe-area-inset-top,0); left:env(safe-area-inset-left,0);
+        margin:8px; padding:6px 10px; font:600 14px/1.2 system-ui, sans-serif;
+        background:rgba(0,0,0,.55); color:#fff; border-radius:8px; z-index:var(--osc-z);
+        -webkit-backdrop-filter:saturate(150%) blur(6px); backdrop-filter:saturate(150%) blur(6px);
+        user-select:none; pointer-events:none;
+      }
+      .osc-wrap{
+        position:fixed; inset:auto 0 env(safe-area-inset-bottom,0) 0;
+        display:flex; justify-content:center; gap:24px; padding:var(--osc-gap);
+        z-index:var(--osc-z); touch-action:manipulation;
+      }
+      .osc { display:flex; align-items:center; gap:16px; }
+      .osc .dpad{ display:grid; grid-template-areas:
+          ".    up    ."
+          "left  mid  right"
+          ".   down   .";
+        gap:8px; align-items:center; justify-items:center;
+      }
+      .osc .actions{ display:flex; gap:10px; }
+      .osc button{
+        min-width:var(--osc-btn); min-height:var(--osc-btn);
+        border:0; border-radius:12px; font:700 16px system-ui, sans-serif;
+        background:rgba(255,255,255,.9); color:#111; box-shadow:0 2px 10px rgba(0,0,0,.2);
+      }
+      .osc .pause{ min-width:72px; }
+      /* 게임 화면 가려짐 방지 */
+      body{ padding-bottom: calc(env(safe-area-inset-bottom,0) + 110px); }
+      @media (pointer:fine){ /* 데스크톱이면 패드 숨김 */
+        .osc-wrap{ display:none; } body{ padding-bottom:0; }
+      }
     </style>
 </head>
 <body>
@@ -207,5 +243,66 @@
         init();
     </script>
     <script src="../global-enhancements.js" defer></script>
+
+    <!-- Creator credit -->
+    <div class="credit-banner" aria-hidden="true">Creator: 박은성</div>
+
+    <!-- On-screen Controls -->
+    <div class="osc-wrap" id="osc-wrap" role="group" aria-label="On-screen game controls">
+      <div class="osc">
+        <div class="dpad">
+          <button data-key="ArrowUp"    style="grid-area:up">▲</button>
+          <button data-key="ArrowLeft"  style="grid-area:left">◀</button>
+          <button data-key="ArrowRight" style="grid-area:right">▶</button>
+          <button data-key="ArrowDown"  style="grid-area:down">▼</button>
+        </div>
+        <div class="actions">
+          <button data-key="Space">A</button>
+          <button data-key="Enter">B</button>
+          <button class="pause" data-key="Escape">⏯︎</button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+(function(){
+  // 일부 게임이 window/document/canvas 등 서로 다른 타깃을 구독하므로, 광범위 전파
+  function send(key, type){
+    const ev = new KeyboardEvent(type, { key, code:key, bubbles:true, cancelable:true });
+    const t = document.activeElement && document.activeElement !== document.body
+      ? document.activeElement : document;
+    t.dispatchEvent(ev); window.dispatchEvent(ev);
+  }
+  function pressStart(key){ send(key,'keydown'); }
+  function pressEnd(key){ send(key,'keyup'); }
+
+  // 버튼 터치/클릭 → 키 이벤트 변환
+  document.getElementById('osc-wrap')?.addEventListener('pointerdown', e=>{
+    const btn = e.target.closest('button[data-key]'); if(!btn) return;
+    e.preventDefault(); btn.setPointerCapture?.(e.pointerId);
+    pressStart(btn.dataset.key);
+    btn.addEventListener('pointerup',  ()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('pointercancel',()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('lostpointercapture',()=>pressEnd(btn.dataset.key), { once:true });
+  });
+
+  // 스와이프 제스처 → 방향키
+  let sx=0, sy=0, tracking=false;
+  const TH=24; // 스와이프 임계값(px)
+  document.addEventListener('touchstart', (e)=>{
+    // 오버레이 위 스와이프는 무시
+    if(e.target.closest('#osc-wrap')) return;
+    tracking=true; const t=e.changedTouches[0]; sx=t.clientX; sy=t.clientY;
+  }, {passive:true});
+  document.addEventListener('touchend', (e)=>{
+    if(!tracking) return; tracking=false;
+    const t=e.changedTouches[0]; const dx=t.clientX-sx, dy=t.clientY-sy;
+    if(Math.abs(dx)<TH && Math.abs(dy)<TH) return;
+    const key = Math.abs(dx)>Math.abs(dy) ? (dx>0?'ArrowRight':'ArrowLeft')
+                                          : (dy>0?'ArrowDown':'ArrowUp');
+    pressStart(key); setTimeout(()=>pressEnd(key), 50);
+  }, {passive:true});
+})();
+</script>
 </body>
 </html>

--- a/game/snake/index.html
+++ b/game/snake/index.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>지렁이 게임</title>
+    <style>
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: clamp(16px, 5vw, 48px);
+            background: linear-gradient(135deg, #09203f 0%, #537895 100%);
+            color: #ecf0f1;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+        }
+        .panel {
+            width: min(100%, 460px);
+            text-align: center;
+            background: rgba(9, 32, 63, 0.85);
+            padding: clamp(22px, 5vw, 36px);
+            border-radius: 22px;
+            box-shadow: 0 18px 35px rgba(0, 0, 0, 0.35);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            display: grid;
+            gap: 16px;
+            justify-items: center;
+        }
+        canvas {
+            background: #04101f;
+            border-radius: 16px;
+            border: 6px solid rgba(255, 255, 255, 0.08);
+            box-shadow: inset 0 0 20px rgba(0,0,0,0.5);
+            width: min(100%, 420px);
+            height: auto;
+        }
+        h1 {
+            margin: 0;
+            letter-spacing: 2px;
+            font-size: clamp(24px, 5vw, 32px);
+        }
+        .signature {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 6px 14px;
+            border-radius: 999px;
+            background: rgba(26, 188, 156, 0.18);
+            color: #1abc9c;
+            font-weight: 700;
+            font-size: 13px;
+        }
+        .score {
+            margin: 0;
+            font-size: clamp(18px, 4vw, 22px);
+            font-weight: 600;
+        }
+        .hint {
+            margin: 0;
+            color: rgba(255, 255, 255, 0.72);
+            font-size: clamp(13px, 3.2vw, 15px);
+            line-height: 1.6;
+        }
+        button {
+            background: #1abc9c;
+            color: #04101f;
+            border: none;
+            border-radius: 999px;
+            padding: 12px clamp(22px, 6vw, 32px);
+            font-weight: 700;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+            font-size: 15px;
+        }
+        button:hover, button:focus-visible {
+            transform: translateY(-2px);
+            box-shadow: 0 10px 20px rgba(26, 188, 156, 0.35);
+            outline: none;
+        }
+        @media (max-width: 480px) {
+            canvas {
+                border-width: 4px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="panel">
+        <div class="signature">박은성이 만든 게임</div>
+        <h1>지렁이 게임</h1>
+        <div class="score">점수: <span id="score">0</span></div>
+        <canvas id="board" width="400" height="400"></canvas>
+        <button id="restart">다시 시작</button>
+        <p class="hint">방향키로 조작하세요. 벽이나 몸에 부딪히면 게임이 종료됩니다.</p>
+    </div>
+
+    <script>
+        const canvas = document.getElementById('board');
+        const ctx = canvas.getContext('2d');
+        const gridSize = 20;
+        const tileCount = canvas.width / gridSize;
+        const scoreEl = document.getElementById('score');
+        const restartBtn = document.getElementById('restart');
+
+        let snake, direction, food, score, speed, frameId;
+
+        function init() {
+            snake = [
+                { x: 9, y: 10 },
+                { x: 8, y: 10 },
+                { x: 7, y: 10 }
+            ];
+            direction = { x: 1, y: 0 };
+            score = 0;
+            speed = 150;
+            placeFood();
+            updateScore();
+            if (frameId) cancelAnimationFrame(frameId);
+            loop();
+        }
+
+        function placeFood() {
+            do {
+                food = {
+                    x: Math.floor(Math.random() * tileCount),
+                    y: Math.floor(Math.random() * tileCount)
+                };
+            } while (snake.some(part => part.x === food.x && part.y === food.y));
+        }
+
+        function updateScore() {
+            scoreEl.textContent = score;
+        }
+
+        let lastRender = 0;
+        function loop(timestamp = 0) {
+            frameId = requestAnimationFrame(loop);
+            if (timestamp - lastRender < speed) return;
+            lastRender = timestamp;
+
+            const head = { x: snake[0].x + direction.x, y: snake[0].y + direction.y };
+            if (head.x < 0) head.x = tileCount - 1;
+            if (head.y < 0) head.y = tileCount - 1;
+            if (head.x >= tileCount) head.x = 0;
+            if (head.y >= tileCount) head.y = 0;
+
+            if (snake.some(part => part.x === head.x && part.y === head.y)) {
+                gameOver();
+                return;
+            }
+
+            snake.unshift(head);
+            if (head.x === food.x && head.y === food.y) {
+                score += 10;
+                speed = Math.max(60, speed - 5);
+                placeFood();
+                updateScore();
+            } else {
+                snake.pop();
+            }
+
+            draw();
+        }
+
+        function draw() {
+            ctx.fillStyle = '#020811';
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+            ctx.fillStyle = '#ff5252';
+            ctx.shadowBlur = 20;
+            ctx.shadowColor = '#ff5252aa';
+            ctx.fillRect(food.x * gridSize, food.y * gridSize, gridSize, gridSize);
+            ctx.shadowBlur = 0;
+
+            snake.forEach((segment, index) => {
+                const t = index / snake.length;
+                const hue = 150 + t * 120;
+                ctx.fillStyle = `hsl(${hue}, 70%, ${60 - t * 20}%)`;
+                ctx.fillRect(segment.x * gridSize, segment.y * gridSize, gridSize - 2, gridSize - 2);
+            });
+        }
+
+        function gameOver() {
+            cancelAnimationFrame(frameId);
+            ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+            ctx.fillStyle = '#ecf0f1';
+            ctx.font = '28px Pretendard, sans-serif';
+            ctx.textAlign = 'center';
+            ctx.fillText('게임 오버!', canvas.width / 2, canvas.height / 2 - 10);
+            ctx.font = '18px Pretendard, sans-serif';
+            ctx.fillText('다시 시작 버튼을 눌러 재도전하세요.', canvas.width / 2, canvas.height / 2 + 24);
+        }
+
+        window.addEventListener('keydown', (e) => {
+            const { key } = e;
+            if (key === 'ArrowUp' && direction.y === 0) direction = { x: 0, y: -1 };
+            else if (key === 'ArrowDown' && direction.y === 0) direction = { x: 0, y: 1 };
+            else if (key === 'ArrowLeft' && direction.x === 0) direction = { x: -1, y: 0 };
+            else if (key === 'ArrowRight' && direction.x === 0) direction = { x: 1, y: 0 };
+        });
+
+        restartBtn.addEventListener('click', init);
+
+        init();
+    </script>
+    <script src="../global-enhancements.js" defer></script>
+</body>
+</html>

--- a/game/sokoban/index.html
+++ b/game/sokoban/index.html
@@ -2,7 +2,6 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>창고지기 소코반 챌린지</title>
     <style>
         :root {
@@ -157,6 +156,44 @@
             color: #dffef5;
         }
     </style>
+
+    <!-- Mobile-friendly viewport -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+    <style>
+      :root { --osc-gap: 10px; --osc-btn: 56px; --osc-z: 9999; }
+      .credit-banner{
+        position:fixed; top:env(safe-area-inset-top,0); left:env(safe-area-inset-left,0);
+        margin:8px; padding:6px 10px; font:600 14px/1.2 system-ui, sans-serif;
+        background:rgba(0,0,0,.55); color:#fff; border-radius:8px; z-index:var(--osc-z);
+        -webkit-backdrop-filter:saturate(150%) blur(6px); backdrop-filter:saturate(150%) blur(6px);
+        user-select:none; pointer-events:none;
+      }
+      .osc-wrap{
+        position:fixed; inset:auto 0 env(safe-area-inset-bottom,0) 0;
+        display:flex; justify-content:center; gap:24px; padding:var(--osc-gap);
+        z-index:var(--osc-z); touch-action:manipulation;
+      }
+      .osc { display:flex; align-items:center; gap:16px; }
+      .osc .dpad{ display:grid; grid-template-areas:
+          ".    up    ."
+          "left  mid  right"
+          ".   down   .";
+        gap:8px; align-items:center; justify-items:center;
+      }
+      .osc .actions{ display:flex; gap:10px; }
+      .osc button{
+        min-width:var(--osc-btn); min-height:var(--osc-btn);
+        border:0; border-radius:12px; font:700 16px system-ui, sans-serif;
+        background:rgba(255,255,255,.9); color:#111; box-shadow:0 2px 10px rgba(0,0,0,.2);
+      }
+      .osc .pause{ min-width:72px; }
+      /* 게임 화면 가려짐 방지 */
+      body{ padding-bottom: calc(env(safe-area-inset-bottom,0) + 110px); }
+      @media (pointer:fine){ /* 데스크톱이면 패드 숨김 */
+        .osc-wrap{ display:none; } body{ padding-bottom:0; }
+      }
+    </style>
+
 </head>
 <body>
     <main>
@@ -402,5 +439,67 @@
         loadLevel(0);
     </script>
     <script src="../global-enhancements.js" defer></script>
+
+    <!-- Creator credit -->
+    <div class="credit-banner" aria-hidden="true">Creator: 박은성</div>
+
+    <!-- On-screen Controls -->
+    <div class="osc-wrap" id="osc-wrap" role="group" aria-label="On-screen game controls">
+      <div class="osc">
+        <div class="dpad">
+          <button data-key="ArrowUp"    style="grid-area:up">▲</button>
+          <button data-key="ArrowLeft"  style="grid-area:left">◀</button>
+          <button data-key="ArrowRight" style="grid-area:right">▶</button>
+          <button data-key="ArrowDown"  style="grid-area:down">▼</button>
+        </div>
+        <div class="actions">
+          <button data-key="Space">A</button>
+          <button data-key="Enter">B</button>
+          <button class="pause" data-key="Escape">⏯︎</button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+(function(){
+  // 일부 게임이 window/document/canvas 등 서로 다른 타깃을 구독하므로, 광범위 전파
+  function send(key, type){
+    const ev = new KeyboardEvent(type, { key, code:key, bubbles:true, cancelable:true });
+    const t = document.activeElement && document.activeElement !== document.body
+      ? document.activeElement : document;
+    t.dispatchEvent(ev); window.dispatchEvent(ev);
+  }
+  function pressStart(key){ send(key,'keydown'); }
+  function pressEnd(key){ send(key,'keyup'); }
+
+  // 버튼 터치/클릭 → 키 이벤트 변환
+  document.getElementById('osc-wrap')?.addEventListener('pointerdown', e=>{
+    const btn = e.target.closest('button[data-key]'); if(!btn) return;
+    e.preventDefault(); btn.setPointerCapture?.(e.pointerId);
+    pressStart(btn.dataset.key);
+    btn.addEventListener('pointerup',  ()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('pointercancel',()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('lostpointercapture',()=>pressEnd(btn.dataset.key), { once:true });
+  });
+
+  // 스와이프 제스처 → 방향키
+  let sx=0, sy=0, tracking=false;
+  const TH=24; // 스와이프 임계값(px)
+  document.addEventListener('touchstart', (e)=>{
+    // 오버레이 위 스와이프는 무시
+    if(e.target.closest('#osc-wrap')) return;
+    tracking=true; const t=e.changedTouches[0]; sx=t.clientX; sy=t.clientY;
+  }, {passive:true});
+  document.addEventListener('touchend', (e)=>{
+    if(!tracking) return; tracking=false;
+    const t=e.changedTouches[0]; const dx=t.clientX-sx, dy=t.clientY-sy;
+    if(Math.abs(dx)<TH && Math.abs(dy)<TH) return;
+    const key = Math.abs(dx)>Math.abs(dy) ? (dx>0?'ArrowRight':'ArrowLeft')
+                                          : (dy>0?'ArrowDown':'ArrowUp');
+    pressStart(key); setTimeout(()=>pressEnd(key), 50);
+  }, {passive:true});
+})();
+    </script>
+
 </body>
 </html>

--- a/game/sokoban/index.html
+++ b/game/sokoban/index.html
@@ -1,0 +1,406 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>창고지기 소코반 챌린지</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            background: radial-gradient(circle at 20% 20%, #382465, #14102b 58%, #06070f 100%);
+            color: #f5f2ff;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: clamp(20px, 4vw, 48px);
+        }
+        main {
+            width: min(100%, 960px);
+            display: grid;
+            gap: clamp(16px, 3vw, 32px);
+            grid-template-columns: minmax(0, 420px) minmax(0, 1fr);
+        }
+        @media (max-width: 960px) {
+            main {
+                grid-template-columns: 1fr;
+            }
+        }
+        .board {
+            background: rgba(18, 12, 38, 0.72);
+            border-radius: 18px;
+            padding: clamp(18px, 3vw, 26px);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            backdrop-filter: blur(12px);
+        }
+        table {
+            border-collapse: collapse;
+            margin: 0 auto;
+        }
+        td {
+            width: 48px;
+            height: 48px;
+            border-radius: 10px;
+            position: relative;
+            transition: transform 0.14s ease;
+        }
+        td.wall {
+            background: linear-gradient(130deg, #352966, #1a1234);
+            box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.4);
+        }
+        td.floor {
+            background: rgba(255, 255, 255, 0.04);
+        }
+        td.goal {
+            background: radial-gradient(circle, rgba(255, 214, 102, 0.7) 0%, rgba(255, 214, 102, 0.05) 72%);
+            border: 1px solid rgba(255, 214, 102, 0.35);
+        }
+        .crate {
+            width: 36px;
+            height: 36px;
+            border-radius: 9px;
+            background: linear-gradient(135deg, #e7b86f, #ba782f);
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+        }
+        .crate.goal {
+            background: linear-gradient(135deg, #ffe58f, #e7b86f);
+            box-shadow: 0 0 16px rgba(255, 214, 102, 0.6);
+        }
+        .player {
+            width: 32px;
+            height: 32px;
+            border-radius: 50%;
+            background: linear-gradient(140deg, #52f2ff, #705dff);
+            border: 3px solid rgba(255, 255, 255, 0.85);
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+        }
+        section {
+            display: flex;
+            flex-direction: column;
+            gap: 18px;
+            background: rgba(16, 12, 32, 0.76);
+            border-radius: 18px;
+            padding: clamp(20px, 3vw, 32px);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            backdrop-filter: blur(14px);
+        }
+        h1 {
+            margin: 0;
+            font-size: clamp(28px, 4vw, 40px);
+        }
+        .stats {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px 16px;
+            font-weight: 600;
+        }
+        .chip {
+            padding: 6px 14px;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.1);
+        }
+        p, ul {
+            margin: 0;
+            line-height: 1.6;
+            color: rgba(238, 235, 255, 0.85);
+        }
+        ul {
+            padding-left: 18px;
+        }
+        .controls {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+        }
+        button {
+            border: none;
+            border-radius: 12px;
+            padding: 12px 18px;
+            font-weight: 600;
+            cursor: pointer;
+            color: #0d0b1f;
+            background: linear-gradient(135deg, #ffdc8f, #ff9c5c);
+            box-shadow: 0 10px 22px rgba(255, 156, 92, 0.35);
+            transition: transform 0.18s ease, box-shadow 0.18s ease;
+        }
+        button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 18px 34px rgba(255, 156, 92, 0.38);
+        }
+        button.secondary {
+            background: rgba(255, 255, 255, 0.12);
+            color: #f8f7ff;
+            box-shadow: none;
+        }
+        .toast {
+            min-height: 40px;
+            display: flex;
+            align-items: center;
+            padding: 12px 16px;
+            border-radius: 12px;
+            background: rgba(82, 245, 214, 0.12);
+            border: 1px solid rgba(82, 245, 214, 0.28);
+            color: #dffef5;
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <div class="board" aria-live="polite">
+            <table id="board" aria-label="소코반 보드"></table>
+        </div>
+        <section>
+            <h1>창고지기 소코반 챌린지</h1>
+            <div class="stats">
+                <span class="chip">레벨 <strong id="level">1</strong></span>
+                <span class="chip">이동 <strong id="moves">0</strong></span>
+                <span class="chip">밀기 <strong id="pushes">0</strong></span>
+            </div>
+            <p>창고지기가 상자를 목표 지점으로 밀어 넣도록 도와주세요. 상자는 끌 수 없고, 한 번에 하나의 상자만 밀 수 있습니다. 치밀하게 동선을 설계해 최소 이동으로 클리어에 도전하세요!</p>
+            <ul>
+                <li>방향키 또는 WASD로 이동합니다.</li>
+                <li>Z 키는 직전 상태로 되돌립니다. 실수했을 때 유용합니다.</li>
+                <li>다음 레벨로 갈 때는 모든 상자를 목표에 올려야 합니다.</li>
+            </ul>
+            <div class="controls">
+                <button id="reset">현재 레벨 재시작</button>
+                <button id="undo" class="secondary">되돌리기</button>
+                <button id="next">다음 퍼즐</button>
+            </div>
+            <div class="toast" id="message" role="status">레벨 1을 공략 중!</div>
+        </section>
+    </main>
+    <script>
+        const LEVELS = [
+            [
+                '#####',
+                '#. @#',
+                '# $ #',
+                '#   #',
+                '#####'
+            ],
+            [
+                '  #####',
+                '###   #',
+                '#.$ $ #',
+                '#  ## #',
+                '# @   #',
+                '### .##',
+                '  #####'
+            ],
+            [
+                '########',
+                '#   .  #',
+                '# ###$ #',
+                '# #  $ #',
+                '# # ## #',
+                '# @  $ #',
+                '#   .  #',
+                '########'
+            ]
+        ];
+
+        const boardEl = document.getElementById('board');
+        const levelEl = document.getElementById('level');
+        const movesEl = document.getElementById('moves');
+        const pushesEl = document.getElementById('pushes');
+        const resetBtn = document.getElementById('reset');
+        const undoBtn = document.getElementById('undo');
+        const nextBtn = document.getElementById('next');
+        const messageEl = document.getElementById('message');
+
+        let levelIndex = 0;
+        let moves = 0;
+        let pushes = 0;
+        let board = [];
+        let player = { x: 0, y: 0 };
+        const history = [];
+
+        function loadLevel(index) {
+            levelIndex = index % LEVELS.length;
+            const layout = LEVELS[levelIndex].map((row) => row.split(''));
+            board = layout;
+            moves = 0;
+            pushes = 0;
+            history.length = 0;
+            for (let y = 0; y < board.length; y++) {
+                for (let x = 0; x < board[y].length; x++) {
+                    if (board[y][x] === '@' || board[y][x] === '+') {
+                        player = { x, y };
+                    }
+                }
+            }
+            render();
+            updateHUD();
+            messageEl.textContent = `레벨 ${levelIndex + 1}을 공략 중!`;
+        }
+
+        function cloneBoard(src) {
+            return src.map((row) => row.slice());
+        }
+
+        function pushHistory() {
+            history.push({
+                board: cloneBoard(board),
+                player: { ...player },
+                moves,
+                pushes
+            });
+            if (history.length > 200) history.shift();
+        }
+
+        function cell(x, y) {
+            return board[y]?.[x] ?? ' ';
+        }
+
+        function setCell(x, y, value) {
+            if (board[y]) board[y][x] = value;
+        }
+
+        function isGoal(x, y) {
+            return LEVELS[levelIndex][y]?.[x] === '.';
+        }
+
+        function move(dx, dy) {
+            const target = { x: player.x + dx, y: player.y + dy };
+            const targetCell = cell(target.x, target.y);
+            if (targetCell === '#' || targetCell === undefined) return;
+            const isCrate = targetCell === '$' || targetCell === '*';
+            const beyond = { x: target.x + dx, y: target.y + dy };
+            const beyondCell = cell(beyond.x, beyond.y);
+            if (isCrate) {
+                if (beyondCell === '#' || beyondCell === '$' || beyondCell === '*') return;
+                pushHistory();
+                moves += 1;
+                pushes += 1;
+                const crateOnGoal = beyondCell === '.';
+                setCell(beyond.x, beyond.y, crateOnGoal ? '*' : '$');
+                setCell(target.x, target.y, isGoal(target.x, target.y) ? '.' : ' ');
+            } else {
+                pushHistory();
+                moves += 1;
+            }
+            const playerWasOnGoal = isGoal(player.x, player.y);
+            setCell(player.x, player.y, playerWasOnGoal ? '.' : ' ');
+            player = target;
+            const playerNowOnGoal = isGoal(player.x, player.y);
+            setCell(player.x, player.y, playerNowOnGoal ? '+' : '@');
+            render();
+            updateHUD();
+            if (checkSolved()) {
+                messageEl.textContent = `완벽해요! 레벨 ${levelIndex + 1} 완료!`;
+                messageEl.style.background = 'rgba(122, 255, 204, 0.18)';
+                messageEl.style.borderColor = 'rgba(122, 255, 204, 0.4)';
+            }
+        }
+
+        function checkSolved() {
+            for (let y = 0; y < board.length; y++) {
+                for (let x = 0; x < board[y].length; x++) {
+                    if (LEVELS[levelIndex][y]?.[x] === '.' && board[y][x] !== '*' && board[y][x] !== '+') {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        function undo() {
+            const prev = history.pop();
+            if (!prev) return;
+            board = cloneBoard(prev.board);
+            player = { ...prev.player };
+            moves = prev.moves;
+            pushes = prev.pushes;
+            render();
+            updateHUD();
+            messageEl.textContent = '한 수 전으로 되돌렸습니다.';
+        }
+
+        function render() {
+            boardEl.innerHTML = '';
+            board.forEach((row, y) => {
+                const tr = document.createElement('tr');
+                row.forEach((cell, x) => {
+                    const td = document.createElement('td');
+                    const type = cell === '#' ? 'wall' : isGoal(x, y) ? 'goal' : 'floor';
+                    td.className = type;
+                    if (cell === '$' || cell === '*') {
+                        const crate = document.createElement('div');
+                        crate.className = 'crate' + (cell === '*' ? ' goal' : '');
+                        td.appendChild(crate);
+                    }
+                    if (cell === '@' || cell === '+') {
+                        const playerEl = document.createElement('div');
+                        playerEl.className = 'player';
+                        td.appendChild(playerEl);
+                    }
+                    tr.appendChild(td);
+                });
+                boardEl.appendChild(tr);
+            });
+        }
+
+        function updateHUD() {
+            levelEl.textContent = levelIndex + 1;
+            movesEl.textContent = moves;
+            pushesEl.textContent = pushes;
+        }
+
+        window.addEventListener('keydown', (event) => {
+            if (checkSolved()) return;
+            switch (event.key) {
+                case 'ArrowUp':
+                case 'w':
+                case 'W':
+                    move(0, -1);
+                    break;
+                case 'ArrowDown':
+                case 's':
+                case 'S':
+                    move(0, 1);
+                    break;
+                case 'ArrowLeft':
+                case 'a':
+                case 'A':
+                    move(-1, 0);
+                    break;
+                case 'ArrowRight':
+                case 'd':
+                case 'D':
+                    move(1, 0);
+                    break;
+                case 'z':
+                case 'Z':
+                    undo();
+                    break;
+            }
+        });
+
+        resetBtn.addEventListener('click', () => loadLevel(levelIndex));
+        undoBtn.addEventListener('click', undo);
+        nextBtn.addEventListener('click', () => {
+            loadLevel((levelIndex + 1) % LEVELS.length);
+            messageEl.style.background = 'rgba(82, 245, 214, 0.12)';
+            messageEl.style.borderColor = 'rgba(82, 245, 214, 0.28)';
+        });
+
+        loadLevel(0);
+    </script>
+    <script src="../global-enhancements.js" defer></script>
+</body>
+</html>

--- a/game/space-shooter/index.html
+++ b/game/space-shooter/index.html
@@ -1,0 +1,422 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>우주 방위전</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: grid;
+            place-items: center;
+            background: radial-gradient(circle at 50% 20%, #040b18, #020409 70%);
+            color: #f5f6fa;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+        }
+        .panel {
+            background: rgba(6, 14, 28, 0.9);
+            padding: 32px;
+            border-radius: 28px;
+            box-shadow: 0 30px 70px rgba(0, 0, 0, 0.55);
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+            align-items: center;
+        }
+        h1 {
+            margin: 0;
+            font-size: 28px;
+            letter-spacing: 1px;
+        }
+        .stats {
+            display: flex;
+            gap: 20px;
+            font-weight: 600;
+        }
+        canvas {
+            background: radial-gradient(circle at 50% 50%, rgba(12, 24, 48, 0.85), rgba(2, 6, 16, 0.92));
+            border-radius: 20px;
+            border: 6px solid rgba(255, 255, 255, 0.08);
+        }
+        button {
+            background: linear-gradient(135deg, #38ef7d, #11998e);
+            color: #02120f;
+            border: none;
+            border-radius: 999px;
+            padding: 10px 24px;
+            font-weight: 700;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 18px 28px rgba(56, 239, 125, 0.28);
+        }
+        p {
+            margin: 0;
+            font-size: 14px;
+            color: rgba(255, 255, 255, 0.72);
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+    <div class="panel">
+        <h1>우주 방위전</h1>
+        <div class="stats">
+            <div>점수: <span id="score">0</span></div>
+            <div>쉴드: <span id="shield">100</span></div>
+            <div>웨이브: <span id="wave">1</span></div>
+        </div>
+        <canvas id="game" width="540" height="720"></canvas>
+        <button id="restart">다시 시작</button>
+        <p>WASD/방향키로 이동하고 스페이스 또는 클릭으로 레이저를 발사하세요. 파워업을 모아 우주를 지키세요!</p>
+    </div>
+
+    <script>
+        const canvas = document.getElementById('game');
+        const ctx = canvas.getContext('2d');
+        const scoreEl = document.getElementById('score');
+        const shieldEl = document.getElementById('shield');
+        const waveEl = document.getElementById('wave');
+        const restartBtn = document.getElementById('restart');
+
+        const WIDTH = canvas.width;
+        const HEIGHT = canvas.height;
+
+        const keys = new Set();
+        let pointerDown = false;
+
+        const particles = [];
+        const bullets = [];
+        const enemies = [];
+        const powerUps = [];
+
+        let player;
+        let score;
+        let wave;
+        let spawnTimer;
+        let running = true;
+        let lastTime = 0;
+
+        const POWER_TYPES = ['heal', 'rapid', 'spread'];
+
+        function createPlayer() {
+            return {
+                x: WIDTH / 2,
+                y: HEIGHT - 80,
+                width: 32,
+                height: 42,
+                speed: 0.4,
+                shield: 100,
+                rapidUntil: 0,
+                spreadUntil: 0
+            };
+        }
+
+        function resetGame() {
+            player = createPlayer();
+            score = 0;
+            wave = 1;
+            spawnTimer = 0;
+            bullets.length = 0;
+            enemies.length = 0;
+            particles.length = 0;
+            powerUps.length = 0;
+            running = true;
+            lastTime = performance.now();
+            shoot.lastShot = 0;
+            pointerDown = false;
+            keys.clear();
+            updateHUD();
+        }
+
+        function updateHUD() {
+            scoreEl.textContent = Math.floor(score);
+            shieldEl.textContent = Math.max(0, Math.floor(player.shield));
+            waveEl.textContent = Math.max(1, Math.floor(wave));
+        }
+
+        function spawnEnemy() {
+            const size = 28 + Math.random() * 16;
+            const x = size + Math.random() * (WIDTH - size * 2);
+            const speed = 0.12 + Math.random() * 0.12 + wave * 0.01;
+            enemies.push({
+                x,
+                y: -size,
+                size,
+                speed,
+                angle: Math.random() * Math.PI * 2,
+                hp: 2 + Math.floor(wave / 2),
+                fireCooldown: 1500 + Math.random() * 1000
+            });
+        }
+
+        function spawnPowerUp(x, y) {
+            const type = POWER_TYPES[Math.floor(Math.random() * POWER_TYPES.length)];
+            powerUps.push({ x, y, type, speed: 0.12 });
+        }
+
+        function shoot() {
+            const now = performance.now();
+            if (!running) return;
+            const rapid = now < player.rapidUntil ? 100 : 280;
+            if (shoot.lastShot && now - shoot.lastShot < rapid) return;
+            shoot.lastShot = now;
+
+            const spreadActive = now < player.spreadUntil;
+            const projectiles = spreadActive ? [-0.18, 0, 0.18] : [0];
+            for (const angle of projectiles) {
+                bullets.push({
+                    x: player.x,
+                    y: player.y - player.height / 2,
+                    vx: Math.sin(angle) * 0.3,
+                    vy: -0.6,
+                    life: 0
+                });
+            }
+            addParticles(player.x, player.y, '#38ef7d');
+        }
+
+        function addParticles(x, y, color) {
+            for (let i = 0; i < 12; i++) {
+                particles.push({
+                    x,
+                    y,
+                    vx: (Math.random() - 0.5) * 0.6,
+                    vy: (Math.random() - 0.5) * 0.6,
+                    life: 600,
+                    color
+                });
+            }
+        }
+
+        function updatePlayer(delta) {
+            const velocity = player.speed * delta;
+            if (keys.has('ArrowLeft') || keys.has('a')) player.x -= velocity;
+            if (keys.has('ArrowRight') || keys.has('d')) player.x += velocity;
+            if (keys.has('ArrowUp') || keys.has('w')) player.y -= velocity;
+            if (keys.has('ArrowDown') || keys.has('s')) player.y += velocity;
+            player.x = Math.max(30, Math.min(WIDTH - 30, player.x));
+            player.y = Math.max(60, Math.min(HEIGHT - 40, player.y));
+            if (pointerDown || keys.has(' ') || keys.has('Space')) shoot();
+        }
+
+        function updateBullets(delta) {
+            for (let i = bullets.length - 1; i >= 0; i--) {
+                const b = bullets[i];
+                b.x += b.vx * delta;
+                b.y += b.vy * delta;
+                b.life += delta;
+                if (b.y < -20 || b.life > 2200) {
+                    bullets.splice(i, 1);
+                }
+            }
+        }
+
+        function updateEnemies(delta) {
+            spawnTimer += delta;
+            if (spawnTimer > Math.max(500 - wave * 10, 180)) {
+                spawnEnemy();
+                spawnTimer = 0;
+            }
+            for (let i = enemies.length - 1; i >= 0; i--) {
+                const enemy = enemies[i];
+                enemy.y += enemy.speed * delta;
+                enemy.x += Math.sin(enemy.angle + performance.now() * 0.001) * 0.12 * delta;
+                if (enemy.y > HEIGHT + enemy.size) {
+                    enemies.splice(i, 1);
+                    continue;
+                }
+                for (let j = bullets.length - 1; j >= 0; j--) {
+                    const b = bullets[j];
+                    if (Math.hypot(b.x - enemy.x, b.y - enemy.y) < enemy.size) {
+                        bullets.splice(j, 1);
+                        enemy.hp--;
+                        score += 15;
+                        updateHUD();
+                        addParticles(enemy.x, enemy.y, '#4facfe');
+                        if (enemy.hp <= 0) {
+                            if (Math.random() < 0.2) spawnPowerUp(enemy.x, enemy.y);
+                            enemies.splice(i, 1);
+                            wave += 0.05;
+                            updateHUD();
+                            break;
+                        }
+                        break;
+                    }
+                }
+                if (!enemies[i]) continue;
+                if (enemies[i]) {
+                    const dist = Math.hypot(player.x - enemy.x, player.y - enemy.y);
+                    if (dist < enemy.size + 24) {
+                        player.shield -= 25;
+                        addParticles(player.x, player.y, '#ff6b6b');
+                        enemies.splice(i, 1);
+                        if (player.shield <= 0) {
+                            endGame();
+                            return;
+                        }
+                        updateHUD();
+                    }
+                }
+            }
+        }
+
+        function updatePowerUps(delta) {
+            for (let i = powerUps.length - 1; i >= 0; i--) {
+                const p = powerUps[i];
+                p.y += p.speed * delta;
+                p.x += Math.sin(performance.now() * 0.002 + i) * 0.06 * delta;
+                if (p.y > HEIGHT + 20) {
+                    powerUps.splice(i, 1);
+                    continue;
+                }
+                if (Math.hypot(player.x - p.x, player.y - p.y) < 28) {
+                    applyPowerUp(p.type);
+                    addParticles(p.x, p.y, '#ffe66d');
+                    powerUps.splice(i, 1);
+                }
+            }
+        }
+
+        function applyPowerUp(type) {
+            if (type === 'heal') {
+                player.shield = Math.min(120, player.shield + 30);
+            } else if (type === 'rapid') {
+                player.rapidUntil = performance.now() + 6000;
+            } else if (type === 'spread') {
+                player.spreadUntil = performance.now() + 6000;
+            }
+            updateHUD();
+        }
+
+        function updateParticles(delta) {
+            for (let i = particles.length - 1; i >= 0; i--) {
+                const p = particles[i];
+                p.x += p.vx * delta;
+                p.y += p.vy * delta;
+                p.life -= delta;
+                if (p.life <= 0) particles.splice(i, 1);
+            }
+        }
+
+        function draw() {
+            ctx.clearRect(0, 0, WIDTH, HEIGHT);
+            ctx.fillStyle = '#0b1731';
+            ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+            ctx.strokeStyle = 'rgba(255,255,255,0.08)';
+            for (let y = 40; y < HEIGHT; y += 60) {
+                ctx.beginPath();
+                ctx.moveTo(0, y + (performance.now() / 40) % 60);
+                ctx.lineTo(WIDTH, y + (performance.now() / 40) % 60);
+                ctx.stroke();
+            }
+
+            particles.forEach(p => {
+                ctx.fillStyle = p.color;
+                ctx.globalAlpha = Math.max(0, p.life / 600);
+                ctx.fillRect(p.x, p.y, 3, 3);
+                ctx.globalAlpha = 1;
+            });
+
+            ctx.fillStyle = '#38ef7d';
+            ctx.beginPath();
+            ctx.moveTo(player.x, player.y - player.height / 2);
+            ctx.lineTo(player.x - player.width / 2, player.y + player.height / 2);
+            ctx.lineTo(player.x + player.width / 2, player.y + player.height / 2);
+            ctx.closePath();
+            ctx.fill();
+
+            ctx.fillStyle = '#74b9ff';
+            bullets.forEach(b => {
+                ctx.fillRect(b.x - 3, b.y - 12, 6, 18);
+            });
+
+            enemies.forEach(enemy => {
+                ctx.fillStyle = '#4facfe';
+                ctx.beginPath();
+                ctx.arc(enemy.x, enemy.y, enemy.size * 0.6, 0, Math.PI * 2);
+                ctx.fill();
+                ctx.strokeStyle = '#c9d6ff';
+                ctx.lineWidth = 2;
+                ctx.stroke();
+            });
+
+            powerUps.forEach(p => {
+                ctx.fillStyle = '#ffe66d';
+                ctx.beginPath();
+                ctx.arc(p.x, p.y, 14, 0, Math.PI * 2);
+                ctx.fill();
+                ctx.fillStyle = '#222';
+                ctx.font = 'bold 14px Pretendard';
+                ctx.textAlign = 'center';
+                ctx.fillText(p.type[0].toUpperCase(), p.x, p.y + 5);
+            });
+
+            ctx.fillStyle = 'rgba(255, 255, 255, 0.2)';
+            ctx.fillRect(40, HEIGHT - 26, (player.shield / 120) * (WIDTH - 80), 12);
+        }
+
+        function update(time = 0) {
+            if (!running) return;
+            const delta = time - lastTime;
+            lastTime = time;
+            updatePlayer(delta);
+            updateBullets(delta);
+            updateEnemies(delta);
+            updatePowerUps(delta);
+            updateParticles(delta);
+            draw();
+            requestAnimationFrame(update);
+        }
+
+        function endGame() {
+            if (!running) return;
+            running = false;
+            updateHUD();
+            ctx.fillStyle = 'rgba(0, 0, 0, 0.65)';
+            ctx.fillRect(0, 0, WIDTH, HEIGHT);
+            ctx.fillStyle = '#f5f6fa';
+            ctx.font = '30px Pretendard, sans-serif';
+            ctx.textAlign = 'center';
+            ctx.fillText('게임 오버', WIDTH / 2, HEIGHT / 2 - 20);
+            ctx.font = '20px Pretendard, sans-serif';
+            ctx.fillText(`최종 점수: ${scoreEl.textContent}`, WIDTH / 2, HEIGHT / 2 + 18);
+        }
+
+        restartBtn.addEventListener('click', () => {
+            resetGame();
+            requestAnimationFrame(update);
+        });
+
+        document.addEventListener('keydown', e => {
+            keys.add(e.key);
+            if (e.key === ' ') e.preventDefault();
+        });
+        document.addEventListener('keyup', e => {
+            keys.delete(e.key);
+        });
+
+        canvas.addEventListener('mousedown', () => {
+            pointerDown = true;
+        });
+        canvas.addEventListener('mouseup', () => {
+            pointerDown = false;
+        });
+        canvas.addEventListener('mouseleave', () => {
+            pointerDown = false;
+        });
+
+        resetGame();
+        draw();
+        requestAnimationFrame(update);
+    </script>
+    <script src="../global-enhancements.js" defer></script>
+</body>
+</html>

--- a/game/space-shooter/index.html
+++ b/game/space-shooter/index.html
@@ -2,7 +2,6 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>우주 방위전</title>
     <style>
         :root {
@@ -63,6 +62,44 @@
             text-align: center;
         }
     </style>
+
+    <!-- Mobile-friendly viewport -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+    <style>
+      :root { --osc-gap: 10px; --osc-btn: 56px; --osc-z: 9999; }
+      .credit-banner{
+        position:fixed; top:env(safe-area-inset-top,0); left:env(safe-area-inset-left,0);
+        margin:8px; padding:6px 10px; font:600 14px/1.2 system-ui, sans-serif;
+        background:rgba(0,0,0,.55); color:#fff; border-radius:8px; z-index:var(--osc-z);
+        -webkit-backdrop-filter:saturate(150%) blur(6px); backdrop-filter:saturate(150%) blur(6px);
+        user-select:none; pointer-events:none;
+      }
+      .osc-wrap{
+        position:fixed; inset:auto 0 env(safe-area-inset-bottom,0) 0;
+        display:flex; justify-content:center; gap:24px; padding:var(--osc-gap);
+        z-index:var(--osc-z); touch-action:manipulation;
+      }
+      .osc { display:flex; align-items:center; gap:16px; }
+      .osc .dpad{ display:grid; grid-template-areas:
+          ".    up    ."
+          "left  mid  right"
+          ".   down   .";
+        gap:8px; align-items:center; justify-items:center;
+      }
+      .osc .actions{ display:flex; gap:10px; }
+      .osc button{
+        min-width:var(--osc-btn); min-height:var(--osc-btn);
+        border:0; border-radius:12px; font:700 16px system-ui, sans-serif;
+        background:rgba(255,255,255,.9); color:#111; box-shadow:0 2px 10px rgba(0,0,0,.2);
+      }
+      .osc .pause{ min-width:72px; }
+      /* 게임 화면 가려짐 방지 */
+      body{ padding-bottom: calc(env(safe-area-inset-bottom,0) + 110px); }
+      @media (pointer:fine){ /* 데스크톱이면 패드 숨김 */
+        .osc-wrap{ display:none; } body{ padding-bottom:0; }
+      }
+    </style>
+
 </head>
 <body>
     <div class="panel">
@@ -418,5 +455,67 @@
         requestAnimationFrame(update);
     </script>
     <script src="../global-enhancements.js" defer></script>
+
+    <!-- Creator credit -->
+    <div class="credit-banner" aria-hidden="true">Creator: 박은성</div>
+
+    <!-- On-screen Controls -->
+    <div class="osc-wrap" id="osc-wrap" role="group" aria-label="On-screen game controls">
+      <div class="osc">
+        <div class="dpad">
+          <button data-key="ArrowUp"    style="grid-area:up">▲</button>
+          <button data-key="ArrowLeft"  style="grid-area:left">◀</button>
+          <button data-key="ArrowRight" style="grid-area:right">▶</button>
+          <button data-key="ArrowDown"  style="grid-area:down">▼</button>
+        </div>
+        <div class="actions">
+          <button data-key="Space">A</button>
+          <button data-key="Enter">B</button>
+          <button class="pause" data-key="Escape">⏯︎</button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+(function(){
+  // 일부 게임이 window/document/canvas 등 서로 다른 타깃을 구독하므로, 광범위 전파
+  function send(key, type){
+    const ev = new KeyboardEvent(type, { key, code:key, bubbles:true, cancelable:true });
+    const t = document.activeElement && document.activeElement !== document.body
+      ? document.activeElement : document;
+    t.dispatchEvent(ev); window.dispatchEvent(ev);
+  }
+  function pressStart(key){ send(key,'keydown'); }
+  function pressEnd(key){ send(key,'keyup'); }
+
+  // 버튼 터치/클릭 → 키 이벤트 변환
+  document.getElementById('osc-wrap')?.addEventListener('pointerdown', e=>{
+    const btn = e.target.closest('button[data-key]'); if(!btn) return;
+    e.preventDefault(); btn.setPointerCapture?.(e.pointerId);
+    pressStart(btn.dataset.key);
+    btn.addEventListener('pointerup',  ()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('pointercancel',()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('lostpointercapture',()=>pressEnd(btn.dataset.key), { once:true });
+  });
+
+  // 스와이프 제스처 → 방향키
+  let sx=0, sy=0, tracking=false;
+  const TH=24; // 스와이프 임계값(px)
+  document.addEventListener('touchstart', (e)=>{
+    // 오버레이 위 스와이프는 무시
+    if(e.target.closest('#osc-wrap')) return;
+    tracking=true; const t=e.changedTouches[0]; sx=t.clientX; sy=t.clientY;
+  }, {passive:true});
+  document.addEventListener('touchend', (e)=>{
+    if(!tracking) return; tracking=false;
+    const t=e.changedTouches[0]; const dx=t.clientX-sx, dy=t.clientY-sy;
+    if(Math.abs(dx)<TH && Math.abs(dy)<TH) return;
+    const key = Math.abs(dx)>Math.abs(dy) ? (dx>0?'ArrowRight':'ArrowLeft')
+                                          : (dy>0?'ArrowDown':'ArrowUp');
+    pressStart(key); setTimeout(()=>pressEnd(key), 50);
+  }, {passive:true});
+})();
+    </script>
+
 </body>
 </html>

--- a/game/tetris/index.html
+++ b/game/tetris/index.html
@@ -1,0 +1,434 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>테트리스</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: clamp(16px, 5vw, 60px);
+            background: radial-gradient(circle at 20% 20%, #41295a, #2f0743 65%, #120024);
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+            color: #f1f2f6;
+        }
+        .wrapper {
+            display: flex;
+            gap: clamp(20px, 5vw, 40px);
+            background: rgba(15, 5, 26, 0.85);
+            padding: clamp(22px, 5vw, 44px);
+            border-radius: clamp(20px, 4vw, 32px);
+            box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5);
+            align-items: flex-start;
+            width: min(100%, 960px);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+        }
+        canvas {
+            background: rgba(5, 1, 12, 0.9);
+            border-radius: 12px;
+            border: 5px solid rgba(255,255,255,0.1);
+            box-shadow: inset 0 0 25px rgba(0,0,0,0.55);
+            width: min(100%, 320px);
+            height: auto;
+        }
+        .panel {
+            width: min(100%, 240px);
+            display: flex;
+            flex-direction: column;
+            gap: 18px;
+        }
+        h1 {
+            margin: 0;
+            font-size: clamp(24px, 4.5vw, 30px);
+            letter-spacing: 2px;
+        }
+        .signature {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 6px 12px;
+            border-radius: 999px;
+            background: rgba(255, 126, 95, 0.2);
+            color: #ffb88c;
+            font-weight: 700;
+            font-size: 13px;
+            width: fit-content;
+        }
+        .stat {
+            background: rgba(255,255,255,0.05);
+            border-radius: 18px;
+            padding: 16px 20px;
+            line-height: 1.6;
+        }
+        .next {
+            height: 160px;
+            display: grid;
+            place-items: center;
+            background: rgba(255,255,255,0.05);
+            border-radius: 18px;
+        }
+        #next-board {
+            width: 140px;
+            height: 140px;
+        }
+        button {
+            background: linear-gradient(135deg, #ff7e5f, #feb47b);
+            color: #120024;
+            border: none;
+            padding: 12px 18px;
+            border-radius: 999px;
+            font-weight: 700;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        button:hover, button:focus-visible {
+            transform: translateY(-2px);
+            box-shadow: 0 15px 20px rgba(255, 126, 95, 0.35);
+            outline: none;
+        }
+        ul {
+            margin: 0;
+            padding-left: 18px;
+            font-size: 14px;
+            color: rgba(255,255,255,0.8);
+        }
+        @media (max-width: 800px) {
+            .wrapper {
+                flex-direction: column;
+                align-items: center;
+            }
+            .panel {
+                width: 100%;
+                flex-direction: column;
+                text-align: center;
+                align-items: center;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="wrapper">
+        <canvas id="board" width="240" height="480"></canvas>
+        <div class="panel">
+            <div class="signature">박은성이 만든 게임</div>
+            <h1>테트리스</h1>
+            <div class="stat">
+                <div>점수: <strong id="score">0</strong></div>
+                <div>라인: <strong id="lines">0</strong></div>
+                <div>레벨: <strong id="level">1</strong></div>
+            </div>
+            <div class="next">
+                <canvas id="next-board" width="120" height="120"></canvas>
+            </div>
+            <button id="restart">새 게임</button>
+            <div class="stat">
+                <h2 style="margin:0 0 8px;font-size:18px;">조작 방법</h2>
+                <ul>
+                    <li>← → : 좌우 이동</li>
+                    <li>↑ : 회전</li>
+                    <li>↓ : 빠른 하강</li>
+                    <li>Space : 즉시 낙하</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        const canvas = document.getElementById('board');
+        const ctx = canvas.getContext('2d');
+        const nextCanvas = document.getElementById('next-board');
+        const nextCtx = nextCanvas.getContext('2d');
+        const ROWS = 20;
+        const COLS = 10;
+        const BLOCK = 24;
+        const COLORS = {
+            I: '#00d8ff',
+            J: '#3b82f6',
+            L: '#f97316',
+            O: '#facc15',
+            S: '#22c55e',
+            T: '#a855f7',
+            Z: '#ef4444'
+        };
+        const SHAPES = {
+            I: [
+                [0, 0, 0, 0],
+                [1, 1, 1, 1],
+                [0, 0, 0, 0],
+                [0, 0, 0, 0]
+            ],
+            J: [
+                [1, 0, 0],
+                [1, 1, 1],
+                [0, 0, 0]
+            ],
+            L: [
+                [0, 0, 1],
+                [1, 1, 1],
+                [0, 0, 0]
+            ],
+            O: [
+                [1, 1],
+                [1, 1]
+            ],
+            S: [
+                [0, 1, 1],
+                [1, 1, 0],
+                [0, 0, 0]
+            ],
+            T: [
+                [0, 1, 0],
+                [1, 1, 1],
+                [0, 0, 0]
+            ],
+            Z: [
+                [1, 1, 0],
+                [0, 1, 1],
+                [0, 0, 0]
+            ]
+        };
+
+        let board, current, next, dropCounter, dropInterval, lastTime;
+        let scoreEl = document.getElementById('score');
+        let linesEl = document.getElementById('lines');
+        let levelEl = document.getElementById('level');
+        let score, lines, level;
+
+        function createMatrix(rows, cols) {
+            return Array.from({ length: rows }, () => Array(cols).fill(0));
+        }
+
+        function randomPiece() {
+            const keys = Object.keys(SHAPES);
+            const type = keys[Math.floor(Math.random() * keys.length)];
+            return {
+                type,
+                matrix: SHAPES[type].map(row => [...row]),
+                pos: { x: Math.floor(COLS / 2) - 1, y: -1 }
+            };
+        }
+
+        function rotate(matrix) {
+            const size = matrix.length;
+            const rotated = matrix.map((row, y) => row.map((_, x) => matrix[size - 1 - x][y]));
+            return rotated;
+        }
+
+        function collide(board, piece) {
+            const { matrix, pos } = piece;
+            for (let y = 0; y < matrix.length; y++) {
+                for (let x = 0; x < matrix[y].length; x++) {
+                    if (!matrix[y][x]) continue;
+                    const boardY = y + pos.y;
+                    const boardX = x + pos.x;
+                    if (boardY < 0) continue;
+                    if (boardX < 0 || boardX >= COLS || boardY >= ROWS || board[boardY][boardX]) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        function merge(board, piece) {
+            piece.matrix.forEach((row, y) => {
+                row.forEach((value, x) => {
+                    if (value) {
+                        const boardY = y + piece.pos.y;
+                        if (boardY >= 0) {
+                            board[boardY][x + piece.pos.x] = piece.type;
+                        }
+                    }
+                });
+            });
+        }
+
+        function clearLines() {
+            let cleared = 0;
+            outer: for (let y = ROWS - 1; y >= 0; y--) {
+                for (let x = 0; x < COLS; x++) {
+                    if (!board[y][x]) {
+                        continue outer;
+                    }
+                }
+                const row = board.splice(y, 1)[0].fill(0);
+                board.unshift(row);
+                y++;
+                cleared++;
+            }
+            if (cleared) {
+                score += [0, 100, 300, 500, 800][cleared];
+                lines += cleared;
+                level = 1 + Math.floor(lines / 10);
+                dropInterval = Math.max(120, 1000 - (level - 1) * 80);
+                updateUI();
+            }
+        }
+
+        function drawBlock(x, y, type, context, size = BLOCK) {
+            context.fillStyle = COLORS[type] || '#64748b';
+            context.fillRect(x * size, y * size, size, size);
+            context.strokeStyle = 'rgba(255,255,255,0.35)';
+            context.lineWidth = 2;
+            context.strokeRect(x * size + 1, y * size + 1, size - 2, size - 2);
+        }
+
+        function drawMatrix(matrix, offset, context, size = BLOCK) {
+            matrix.forEach((row, y) => {
+                row.forEach((value, x) => {
+                    if (value) {
+                        drawBlock(x + offset.x, y + offset.y, current.type, context, size);
+                    }
+                });
+            });
+        }
+
+        function drawBoard() {
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            board.forEach((row, y) => {
+                row.forEach((value, x) => {
+                    if (value) drawBlock(x, y, value, ctx);
+                });
+            });
+            drawMatrix(current.matrix, current.pos, ctx);
+        }
+
+        function drawNext() {
+            nextCtx.clearRect(0, 0, nextCanvas.width, nextCanvas.height);
+            const matrix = next.matrix;
+            const size = nextCanvas.width / 6;
+            const offsetX = Math.floor((6 - matrix[0].length) / 2);
+            const offsetY = Math.floor((6 - matrix.length) / 2);
+            matrix.forEach((row, y) => {
+                row.forEach((value, x) => {
+                    if (value) {
+                        drawBlock(x + offsetX, y + offsetY, next.type, nextCtx, size);
+                    }
+                });
+            });
+        }
+
+        function drop() {
+            current.pos.y++;
+            if (collide(board, current)) {
+                current.pos.y--;
+                merge(board, current);
+                clearLines();
+                spawnPiece();
+                if (collide(board, current)) {
+                    init();
+                }
+            }
+            dropCounter = 0;
+        }
+
+        function hardDrop() {
+            while (!collide(board, current)) {
+                current.pos.y++;
+            }
+            current.pos.y--;
+            merge(board, current);
+            score += 2;
+            clearLines();
+            spawnPiece();
+        }
+
+        function move(dir) {
+            current.pos.x += dir;
+            if (collide(board, current)) {
+                current.pos.x -= dir;
+            }
+        }
+
+        function rotateCurrent() {
+            const original = current.matrix;
+            current.matrix = rotate(current.matrix);
+            const pos = current.pos.x;
+            let offset = 1;
+            while (collide(board, current)) {
+                current.pos.x += offset;
+                offset = -(offset + (offset > 0 ? 1 : -1));
+                if (offset > current.matrix[0].length) {
+                    current.matrix = original;
+                    current.pos.x = pos;
+                    return;
+                }
+            }
+        }
+
+        function update(time = 0) {
+            const delta = time - lastTime;
+            lastTime = time;
+            dropCounter += delta;
+            if (dropCounter > dropInterval) {
+                drop();
+            }
+            drawBoard();
+            drawNext();
+            requestAnimationFrame(update);
+        }
+
+        function spawnPiece() {
+            current = next;
+            current.pos = { x: Math.floor(COLS / 2) - Math.ceil(current.matrix[0].length / 2), y: -1 };
+            next = randomPiece();
+            drawNext();
+        }
+
+        function updateUI() {
+            scoreEl.textContent = score;
+            linesEl.textContent = lines;
+            levelEl.textContent = level;
+        }
+
+        function init() {
+            board = createMatrix(ROWS, COLS);
+            score = 0;
+            lines = 0;
+            level = 1;
+            dropInterval = 1000;
+            dropCounter = 0;
+            lastTime = 0;
+            next = randomPiece();
+            spawnPiece();
+            updateUI();
+        }
+
+        document.addEventListener('keydown', e => {
+            switch (e.code) {
+                case 'ArrowLeft':
+                    move(-1);
+                    break;
+                case 'ArrowRight':
+                    move(1);
+                    break;
+                case 'ArrowDown':
+                    drop();
+                    score++;
+                    updateUI();
+                    break;
+                case 'ArrowUp':
+                    rotateCurrent();
+                    break;
+                case 'Space':
+                    hardDrop();
+                    updateUI();
+                    break;
+            }
+        });
+
+        document.getElementById('restart').addEventListener('click', init);
+
+        init();
+        update();
+    </script>
+    <script src="../global-enhancements.js" defer></script>
+</body>
+</html>

--- a/game/tetris/index.html
+++ b/game/tetris/index.html
@@ -2,7 +2,6 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>테트리스</title>
     <style>
         :root {
@@ -112,6 +111,44 @@
             }
         }
     </style>
+
+    <!-- Mobile-friendly viewport -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+    <style>
+      :root { --osc-gap: 10px; --osc-btn: 56px; --osc-z: 9999; }
+      .credit-banner{
+        position:fixed; top:env(safe-area-inset-top,0); left:env(safe-area-inset-left,0);
+        margin:8px; padding:6px 10px; font:600 14px/1.2 system-ui, sans-serif;
+        background:rgba(0,0,0,.55); color:#fff; border-radius:8px; z-index:var(--osc-z);
+        -webkit-backdrop-filter:saturate(150%) blur(6px); backdrop-filter:saturate(150%) blur(6px);
+        user-select:none; pointer-events:none;
+      }
+      .osc-wrap{
+        position:fixed; inset:auto 0 env(safe-area-inset-bottom,0) 0;
+        display:flex; justify-content:center; gap:24px; padding:var(--osc-gap);
+        z-index:var(--osc-z); touch-action:manipulation;
+      }
+      .osc { display:flex; align-items:center; gap:16px; }
+      .osc .dpad{ display:grid; grid-template-areas:
+          ".    up    ."
+          "left  mid  right"
+          ".   down   .";
+        gap:8px; align-items:center; justify-items:center;
+      }
+      .osc .actions{ display:flex; gap:10px; }
+      .osc button{
+        min-width:var(--osc-btn); min-height:var(--osc-btn);
+        border:0; border-radius:12px; font:700 16px system-ui, sans-serif;
+        background:rgba(255,255,255,.9); color:#111; box-shadow:0 2px 10px rgba(0,0,0,.2);
+      }
+      .osc .pause{ min-width:72px; }
+      /* 게임 화면 가려짐 방지 */
+      body{ padding-bottom: calc(env(safe-area-inset-bottom,0) + 110px); }
+      @media (pointer:fine){ /* 데스크톱이면 패드 숨김 */
+        .osc-wrap{ display:none; } body{ padding-bottom:0; }
+      }
+    </style>
+
 </head>
 <body>
     <div class="wrapper">
@@ -430,5 +467,67 @@
         update();
     </script>
     <script src="../global-enhancements.js" defer></script>
+
+    <!-- Creator credit -->
+    <div class="credit-banner" aria-hidden="true">Creator: 박은성</div>
+
+    <!-- On-screen Controls -->
+    <div class="osc-wrap" id="osc-wrap" role="group" aria-label="On-screen game controls">
+      <div class="osc">
+        <div class="dpad">
+          <button data-key="ArrowUp"    style="grid-area:up">▲</button>
+          <button data-key="ArrowLeft"  style="grid-area:left">◀</button>
+          <button data-key="ArrowRight" style="grid-area:right">▶</button>
+          <button data-key="ArrowDown"  style="grid-area:down">▼</button>
+        </div>
+        <div class="actions">
+          <button data-key="Space">A</button>
+          <button data-key="Enter">B</button>
+          <button class="pause" data-key="Escape">⏯︎</button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+(function(){
+  // 일부 게임이 window/document/canvas 등 서로 다른 타깃을 구독하므로, 광범위 전파
+  function send(key, type){
+    const ev = new KeyboardEvent(type, { key, code:key, bubbles:true, cancelable:true });
+    const t = document.activeElement && document.activeElement !== document.body
+      ? document.activeElement : document;
+    t.dispatchEvent(ev); window.dispatchEvent(ev);
+  }
+  function pressStart(key){ send(key,'keydown'); }
+  function pressEnd(key){ send(key,'keyup'); }
+
+  // 버튼 터치/클릭 → 키 이벤트 변환
+  document.getElementById('osc-wrap')?.addEventListener('pointerdown', e=>{
+    const btn = e.target.closest('button[data-key]'); if(!btn) return;
+    e.preventDefault(); btn.setPointerCapture?.(e.pointerId);
+    pressStart(btn.dataset.key);
+    btn.addEventListener('pointerup',  ()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('pointercancel',()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('lostpointercapture',()=>pressEnd(btn.dataset.key), { once:true });
+  });
+
+  // 스와이프 제스처 → 방향키
+  let sx=0, sy=0, tracking=false;
+  const TH=24; // 스와이프 임계값(px)
+  document.addEventListener('touchstart', (e)=>{
+    // 오버레이 위 스와이프는 무시
+    if(e.target.closest('#osc-wrap')) return;
+    tracking=true; const t=e.changedTouches[0]; sx=t.clientX; sy=t.clientY;
+  }, {passive:true});
+  document.addEventListener('touchend', (e)=>{
+    if(!tracking) return; tracking=false;
+    const t=e.changedTouches[0]; const dx=t.clientX-sx, dy=t.clientY-sy;
+    if(Math.abs(dx)<TH && Math.abs(dy)<TH) return;
+    const key = Math.abs(dx)>Math.abs(dy) ? (dx>0?'ArrowRight':'ArrowLeft')
+                                          : (dy>0?'ArrowDown':'ArrowUp');
+    pressStart(key); setTimeout(()=>pressEnd(key), 50);
+  }, {passive:true});
+})();
+    </script>
+
 </body>
 </html>

--- a/game/tower-defense/index.html
+++ b/game/tower-defense/index.html
@@ -2,7 +2,6 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>하늘길 디펜스 지휘본부</title>
     <style>
         :root { color-scheme: dark; }
@@ -78,6 +77,44 @@
             border: 1px solid rgba(111, 205, 255, 0.22);
         }
     </style>
+
+    <!-- Mobile-friendly viewport -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+    <style>
+      :root { --osc-gap: 10px; --osc-btn: 56px; --osc-z: 9999; }
+      .credit-banner{
+        position:fixed; top:env(safe-area-inset-top,0); left:env(safe-area-inset-left,0);
+        margin:8px; padding:6px 10px; font:600 14px/1.2 system-ui, sans-serif;
+        background:rgba(0,0,0,.55); color:#fff; border-radius:8px; z-index:var(--osc-z);
+        -webkit-backdrop-filter:saturate(150%) blur(6px); backdrop-filter:saturate(150%) blur(6px);
+        user-select:none; pointer-events:none;
+      }
+      .osc-wrap{
+        position:fixed; inset:auto 0 env(safe-area-inset-bottom,0) 0;
+        display:flex; justify-content:center; gap:24px; padding:var(--osc-gap);
+        z-index:var(--osc-z); touch-action:manipulation;
+      }
+      .osc { display:flex; align-items:center; gap:16px; }
+      .osc .dpad{ display:grid; grid-template-areas:
+          ".    up    ."
+          "left  mid  right"
+          ".   down   .";
+        gap:8px; align-items:center; justify-items:center;
+      }
+      .osc .actions{ display:flex; gap:10px; }
+      .osc button{
+        min-width:var(--osc-btn); min-height:var(--osc-btn);
+        border:0; border-radius:12px; font:700 16px system-ui, sans-serif;
+        background:rgba(255,255,255,.9); color:#111; box-shadow:0 2px 10px rgba(0,0,0,.2);
+      }
+      .osc .pause{ min-width:72px; }
+      /* 게임 화면 가려짐 방지 */
+      body{ padding-bottom: calc(env(safe-area-inset-bottom,0) + 110px); }
+      @media (pointer:fine){ /* 데스크톱이면 패드 숨김 */
+        .osc-wrap{ display:none; } body{ padding-bottom:0; }
+      }
+    </style>
+
 </head>
 <body>
     <main>
@@ -505,5 +542,67 @@
         loop(0);
     </script>
     <script src="../global-enhancements.js" defer></script>
+
+    <!-- Creator credit -->
+    <div class="credit-banner" aria-hidden="true">Creator: 박은성</div>
+
+    <!-- On-screen Controls -->
+    <div class="osc-wrap" id="osc-wrap" role="group" aria-label="On-screen game controls">
+      <div class="osc">
+        <div class="dpad">
+          <button data-key="ArrowUp"    style="grid-area:up">▲</button>
+          <button data-key="ArrowLeft"  style="grid-area:left">◀</button>
+          <button data-key="ArrowRight" style="grid-area:right">▶</button>
+          <button data-key="ArrowDown"  style="grid-area:down">▼</button>
+        </div>
+        <div class="actions">
+          <button data-key="Space">A</button>
+          <button data-key="Enter">B</button>
+          <button class="pause" data-key="Escape">⏯︎</button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+(function(){
+  // 일부 게임이 window/document/canvas 등 서로 다른 타깃을 구독하므로, 광범위 전파
+  function send(key, type){
+    const ev = new KeyboardEvent(type, { key, code:key, bubbles:true, cancelable:true });
+    const t = document.activeElement && document.activeElement !== document.body
+      ? document.activeElement : document;
+    t.dispatchEvent(ev); window.dispatchEvent(ev);
+  }
+  function pressStart(key){ send(key,'keydown'); }
+  function pressEnd(key){ send(key,'keyup'); }
+
+  // 버튼 터치/클릭 → 키 이벤트 변환
+  document.getElementById('osc-wrap')?.addEventListener('pointerdown', e=>{
+    const btn = e.target.closest('button[data-key]'); if(!btn) return;
+    e.preventDefault(); btn.setPointerCapture?.(e.pointerId);
+    pressStart(btn.dataset.key);
+    btn.addEventListener('pointerup',  ()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('pointercancel',()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('lostpointercapture',()=>pressEnd(btn.dataset.key), { once:true });
+  });
+
+  // 스와이프 제스처 → 방향키
+  let sx=0, sy=0, tracking=false;
+  const TH=24; // 스와이프 임계값(px)
+  document.addEventListener('touchstart', (e)=>{
+    // 오버레이 위 스와이프는 무시
+    if(e.target.closest('#osc-wrap')) return;
+    tracking=true; const t=e.changedTouches[0]; sx=t.clientX; sy=t.clientY;
+  }, {passive:true});
+  document.addEventListener('touchend', (e)=>{
+    if(!tracking) return; tracking=false;
+    const t=e.changedTouches[0]; const dx=t.clientX-sx, dy=t.clientY-sy;
+    if(Math.abs(dx)<TH && Math.abs(dy)<TH) return;
+    const key = Math.abs(dx)>Math.abs(dy) ? (dx>0?'ArrowRight':'ArrowLeft')
+                                          : (dy>0?'ArrowDown':'ArrowUp');
+    pressStart(key); setTimeout(()=>pressEnd(key), 50);
+  }, {passive:true});
+})();
+    </script>
+
 </body>
 </html>

--- a/game/tower-defense/index.html
+++ b/game/tower-defense/index.html
@@ -1,0 +1,509 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>하늘길 디펜스 지휘본부</title>
+    <style>
+        :root { color-scheme: dark; }
+        * { box-sizing: border-box; }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: grid;
+            place-items: center;
+            background: radial-gradient(circle at 30% 20%, #14253f, #060b16 65%, #020409 100%);
+            color: #f4f7ff;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+            padding: clamp(24px, 4vw, 48px);
+        }
+        main {
+            width: min(100%, 1080px);
+            display: grid;
+            gap: clamp(18px, 4vw, 28px);
+            grid-template-columns: minmax(0, 740px) minmax(0, 1fr);
+        }
+        @media (max-width: 1040px) {
+            main { grid-template-columns: 1fr; }
+        }
+        canvas {
+            width: 100%;
+            max-width: 740px;
+            border-radius: 24px;
+            border: 2px solid rgba(255, 255, 255, 0.12);
+            background: #0b1422;
+            box-shadow: 0 26px 64px rgba(0, 0, 0, 0.45);
+        }
+        aside {
+            background: rgba(8, 18, 34, 0.78);
+            border-radius: 24px;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            padding: clamp(22px, 3vw, 32px);
+            display: flex;
+            flex-direction: column;
+            gap: 18px;
+            backdrop-filter: blur(14px);
+        }
+        h1 { margin: 0; font-size: clamp(30px, 4vw, 40px); }
+        .stats { display: flex; flex-wrap: wrap; gap: 12px 16px; font-weight: 600; }
+        .chip { background: rgba(255, 255, 255, 0.1); border-radius: 999px; padding: 6px 14px; }
+        button {
+            border: none;
+            border-radius: 14px;
+            padding: 12px 18px;
+            font-weight: 700;
+            cursor: pointer;
+            background: linear-gradient(135deg, #38d2ff, #6872ff);
+            color: white;
+            box-shadow: 0 18px 40px rgba(56, 210, 255, 0.3);
+            transition: transform 0.18s ease, box-shadow 0.18s ease;
+        }
+        button.secondary { background: rgba(255, 255, 255, 0.12); box-shadow: none; }
+        button:hover { transform: translateY(-2px); }
+        ul { margin: 0; padding-left: 18px; color: rgba(230, 236, 255, 0.82); line-height: 1.6; }
+        .tower-option {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            background: rgba(255, 255, 255, 0.05);
+            border-radius: 16px;
+            padding: 14px 16px;
+        }
+        .tower-option.active { border: 1px solid rgba(111, 205, 255, 0.52); background: rgba(111, 205, 255, 0.12); }
+        .log {
+            min-height: 48px;
+            padding: 12px 16px;
+            border-radius: 14px;
+            background: rgba(111, 205, 255, 0.12);
+            border: 1px solid rgba(111, 205, 255, 0.22);
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <canvas id="game" width="720" height="480" aria-label="타워 디펜스 전장"></canvas>
+        <aside>
+            <h1>하늘길 디펜스</h1>
+            <div class="stats">
+                <span class="chip">웨이브 <strong id="wave">1</strong></span>
+                <span class="chip">라이프 <strong id="lives">20</strong></span>
+                <span class="chip">에너지 <strong id="energy">150</strong></span>
+            </div>
+            <div class="tower-option" id="basic-tower">
+                <div>
+                    <strong>펄스 타워</strong>
+                    <p style="margin:4px 0 0;font-size:13px;color:rgba(230,236,255,0.75);">단일 적에게 빠른 펄스를 발사합니다. 사거리 120, 공격 속도 0.6초.</p>
+                </div>
+                <button class="secondary" data-cost="80">80</button>
+            </div>
+            <div class="tower-option" id="slow-tower">
+                <div>
+                    <strong>아이싱 타워</strong>
+                    <p style="margin:4px 0 0;font-size:13px;color:rgba(230,236,255,0.75);">적을 둔화시키는 냉기 빔. 사거리 100, 공격 속도 1.2초.</p>
+                </div>
+                <button class="secondary" data-cost="110">110</button>
+            </div>
+            <button id="start">다음 웨이브 시작</button>
+            <div class="log" id="log">타워를 선택한 뒤 전장에 배치하세요.</div>
+            <ul>
+                <li>타워는 길 위에는 배치할 수 없습니다. 전략적으로 위치를 선택하세요.</li>
+                <li>웨이브 사이에 에너지가 보충됩니다. 어려운 적은 둔화 타워로 관리해 보세요.</li>
+                <li>적이 골라인에 도달하면 라이프가 줄어듭니다. 0이 되기 전에 모두 막아내세요!</li>
+            </ul>
+        </aside>
+    </main>
+    <script>
+        const canvas = document.getElementById('game');
+        const ctx = canvas.getContext('2d');
+        const waveEl = document.getElementById('wave');
+        const livesEl = document.getElementById('lives');
+        const energyEl = document.getElementById('energy');
+        const logEl = document.getElementById('log');
+        const towerButtons = document.querySelectorAll('.tower-option button');
+        const towerContainers = document.querySelectorAll('.tower-option');
+        const startBtn = document.getElementById('start');
+
+        const path = [
+            { x: 60, y: 460 },
+            { x: 60, y: 300 },
+            { x: 240, y: 300 },
+            { x: 240, y: 140 },
+            { x: 420, y: 140 },
+            { x: 420, y: 360 },
+            { x: 640, y: 360 },
+            { x: 640, y: 60 }
+        ];
+
+        let wave = 1;
+        let lives = 20;
+        let energy = 150;
+        let nextWaveReady = true;
+        let selectedTower = null;
+        let placingTower = false;
+        let ghostPosition = null;
+
+        const towers = [];
+        const enemies = [];
+        const projectiles = [];
+        let spawnQueue = [];
+        let spawnTimer = 0;
+        let lastTime = 0;
+
+        const towerTypes = {
+            basic: { cost: 80, range: 120, cooldown: 0.6, damage: 20, slow: 0 },
+            slow: { cost: 110, range: 100, cooldown: 1.2, damage: 10, slow: 0.45, slowDuration: 1.6 }
+        };
+
+        canvas.addEventListener('mousemove', handleHover);
+        canvas.addEventListener('mouseleave', () => {
+            ghostPosition = null;
+            canvas.style.cursor = 'default';
+        });
+        canvas.addEventListener('click', handlePlacement);
+        startBtn.addEventListener('click', startWave);
+        towerButtons.forEach((button) => {
+            button.addEventListener('click', () => selectTower(button));
+        });
+        window.addEventListener('keydown', (event) => {
+            if (event.key === 'Escape') {
+                placingTower = false;
+                selectedTower = null;
+                ghostPosition = null;
+                canvas.style.cursor = 'default';
+                towerContainers.forEach((container) => container.classList.remove('active'));
+                logEl.textContent = '타워 배치를 취소했습니다.';
+            }
+        });
+
+        function selectTower(button) {
+            const type = button.parentElement.id === 'basic-tower' ? 'basic' : 'slow';
+            const cost = towerTypes[type].cost;
+            if (energy < cost) {
+                logEl.textContent = '에너지가 부족합니다. 적을 처치해 에너지를 모으세요.';
+                return;
+            }
+            selectedTower = type;
+            placingTower = true;
+            towerContainers.forEach((container) => container.classList.remove('active'));
+            button.parentElement.classList.add('active');
+            logEl.textContent = `${cost} 에너지를 사용해 ${type === 'basic' ? '펄스 타워' : '아이싱 타워'}를 배치하세요.`;
+        }
+
+        function handleHover(event) {
+            if (!placingTower) {
+                ghostPosition = null;
+                canvas.style.cursor = 'default';
+                return;
+            }
+            const { offsetX, offsetY } = event;
+            ghostPosition = { x: offsetX, y: offsetY };
+            canvas.style.cursor = 'crosshair';
+        }
+
+        function handlePlacement(event) {
+            if (!placingTower || !selectedTower) return;
+            const { offsetX, offsetY } = event;
+            if (!canPlaceTower(offsetX, offsetY)) {
+                logEl.textContent = '이 위치에는 타워를 지을 수 없습니다.';
+                return;
+            }
+            const type = towerTypes[selectedTower];
+            energy -= type.cost;
+            updateHUD();
+            towers.push({
+                x: offsetX,
+                y: offsetY,
+                type: selectedTower,
+                cooldown: 0
+            });
+            placingTower = false;
+            selectedTower = null;
+            canvas.style.cursor = 'default';
+            towerContainers.forEach((container) => container.classList.remove('active'));
+            logEl.textContent = '타워를 배치했습니다! 웨이브를 시작하거나 추가 배치를 계속하세요.';
+            ghostPosition = null;
+        }
+
+        function canPlaceTower(x, y) {
+            const margin = 28;
+            if (x < margin || y < margin || x > canvas.width - margin || y > canvas.height - margin) return false;
+            if (towers.some((tower) => distance(tower, { x, y }) < 50)) return false;
+            for (let i = 0; i < path.length - 1; i++) {
+                const a = path[i];
+                const b = path[i + 1];
+                if (pointToSegmentDistance({ x, y }, a, b) < 32) return false;
+            }
+            return true;
+        }
+
+        function startWave() {
+            if (!nextWaveReady) {
+                logEl.textContent = '웨이브 진행 중입니다. 먼저 적을 모두 처치하세요.';
+                return;
+            }
+            nextWaveReady = false;
+            const count = 6 + wave * 2;
+            spawnQueue = Array.from({ length: count }, (_, i) => ({
+                hp: 60 + wave * 18,
+                speed: 55 + wave * 3,
+                reward: 14 + wave * 2,
+                delay: i * 0.8
+            }));
+            spawnTimer = 0;
+            logEl.textContent = `웨이브 ${wave} 시작! 적 ${count}마리가 접근합니다.`;
+        }
+
+        function spawnEnemies(dt) {
+            if (!spawnQueue.length) return;
+            spawnTimer += dt;
+            while (spawnQueue.length && spawnTimer >= spawnQueue[0].delay) {
+                const data = spawnQueue.shift();
+                enemies.push({
+                    x: path[0].x,
+                    y: path[0].y,
+                    hp: data.hp,
+                    maxHp: data.hp,
+                    speed: data.speed,
+                    reward: data.reward,
+                    pathIndex: 0,
+                    progress: 0,
+                    slowTimer: 0,
+                    slowFactor: 1
+                });
+            }
+            if (!spawnQueue.length) {
+                spawnTimer = 0;
+            }
+        }
+
+        function update(dt) {
+            spawnEnemies(dt);
+            enemies.forEach((enemy) => {
+                const target = path[enemy.pathIndex + 1];
+                if (!target) return;
+                if (enemy.slowTimer > 0) {
+                    enemy.slowTimer -= dt;
+                    if (enemy.slowTimer <= 0) enemy.slowFactor = 1;
+                }
+                const dir = normalize({ x: target.x - enemy.x, y: target.y - enemy.y });
+                const moveSpeed = enemy.speed * enemy.slowFactor * dt;
+                enemy.x += dir.x * moveSpeed;
+                enemy.y += dir.y * moveSpeed;
+                if (distance(enemy, target) < 4) {
+                    enemy.pathIndex += 1;
+                    if (enemy.pathIndex >= path.length - 1) {
+                        enemy.reached = true;
+                    }
+                }
+            });
+            enemies.filter((enemy) => enemy.reached).forEach((enemy) => {
+                lives -= 1;
+                updateHUD();
+            });
+            for (let i = enemies.length - 1; i >= 0; i--) {
+                if (enemies[i].hp <= 0) {
+                    energy += enemies[i].reward;
+                    enemies.splice(i, 1);
+                    updateHUD();
+                } else if (enemies[i].reached) {
+                    enemies.splice(i, 1);
+                }
+            }
+            towers.forEach((tower) => {
+                tower.cooldown = Math.max(0, tower.cooldown - dt);
+                if (tower.cooldown > 0) return;
+                const type = towerTypes[tower.type];
+                const target = findTarget(tower, type.range);
+                if (target) {
+                    fireProjectile(tower, target, type);
+                    tower.cooldown = type.cooldown;
+                }
+            });
+            projectiles.forEach((shot) => {
+                shot.x += shot.vx * dt;
+                shot.y += shot.vy * dt;
+                shot.life -= dt;
+                if (shot.life <= 0) shot.remove = true;
+                const enemy = enemies.find((e) => distance(e, shot) < 14);
+                if (enemy) {
+                    enemy.hp -= shot.damage;
+                    if (shot.slow && enemy.slowFactor === 1) {
+                        enemy.slowFactor = shot.slow;
+                        enemy.slowTimer = shot.slowDuration;
+                    }
+                    shot.remove = true;
+                }
+            });
+            for (let i = projectiles.length - 1; i >= 0; i--) {
+                if (projectiles[i].remove) projectiles.splice(i, 1);
+            }
+            if (!spawnQueue.length && !enemies.length && !nextWaveReady) {
+                nextWaveReady = true;
+                energy += Math.floor(40 + wave * 8);
+                wave += 1;
+                updateHUD();
+                logEl.textContent = `웨이브 ${wave - 1} 방어 성공! 에너지가 보충되었습니다.`;
+            }
+            if (lives <= 0) {
+                logEl.textContent = '기지가 함락되었습니다... 다시 시도해 보세요!';
+                resetGame();
+            }
+        }
+
+        function fireProjectile(tower, target, type) {
+            const dir = normalize({ x: target.x - tower.x, y: target.y - tower.y });
+            const speed = 380;
+            projectiles.push({
+                x: tower.x,
+                y: tower.y,
+                vx: dir.x * speed,
+                vy: dir.y * speed,
+                damage: type.damage,
+                life: 1.2,
+                slow: type.slow ? 0.55 : 0,
+                slowDuration: type.slowDuration || 0
+            });
+        }
+
+        function findTarget(tower, range) {
+            let nearest = null;
+            let nearestDist = Infinity;
+            enemies.forEach((enemy) => {
+                const dist = distance(tower, enemy);
+                if (dist <= range && dist < nearestDist) {
+                    nearest = enemy;
+                    nearestDist = dist;
+                }
+            });
+            return nearest;
+        }
+
+        function draw() {
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            drawPath();
+            towers.forEach((tower) => drawTower(tower));
+            enemies.forEach((enemy) => drawEnemy(enemy));
+            projectiles.forEach((shot) => drawProjectile(shot));
+            if (ghostPosition && selectedTower) {
+                drawTowerGhost(ghostPosition.x, ghostPosition.y, towerTypes[selectedTower]);
+            }
+        }
+
+        function drawPath() {
+            ctx.strokeStyle = '#354b63';
+            ctx.lineWidth = 46;
+            ctx.lineCap = 'round';
+            ctx.beginPath();
+            ctx.moveTo(path[0].x, path[0].y);
+            for (let i = 1; i < path.length; i++) {
+                ctx.lineTo(path[i].x, path[i].y);
+            }
+            ctx.stroke();
+            ctx.lineWidth = 22;
+            ctx.strokeStyle = '#2a394b';
+            ctx.stroke();
+        }
+
+        function drawTower(tower) {
+            ctx.fillStyle = tower.type === 'basic' ? '#61f5ff' : '#7cc9ff';
+            ctx.beginPath();
+            ctx.arc(tower.x, tower.y, 18, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.strokeStyle = 'rgba(255,255,255,0.35)';
+            ctx.lineWidth = 2;
+            ctx.stroke();
+        }
+
+        function drawTowerGhost(x, y, type) {
+            ctx.save();
+            ctx.globalAlpha = 0.4;
+            ctx.fillStyle = '#61f5ff';
+            ctx.beginPath();
+            ctx.arc(x, y, 18, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.strokeStyle = '#61f5ff';
+            ctx.lineWidth = 1;
+            ctx.beginPath();
+            ctx.arc(x, y, type.range, 0, Math.PI * 2);
+            ctx.stroke();
+            ctx.restore();
+        }
+
+        function drawEnemy(enemy) {
+            ctx.fillStyle = '#ff6b81';
+            ctx.beginPath();
+            ctx.arc(enemy.x, enemy.y, 16, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.fillStyle = '#1b0a13';
+            ctx.beginPath();
+            ctx.arc(enemy.x - 4, enemy.y - 4, 3, 0, Math.PI * 2);
+            ctx.arc(enemy.x + 4, enemy.y - 4, 3, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.fillStyle = '#000';
+            ctx.fillRect(enemy.x - 18, enemy.y - 22, 36, 6);
+            ctx.fillStyle = '#45f1c5';
+            const hpRatio = Math.max(enemy.hp, 0) / enemy.maxHp;
+            ctx.fillRect(enemy.x - 18, enemy.y - 22, 36 * hpRatio, 6);
+        }
+
+        function drawProjectile(shot) {
+            ctx.fillStyle = '#afffff';
+            ctx.beginPath();
+            ctx.arc(shot.x, shot.y, 5, 0, Math.PI * 2);
+            ctx.fill();
+        }
+
+        function updateHUD() {
+            waveEl.textContent = wave;
+            livesEl.textContent = lives;
+            energyEl.textContent = energy;
+        }
+
+        function distance(a, b) {
+            return Math.hypot(a.x - b.x, a.y - b.y);
+        }
+
+        function normalize(vec) {
+            const length = Math.hypot(vec.x, vec.y) || 1;
+            return { x: vec.x / length, y: vec.y / length };
+        }
+
+        function pointToSegmentDistance(point, a, b) {
+            const ab = { x: b.x - a.x, y: b.y - a.y };
+            const ap = { x: point.x - a.x, y: point.y - a.y };
+            const t = Math.max(0, Math.min(1, (ap.x * ab.x + ap.y * ab.y) / (ab.x * ab.x + ab.y * ab.y)));
+            const closest = { x: a.x + ab.x * t, y: a.y + ab.y * t };
+            return distance(point, closest);
+        }
+
+        function resetGame() {
+            enemies.length = 0;
+            towers.length = 0;
+            projectiles.length = 0;
+            spawnQueue.length = 0;
+            wave = 1;
+            lives = 20;
+            energy = 150;
+            nextWaveReady = true;
+            placingTower = false;
+            selectedTower = null;
+            ghostPosition = null;
+            towerContainers.forEach((container) => container.classList.remove('active'));
+            updateHUD();
+            logEl.textContent = '방어를 다시 준비하세요. 타워를 배치한 뒤 웨이브를 시작하세요.';
+        }
+
+        function loop(timestamp) {
+            const dt = Math.min(0.1, (timestamp - lastTime) / 1000 || 0);
+            lastTime = timestamp;
+            update(dt);
+            draw();
+            requestAnimationFrame(loop);
+        }
+
+        updateHUD();
+        loop(0);
+    </script>
+    <script src="../global-enhancements.js" defer></script>
+</body>
+</html>

--- a/game/whack-a-mole/index.html
+++ b/game/whack-a-mole/index.html
@@ -1,0 +1,350 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>두더지 팡팡 스튜디오</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            background: radial-gradient(circle at 50% 0%, #2d1848 0%, #0a0710 70%, #050309 100%);
+            color: #fff3ff;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: clamp(24px, 5vw, 56px);
+        }
+        main {
+            width: min(100%, 960px);
+            display: grid;
+            gap: clamp(18px, 4vw, 32px);
+            grid-template-columns: minmax(0, 380px) minmax(0, 1fr);
+            align-items: center;
+        }
+        @media (max-width: 900px) {
+            main {
+                grid-template-columns: 1fr;
+            }
+        }
+        .arena {
+            background: linear-gradient(160deg, rgba(53, 22, 84, 0.86), rgba(20, 9, 31, 0.92));
+            border-radius: 24px;
+            padding: clamp(18px, 3vw, 28px);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            box-shadow: 0 26px 60px rgba(0, 0, 0, 0.45);
+        }
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: clamp(12px, 3vw, 20px);
+        }
+        .hole {
+            background: radial-gradient(circle at 50% 65%, rgba(0, 0, 0, 0.7) 0%, rgba(0, 0, 0, 0.2) 60%, rgba(255, 255, 255, 0.1) 100%);
+            border-radius: 50%;
+            position: relative;
+            width: 100%;
+            padding-top: 100%;
+            overflow: hidden;
+            cursor: pointer;
+            transition: transform 0.12s ease;
+        }
+        .hole:active {
+            transform: scale(0.97);
+        }
+        .mole {
+            position: absolute;
+            left: 50%;
+            bottom: -60%;
+            width: 66%;
+            height: 66%;
+            transform: translate(-50%, 0);
+            background: radial-gradient(circle at 30% 30%, #fbd6a1, #8b5125 65%, #59311a 100%);
+            border-radius: 50% 50% 40% 40%;
+            border: 4px solid rgba(0, 0, 0, 0.25);
+            transition: bottom 0.16s ease;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #2c1a0c;
+            font-weight: 700;
+        }
+        .hole.active .mole {
+            bottom: 12%;
+        }
+        section {
+            background: rgba(14, 9, 24, 0.75);
+            border-radius: 24px;
+            padding: clamp(24px, 4vw, 36px);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+        h1 {
+            margin: 0;
+            font-size: clamp(30px, 4vw, 42px);
+            letter-spacing: -0.02em;
+        }
+        .stats {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px 18px;
+            font-weight: 600;
+        }
+        .chip {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 999px;
+            padding: 6px 14px;
+        }
+        label {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            font-weight: 600;
+        }
+        select {
+            background: rgba(255, 255, 255, 0.08);
+            color: white;
+            border: 1px solid rgba(255, 255, 255, 0.16);
+            border-radius: 12px;
+            padding: 10px 14px;
+            font-size: 15px;
+        }
+        button {
+            border: none;
+            border-radius: 14px;
+            padding: 12px 18px;
+            font-weight: 600;
+            cursor: pointer;
+            background: linear-gradient(135deg, #ff7bcd, #7158ff);
+            color: white;
+            box-shadow: 0 16px 40px rgba(113, 88, 255, 0.35);
+            transition: transform 0.18s ease, box-shadow 0.18s ease;
+        }
+        button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 20px 44px rgba(113, 88, 255, 0.42);
+        }
+        ul {
+            margin: 0;
+            padding-left: 18px;
+            color: rgba(240, 236, 255, 0.8);
+            line-height: 1.6;
+        }
+        .log {
+            background: rgba(255, 255, 255, 0.08);
+            border-radius: 14px;
+            padding: 12px 16px;
+            min-height: 56px;
+            display: flex;
+            align-items: center;
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <div class="arena">
+            <div class="grid" id="holes" aria-live="polite"></div>
+        </div>
+        <section>
+            <h1>두더지 팡팡 스튜디오</h1>
+            <div class="stats">
+                <span class="chip">점수 <strong id="score">0</strong></span>
+                <span class="chip">콤보 <strong id="combo">x1</strong></span>
+                <span class="chip">남은 시간 <strong id="time">60</strong>s</span>
+                <span class="chip">최고 기록 <strong id="best">0</strong></span>
+            </div>
+            <label>
+                난이도 선택
+                <select id="difficulty">
+                    <option value="normal">노말 - 기본 속도</option>
+                    <option value="hard">하드 - 빠르게 등장</option>
+                    <option value="extreme">익스트림 - 랜덤 폭탄 주의</option>
+                </select>
+            </label>
+            <button id="start">게임 시작</button>
+            <ul>
+                <li>두더지가 올라왔을 때 빠르게 클릭해 점수를 획득하세요.</li>
+                <li>콤보를 유지하면 점수가 배로 올라갑니다.</li>
+                <li>익스트림 모드에서는 폭탄 두더지를 피해야 합니다!</li>
+            </ul>
+            <div class="log" id="log">준비되면 게임 시작 버튼을 누르세요.</div>
+        </section>
+    </main>
+    <script>
+        const holesContainer = document.getElementById('holes');
+        const startBtn = document.getElementById('start');
+        const difficultySelect = document.getElementById('difficulty');
+        const scoreEl = document.getElementById('score');
+        const comboEl = document.getElementById('combo');
+        const timeEl = document.getElementById('time');
+        const bestEl = document.getElementById('best');
+        const logEl = document.getElementById('log');
+
+        const HOLE_COUNT = 9;
+        const holes = [];
+        let timer = null;
+        let spawnTimer = null;
+        let remaining = 60;
+        let score = 0;
+        let combo = 1;
+        let comboTimer = 0;
+        let activeIndex = -1;
+        let isRunning = false;
+        let bombActive = false;
+
+        let bestScore = Number(localStorage.getItem('whack-best') || 0);
+        bestEl.textContent = bestScore;
+
+        function createHoles() {
+            for (let i = 0; i < HOLE_COUNT; i++) {
+                const hole = document.createElement('button');
+                hole.className = 'hole';
+                hole.setAttribute('aria-label', `두더지 구멍 ${i + 1}`);
+                hole.innerHTML = '<div class="mole">:)</div>';
+                hole.addEventListener('click', () => whack(i));
+                holesContainer.appendChild(hole);
+                holes.push(hole);
+            }
+        }
+
+        function resetGame() {
+            clearInterval(timer);
+            clearTimeout(spawnTimer);
+            holes.forEach((hole) => {
+                hole.classList.remove('active', 'bomb');
+                const mole = hole.querySelector('.mole');
+                if (mole) mole.textContent = ':)';
+            });
+            remaining = 60;
+            score = 0;
+            combo = 1;
+            comboTimer = 0;
+            activeIndex = -1;
+            bombActive = false;
+            isRunning = false;
+            updateHUD();
+            logEl.textContent = '준비되면 게임 시작 버튼을 누르세요.';
+            startBtn.disabled = false;
+        }
+
+        function updateHUD() {
+            scoreEl.textContent = score;
+            comboEl.textContent = `x${combo}`;
+            timeEl.textContent = remaining;
+            bestEl.textContent = bestScore;
+        }
+
+        function scheduleNextMole() {
+            const difficulty = difficultySelect.value;
+            let delay = 800;
+            if (difficulty === 'hard') delay = 550;
+            if (difficulty === 'extreme') delay = 400;
+            const jitter = Math.random() * 200;
+            spawnTimer = setTimeout(() => {
+                popMole();
+                if (isRunning) scheduleNextMole();
+            }, delay + jitter);
+        }
+
+        function popMole() {
+            holes.forEach((hole) => hole.classList.remove('active', 'bomb'));
+            activeIndex = Math.floor(Math.random() * HOLE_COUNT);
+            bombActive = false;
+            if (difficultySelect.value === 'extreme' && Math.random() < 0.2) {
+                holes[activeIndex].classList.add('bomb');
+                holes[activeIndex].querySelector('.mole').textContent = '!';
+                bombActive = true;
+            } else {
+                holes[activeIndex].querySelector('.mole').textContent = ':)';
+            }
+            holes[activeIndex].classList.add('active');
+            comboTimer = 1.8;
+        }
+
+        function whack(index) {
+            if (!isRunning) return;
+            if (index !== activeIndex) {
+                combo = 1;
+                updateHUD();
+                return;
+            }
+            if (bombActive) {
+                logEl.textContent = '앗! 폭탄을 건드렸어요. 점수가 크게 줄었습니다.';
+                score = Math.max(0, Math.floor(score * 0.6));
+                combo = 1;
+                bombActive = false;
+            } else {
+                const gained = 10 * combo;
+                score += gained;
+                combo = Math.min(10, combo + 1);
+                logEl.textContent = `훌륭해요! +${gained}점, 콤보 ${combo - 1} 유지 중.`;
+                if (difficultySelect.value === 'extreme' && Math.random() < 0.12) {
+                    logEl.textContent += ' 보너스 시간이 +2초 추가됐어요!';
+                    remaining = Math.min(99, remaining + 2);
+                }
+            }
+            updateHUD();
+            holes[index].classList.remove('active', 'bomb');
+            activeIndex = -1;
+        }
+
+        function tick() {
+            if (!isRunning) return;
+            remaining -= 1;
+            comboTimer = Math.max(0, comboTimer - 1);
+            if (comboTimer === 0) combo = 1;
+            if (remaining <= 0) {
+                endGame();
+                return;
+            }
+            updateHUD();
+        }
+
+        function startGame() {
+            resetGame();
+            isRunning = true;
+            startBtn.disabled = true;
+            logEl.textContent = '게임 시작! 두더지를 연속으로 잡아서 콤보를 노리세요.';
+            updateHUD();
+            scheduleNextMole();
+            timer = setInterval(tick, 1000);
+        }
+
+        function endGame() {
+            isRunning = false;
+            clearInterval(timer);
+            clearTimeout(spawnTimer);
+            holes.forEach((hole) => hole.classList.remove('active', 'bomb'));
+            if (score > bestScore) {
+                bestScore = score;
+                localStorage.setItem('whack-best', bestScore);
+                logEl.textContent = `새로운 최고 기록! ${score}점을 달성했습니다.`;
+            } else {
+                logEl.textContent = `게임 종료! 최종 점수는 ${score}점입니다.`;
+            }
+            startBtn.disabled = false;
+            updateHUD();
+        }
+
+        startBtn.addEventListener('click', startGame);
+        difficultySelect.addEventListener('change', () => {
+            if (!isRunning) return;
+            clearTimeout(spawnTimer);
+            scheduleNextMole();
+        });
+
+        createHoles();
+        resetGame();
+    </script>
+    <script src="../global-enhancements.js" defer></script>
+</body>
+</html>

--- a/game/whack-a-mole/index.html
+++ b/game/whack-a-mole/index.html
@@ -2,7 +2,6 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>두더지 팡팡 스튜디오</title>
     <style>
         :root {
@@ -148,6 +147,44 @@
             align-items: center;
         }
     </style>
+
+    <!-- Mobile-friendly viewport -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+    <style>
+      :root { --osc-gap: 10px; --osc-btn: 56px; --osc-z: 9999; }
+      .credit-banner{
+        position:fixed; top:env(safe-area-inset-top,0); left:env(safe-area-inset-left,0);
+        margin:8px; padding:6px 10px; font:600 14px/1.2 system-ui, sans-serif;
+        background:rgba(0,0,0,.55); color:#fff; border-radius:8px; z-index:var(--osc-z);
+        -webkit-backdrop-filter:saturate(150%) blur(6px); backdrop-filter:saturate(150%) blur(6px);
+        user-select:none; pointer-events:none;
+      }
+      .osc-wrap{
+        position:fixed; inset:auto 0 env(safe-area-inset-bottom,0) 0;
+        display:flex; justify-content:center; gap:24px; padding:var(--osc-gap);
+        z-index:var(--osc-z); touch-action:manipulation;
+      }
+      .osc { display:flex; align-items:center; gap:16px; }
+      .osc .dpad{ display:grid; grid-template-areas:
+          ".    up    ."
+          "left  mid  right"
+          ".   down   .";
+        gap:8px; align-items:center; justify-items:center;
+      }
+      .osc .actions{ display:flex; gap:10px; }
+      .osc button{
+        min-width:var(--osc-btn); min-height:var(--osc-btn);
+        border:0; border-radius:12px; font:700 16px system-ui, sans-serif;
+        background:rgba(255,255,255,.9); color:#111; box-shadow:0 2px 10px rgba(0,0,0,.2);
+      }
+      .osc .pause{ min-width:72px; }
+      /* 게임 화면 가려짐 방지 */
+      body{ padding-bottom: calc(env(safe-area-inset-bottom,0) + 110px); }
+      @media (pointer:fine){ /* 데스크톱이면 패드 숨김 */
+        .osc-wrap{ display:none; } body{ padding-bottom:0; }
+      }
+    </style>
+
 </head>
 <body>
     <main>
@@ -346,5 +383,67 @@
         resetGame();
     </script>
     <script src="../global-enhancements.js" defer></script>
+
+    <!-- Creator credit -->
+    <div class="credit-banner" aria-hidden="true">Creator: 박은성</div>
+
+    <!-- On-screen Controls -->
+    <div class="osc-wrap" id="osc-wrap" role="group" aria-label="On-screen game controls">
+      <div class="osc">
+        <div class="dpad">
+          <button data-key="ArrowUp"    style="grid-area:up">▲</button>
+          <button data-key="ArrowLeft"  style="grid-area:left">◀</button>
+          <button data-key="ArrowRight" style="grid-area:right">▶</button>
+          <button data-key="ArrowDown"  style="grid-area:down">▼</button>
+        </div>
+        <div class="actions">
+          <button data-key="Space">A</button>
+          <button data-key="Enter">B</button>
+          <button class="pause" data-key="Escape">⏯︎</button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+(function(){
+  // 일부 게임이 window/document/canvas 등 서로 다른 타깃을 구독하므로, 광범위 전파
+  function send(key, type){
+    const ev = new KeyboardEvent(type, { key, code:key, bubbles:true, cancelable:true });
+    const t = document.activeElement && document.activeElement !== document.body
+      ? document.activeElement : document;
+    t.dispatchEvent(ev); window.dispatchEvent(ev);
+  }
+  function pressStart(key){ send(key,'keydown'); }
+  function pressEnd(key){ send(key,'keyup'); }
+
+  // 버튼 터치/클릭 → 키 이벤트 변환
+  document.getElementById('osc-wrap')?.addEventListener('pointerdown', e=>{
+    const btn = e.target.closest('button[data-key]'); if(!btn) return;
+    e.preventDefault(); btn.setPointerCapture?.(e.pointerId);
+    pressStart(btn.dataset.key);
+    btn.addEventListener('pointerup',  ()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('pointercancel',()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('lostpointercapture',()=>pressEnd(btn.dataset.key), { once:true });
+  });
+
+  // 스와이프 제스처 → 방향키
+  let sx=0, sy=0, tracking=false;
+  const TH=24; // 스와이프 임계값(px)
+  document.addEventListener('touchstart', (e)=>{
+    // 오버레이 위 스와이프는 무시
+    if(e.target.closest('#osc-wrap')) return;
+    tracking=true; const t=e.changedTouches[0]; sx=t.clientX; sy=t.clientY;
+  }, {passive:true});
+  document.addEventListener('touchend', (e)=>{
+    if(!tracking) return; tracking=false;
+    const t=e.changedTouches[0]; const dx=t.clientX-sx, dy=t.clientY-sy;
+    if(Math.abs(dx)<TH && Math.abs(dy)<TH) return;
+    const key = Math.abs(dx)>Math.abs(dy) ? (dx>0?'ArrowRight':'ArrowLeft')
+                                          : (dy>0?'ArrowDown':'ArrowUp');
+    pressStart(key); setTimeout(()=>pressEnd(key), 50);
+  }, {passive:true});
+})();
+    </script>
+
 </body>
 </html>

--- a/game/wordle/index.html
+++ b/game/wordle/index.html
@@ -2,7 +2,6 @@
 <html lang="ko">
 <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>코드 워들 챌린지</title>
     <style>
         :root {
@@ -125,6 +124,44 @@
             box-shadow: 0 18px 40px rgba(79, 167, 255, 0.3);
         }
     </style>
+
+    <!-- Mobile-friendly viewport -->
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover">
+    <style>
+      :root { --osc-gap: 10px; --osc-btn: 56px; --osc-z: 9999; }
+      .credit-banner{
+        position:fixed; top:env(safe-area-inset-top,0); left:env(safe-area-inset-left,0);
+        margin:8px; padding:6px 10px; font:600 14px/1.2 system-ui, sans-serif;
+        background:rgba(0,0,0,.55); color:#fff; border-radius:8px; z-index:var(--osc-z);
+        -webkit-backdrop-filter:saturate(150%) blur(6px); backdrop-filter:saturate(150%) blur(6px);
+        user-select:none; pointer-events:none;
+      }
+      .osc-wrap{
+        position:fixed; inset:auto 0 env(safe-area-inset-bottom,0) 0;
+        display:flex; justify-content:center; gap:24px; padding:var(--osc-gap);
+        z-index:var(--osc-z); touch-action:manipulation;
+      }
+      .osc { display:flex; align-items:center; gap:16px; }
+      .osc .dpad{ display:grid; grid-template-areas:
+          ".    up    ."
+          "left  mid  right"
+          ".   down   .";
+        gap:8px; align-items:center; justify-items:center;
+      }
+      .osc .actions{ display:flex; gap:10px; }
+      .osc button{
+        min-width:var(--osc-btn); min-height:var(--osc-btn);
+        border:0; border-radius:12px; font:700 16px system-ui, sans-serif;
+        background:rgba(255,255,255,.9); color:#111; box-shadow:0 2px 10px rgba(0,0,0,.2);
+      }
+      .osc .pause{ min-width:72px; }
+      /* 게임 화면 가려짐 방지 */
+      body{ padding-bottom: calc(env(safe-area-inset-bottom,0) + 110px); }
+      @media (pointer:fine){ /* 데스크톱이면 패드 숨김 */
+        .osc-wrap{ display:none; } body{ padding-bottom:0; }
+      }
+    </style>
+
 </head>
 <body>
     <main>
@@ -324,5 +361,67 @@
         resetGame();
     </script>
     <script src="../global-enhancements.js" defer></script>
+
+    <!-- Creator credit -->
+    <div class="credit-banner" aria-hidden="true">Creator: 박은성</div>
+
+    <!-- On-screen Controls -->
+    <div class="osc-wrap" id="osc-wrap" role="group" aria-label="On-screen game controls">
+      <div class="osc">
+        <div class="dpad">
+          <button data-key="ArrowUp"    style="grid-area:up">▲</button>
+          <button data-key="ArrowLeft"  style="grid-area:left">◀</button>
+          <button data-key="ArrowRight" style="grid-area:right">▶</button>
+          <button data-key="ArrowDown"  style="grid-area:down">▼</button>
+        </div>
+        <div class="actions">
+          <button data-key="Space">A</button>
+          <button data-key="Enter">B</button>
+          <button class="pause" data-key="Escape">⏯︎</button>
+        </div>
+      </div>
+    </div>
+
+    <script>
+(function(){
+  // 일부 게임이 window/document/canvas 등 서로 다른 타깃을 구독하므로, 광범위 전파
+  function send(key, type){
+    const ev = new KeyboardEvent(type, { key, code:key, bubbles:true, cancelable:true });
+    const t = document.activeElement && document.activeElement !== document.body
+      ? document.activeElement : document;
+    t.dispatchEvent(ev); window.dispatchEvent(ev);
+  }
+  function pressStart(key){ send(key,'keydown'); }
+  function pressEnd(key){ send(key,'keyup'); }
+
+  // 버튼 터치/클릭 → 키 이벤트 변환
+  document.getElementById('osc-wrap')?.addEventListener('pointerdown', e=>{
+    const btn = e.target.closest('button[data-key]'); if(!btn) return;
+    e.preventDefault(); btn.setPointerCapture?.(e.pointerId);
+    pressStart(btn.dataset.key);
+    btn.addEventListener('pointerup',  ()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('pointercancel',()=>pressEnd(btn.dataset.key), { once:true });
+    btn.addEventListener('lostpointercapture',()=>pressEnd(btn.dataset.key), { once:true });
+  });
+
+  // 스와이프 제스처 → 방향키
+  let sx=0, sy=0, tracking=false;
+  const TH=24; // 스와이프 임계값(px)
+  document.addEventListener('touchstart', (e)=>{
+    // 오버레이 위 스와이프는 무시
+    if(e.target.closest('#osc-wrap')) return;
+    tracking=true; const t=e.changedTouches[0]; sx=t.clientX; sy=t.clientY;
+  }, {passive:true});
+  document.addEventListener('touchend', (e)=>{
+    if(!tracking) return; tracking=false;
+    const t=e.changedTouches[0]; const dx=t.clientX-sx, dy=t.clientY-sy;
+    if(Math.abs(dx)<TH && Math.abs(dy)<TH) return;
+    const key = Math.abs(dx)>Math.abs(dy) ? (dx>0?'ArrowRight':'ArrowLeft')
+                                          : (dy>0?'ArrowDown':'ArrowUp');
+    pressStart(key); setTimeout(()=>pressEnd(key), 50);
+  }, {passive:true});
+})();
+    </script>
+
 </body>
 </html>

--- a/game/wordle/index.html
+++ b/game/wordle/index.html
@@ -1,0 +1,328 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>코드 워들 챌린지</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        * { box-sizing: border-box; }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            background: radial-gradient(circle at 50% 0%, #203248 0%, #070c16 70%, #03040a 100%);
+            color: #f5f7ff;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: clamp(24px, 5vw, 64px);
+        }
+        main {
+            width: min(100%, 720px);
+            display: grid;
+            gap: clamp(18px, 3vw, 32px);
+            justify-items: center;
+            background: rgba(9, 17, 32, 0.82);
+            border-radius: 28px;
+            padding: clamp(28px, 4vw, 48px);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            box-shadow: 0 28px 70px rgba(0, 0, 0, 0.48);
+        }
+        h1 {
+            margin: 0;
+            font-size: clamp(30px, 4vw, 42px);
+            letter-spacing: 0.12em;
+        }
+        p {
+            margin: 0;
+            text-align: center;
+            color: rgba(240, 242, 255, 0.84);
+            line-height: 1.6;
+        }
+        .board {
+            display: grid;
+            grid-template-columns: repeat(5, 64px);
+            gap: 10px;
+        }
+        .cell {
+            width: 64px;
+            height: 64px;
+            border-radius: 12px;
+            border: 2px solid rgba(255, 255, 255, 0.15);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 28px;
+            font-weight: 700;
+            text-transform: uppercase;
+            transition: transform 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+        }
+        .cell.filled {
+            border-color: rgba(255, 255, 255, 0.35);
+        }
+        .cell.correct {
+            background: linear-gradient(135deg, #4ebc7f, #2c8b53);
+            border-color: rgba(255, 255, 255, 0.35);
+        }
+        .cell.present {
+            background: linear-gradient(135deg, #d6a63f, #9d6f13);
+            border-color: rgba(255, 255, 255, 0.2);
+        }
+        .cell.absent {
+            background: rgba(255, 255, 255, 0.06);
+            border-color: rgba(255, 255, 255, 0.08);
+            color: rgba(255, 255, 255, 0.5);
+        }
+        .keyboard {
+            display: grid;
+            gap: 8px;
+            width: 100%;
+        }
+        .keyboard-row {
+            display: flex;
+            gap: 6px;
+            justify-content: center;
+        }
+        .key {
+            flex: 1;
+            padding: 14px 10px;
+            border-radius: 10px;
+            border: none;
+            background: rgba(255, 255, 255, 0.1);
+            color: white;
+            font-weight: 600;
+            cursor: pointer;
+            text-transform: uppercase;
+            transition: transform 0.12s ease, background 0.12s ease;
+        }
+        .key.wide { flex: 1.5; }
+        .key:active {
+            transform: scale(0.96);
+        }
+        .key.correct { background: linear-gradient(135deg, #4ebc7f, #2c8b53); }
+        .key.present { background: linear-gradient(135deg, #d6a63f, #9d6f13); }
+        .key.absent { background: rgba(255, 255, 255, 0.06); color: rgba(255, 255, 255, 0.45); }
+        .status {
+            min-height: 42px;
+            background: rgba(79, 167, 255, 0.12);
+            border-radius: 14px;
+            padding: 12px 16px;
+            color: #d7e9ff;
+            text-align: center;
+            border: 1px solid rgba(79, 167, 255, 0.24);
+        }
+        button#restart {
+            border: none;
+            border-radius: 14px;
+            padding: 12px 20px;
+            font-weight: 700;
+            background: linear-gradient(135deg, #4ea9ff, #765bff);
+            color: white;
+            cursor: pointer;
+            box-shadow: 0 18px 40px rgba(79, 167, 255, 0.3);
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <h1>CODEL</h1>
+        <p>5글자 단어를 6번 안에 맞춰보세요. 초록색은 정확한 자리, 노란색은 다른 위치, 회색은 단어에 없는 글자입니다. 한국어 설명이지만 영어 단어로 플레이합니다!</p>
+        <div class="board" id="board" aria-label="워들 보드"></div>
+        <div class="keyboard" id="keyboard"></div>
+        <div class="status" id="status" role="status">단어를 입력하세요.</div>
+        <button id="restart">새 게임</button>
+    </main>
+    <script>
+        const WORD_LIST = [
+            'ARRAY', 'DEBUG', 'CYCLE', 'PIXEL', 'SCOPE', 'ALERT', 'STACK', 'GUESS', 'HONEY', 'SHAPE',
+            'MUSIC', 'ROUTE', 'DRIFT', 'QUEST', 'LOGIC', 'MAGIC', 'FRAME', 'CLOUD', 'INPUT', 'NEXUS',
+            'SHIFT', 'FROST', 'BASIC', 'SMART', 'CLICK', 'HEART', 'BRAVE', 'FLASH', 'RHYME', 'LIGHT'
+        ];
+        const MAX_ROWS = 6;
+        const COLS = 5;
+
+        const boardEl = document.getElementById('board');
+        const keyboardEl = document.getElementById('keyboard');
+        const statusEl = document.getElementById('status');
+        const restartBtn = document.getElementById('restart');
+
+        const keyboardLayout = [
+            ['Q','W','E','R','T','Y','U','I','O','P'],
+            ['A','S','D','F','G','H','J','K','L'],
+            ['ENTER','Z','X','C','V','B','N','M','DEL']
+        ];
+
+        let target = '';
+        let row = 0;
+        let col = 0;
+        const grid = [];
+        const state = { finished: false };
+
+        function initBoard() {
+            boardEl.innerHTML = '';
+            grid.length = 0;
+            for (let r = 0; r < MAX_ROWS; r++) {
+                const rowCells = [];
+                for (let c = 0; c < COLS; c++) {
+                    const cell = document.createElement('div');
+                    cell.className = 'cell';
+                    cell.setAttribute('aria-live', 'polite');
+                    boardEl.appendChild(cell);
+                    rowCells.push(cell);
+                }
+                grid.push(rowCells);
+            }
+        }
+
+        function initKeyboard() {
+            keyboardEl.innerHTML = '';
+            keyboardLayout.forEach((line) => {
+                const rowEl = document.createElement('div');
+                rowEl.className = 'keyboard-row';
+                line.forEach((key) => {
+                    const button = document.createElement('button');
+                    button.className = 'key' + (key.length > 1 ? ' wide' : '');
+                    button.textContent = key;
+                    button.dataset.key = key;
+                    button.addEventListener('click', () => handleInput(key));
+                    rowEl.appendChild(button);
+                });
+                keyboardEl.appendChild(rowEl);
+            });
+        }
+
+        function pickWord() {
+            target = WORD_LIST[Math.floor(Math.random() * WORD_LIST.length)];
+        }
+
+        function handleInput(key) {
+            if (state.finished) return;
+            if (key === 'DEL') {
+                if (col > 0) {
+                    col -= 1;
+                    const cell = grid[row][col];
+                    cell.textContent = '';
+                    cell.classList.remove('filled');
+                }
+                return;
+            }
+            if (key === 'ENTER') {
+                submitRow();
+                return;
+            }
+            if (col >= COLS) return;
+            const letter = key.toUpperCase();
+            if (!/^[A-Z]$/.test(letter)) return;
+            const cell = grid[row][col];
+            cell.textContent = letter;
+            cell.classList.add('filled');
+            col += 1;
+        }
+
+        function submitRow() {
+            if (col < COLS) {
+                statusEl.textContent = '5글자를 모두 입력하세요.';
+                return;
+            }
+            const guess = grid[row].map((cell) => cell.textContent).join('');
+            if (!WORD_LIST.includes(guess)) {
+                statusEl.textContent = '사전에 없는 단어입니다. 다른 단어를 시도하세요.';
+                return;
+            }
+            evaluateGuess(guess);
+        }
+
+        function evaluateGuess(guess) {
+            const targetLetters = target.split('');
+            const result = Array(COLS).fill('absent');
+            const remaining = targetLetters.slice();
+
+            // correct positions
+            for (let i = 0; i < COLS; i++) {
+                if (guess[i] === targetLetters[i]) {
+                    result[i] = 'correct';
+                    remaining[i] = null;
+                }
+            }
+            // present but wrong position
+            for (let i = 0; i < COLS; i++) {
+                if (result[i] === 'correct') continue;
+                const idx = remaining.indexOf(guess[i]);
+                if (idx !== -1) {
+                    result[i] = 'present';
+                    remaining[idx] = null;
+                }
+            }
+
+            grid[row].forEach((cell, i) => {
+                cell.classList.remove('filled');
+                cell.classList.add(result[i]);
+                cell.style.transform = 'rotateX(0deg)';
+            });
+            updateKeyboard(result, guess);
+
+            if (guess === target) {
+                statusEl.textContent = `${row + 1}번째 만에 정답! 대단해요!`;
+                state.finished = true;
+                return;
+            }
+            row += 1;
+            col = 0;
+            if (row === MAX_ROWS) {
+                statusEl.textContent = `실패! 정답은 ${target}였습니다.`;
+                state.finished = true;
+            } else {
+                statusEl.textContent = `${MAX_ROWS - row}번의 기회가 남았습니다.`;
+            }
+        }
+
+        function updateKeyboard(result, guess) {
+            const keys = keyboardEl.querySelectorAll('.key');
+            result.forEach((status, idx) => {
+                const letter = guess[idx];
+                keys.forEach((keyBtn) => {
+                    if (keyBtn.dataset.key === letter) {
+                        if (keyBtn.classList.contains('correct')) return;
+                        if (status === 'correct') {
+                            keyBtn.className = 'key correct';
+                        } else if (status === 'present' && !keyBtn.classList.contains('correct')) {
+                            keyBtn.classList.add('present');
+                        } else if (status === 'absent' && !keyBtn.classList.contains('present') && !keyBtn.classList.contains('correct')) {
+                            keyBtn.classList.add('absent');
+                        }
+                    }
+                });
+            });
+        }
+
+        function resetGame() {
+            state.finished = false;
+            row = 0;
+            col = 0;
+            pickWord();
+            initBoard();
+            initKeyboard();
+            statusEl.textContent = '단어를 입력하세요.';
+        }
+
+        window.addEventListener('keydown', (event) => {
+            if (event.metaKey || event.ctrlKey || event.altKey) return;
+            if (event.key === 'Backspace') {
+                handleInput('DEL');
+            } else if (event.key === 'Enter') {
+                handleInput('ENTER');
+            } else {
+                handleInput(event.key.toUpperCase());
+            }
+        });
+
+        restartBtn.addEventListener('click', resetGame);
+
+        resetGame();
+    </script>
+    <script src="../global-enhancements.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a shared enhancement script that injects 박은성 제작 배지와 모바일 친화 레이아웃 조정을 모든 게임 페이지에 적용
- refresh the /game 허브 카드, 기기 지원 안내, 그리고 박은성 시그니처 배지를 추가해 브랜드를 강조
- 재정비된 Snake, Tetris, 2048, Breakout, Flappy, Minesweeper, Memory Match, Nebulous, Pong 화면에 반응형 패널과 포커스 상태를 더해 모바일과 데스크톱 모두에서 부드럽게 플레이 가능하게 개선

## Testing
- not run (static HTML/JS content)


------
https://chatgpt.com/codex/tasks/task_e_68f03b8f5ff8832981f84eb349b88c15