### PR TITLE
Add new arcade titles and polish 2048 logic

### DIFF
--- a/game/2048/index.html
+++ b/game/2048/index.html
@@ -1,0 +1,319 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>2048 퍼즐</title>
+    <style>
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
+            color: #fff;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+        }
+        .container {
+            background: rgba(12, 32, 66, 0.85);
+            padding: 32px;
+            border-radius: 24px;
+            width: min(90vw, 460px);
+            box-shadow: 0 25px 60px rgba(0, 0, 0, 0.45);
+        }
+        header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 20px;
+        }
+        h1 {
+            margin: 0;
+            font-size: 32px;
+            letter-spacing: 1px;
+        }
+        .score-board {
+            display: flex;
+            gap: 12px;
+        }
+        .badge {
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 12px;
+            padding: 10px 16px;
+            text-align: center;
+            font-weight: 600;
+            line-height: 1.4;
+        }
+        .board {
+            position: relative;
+            background: rgba(6, 16, 36, 0.8);
+            border-radius: 16px;
+            padding: 12px;
+            display: grid;
+            grid-template-columns: repeat(4, 1fr);
+            gap: 12px;
+        }
+        .cell {
+            padding-top: 100%;
+            border-radius: 12px;
+            background: rgba(255,255,255,0.06);
+            position: relative;
+            overflow: hidden;
+        }
+        .tile {
+            position: absolute;
+            inset: 0;
+            display: grid;
+            place-items: center;
+            font-weight: 700;
+            font-size: 28px;
+            border-radius: 12px;
+            transform: scale(0.9);
+            transition: transform 0.1s ease;
+        }
+        .tile.new {
+            animation: pop 0.2s ease-out;
+        }
+        .tile.merged {
+            animation: merge 0.25s ease-out;
+        }
+        @keyframes pop {
+            from { transform: scale(0.2); opacity: 0; }
+            to { transform: scale(1); opacity: 1; }
+        }
+        @keyframes merge {
+            from { transform: scale(1.2); }
+            to { transform: scale(1); }
+        }
+        button {
+            margin-top: 20px;
+            width: 100%;
+            padding: 12px;
+            background: #fbc531;
+            border: none;
+            border-radius: 999px;
+            font-weight: 700;
+            cursor: pointer;
+            color: #273c75;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 15px 25px rgba(251, 197, 49, 0.35);
+        }
+        p {
+            margin-top: 16px;
+            font-size: 14px;
+            color: rgba(255,255,255,0.75);
+            line-height: 1.5;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>2048</h1>
+            <div class="score-board">
+                <div class="badge">점수<br><span id="score">0</span></div>
+                <div class="badge">최고 기록<br><span id="best">0</span></div>
+            </div>
+        </header>
+        <div class="board" id="board"></div>
+        <button id="restart">새 게임</button>
+        <p>방향키 또는 스와이프(모바일)로 타일을 이동하세요. 같은 숫자가 만나면 합쳐집니다!</p>
+    </div>
+
+    <script>
+        const boardEl = document.getElementById('board');
+        const scoreEl = document.getElementById('score');
+        const bestEl = document.getElementById('best');
+        const restartBtn = document.getElementById('restart');
+        const size = 4;
+        let board, score, bestScore = Number(localStorage.getItem('best-2048')) || 0;
+        bestEl.textContent = bestScore;
+
+        function createBoard() {
+            board = Array.from({ length: size }, () => Array(size).fill(0));
+            score = 0;
+            updateScore();
+            boardEl.innerHTML = '';
+            for (let i = 0; i < size * size; i++) {
+                const cell = document.createElement('div');
+                cell.className = 'cell';
+                boardEl.appendChild(cell);
+            }
+            addRandomTile();
+            addRandomTile();
+            render();
+        }
+
+        function updateScore() {
+            scoreEl.textContent = score;
+            if (score > bestScore) {
+                bestScore = score;
+                localStorage.setItem('best-2048', bestScore);
+                bestEl.textContent = bestScore;
+            }
+        }
+
+        function addRandomTile() {
+            const empty = [];
+            for (let y = 0; y < size; y++) {
+                for (let x = 0; x < size; x++) {
+                    if (board[y][x] === 0) empty.push({ x, y });
+                }
+            }
+            if (!empty.length) return false;
+            const { x, y } = empty[Math.floor(Math.random() * empty.length)];
+            board[y][x] = Math.random() < 0.9 ? 2 : 4;
+            return true;
+        }
+
+        function render() {
+            boardEl.querySelectorAll('.cell').forEach((cell, index) => {
+                cell.innerHTML = '';
+                const x = index % size;
+                const y = Math.floor(index / size);
+                const value = board[y][x];
+                if (value) {
+                    const tile = document.createElement('div');
+                    tile.className = 'tile new tile-' + value;
+                    tile.style.background = getTileColor(value);
+                    tile.style.color = value <= 4 ? '#2f3640' : '#f5f6fa';
+                    tile.textContent = value;
+                    cell.appendChild(tile);
+                    requestAnimationFrame(() => tile.classList.remove('new'));
+                }
+            });
+        }
+
+        function getTileColor(value) {
+            const palette = {
+                2: '#cfe2ff',
+                4: '#9ec5fe',
+                8: '#74c0fc',
+                16: '#4dabf7',
+                32: '#339af0',
+                64: '#1864ab',
+                128: '#ffd43b',
+                256: '#fab005',
+                512: '#f08c00',
+                1024: '#e8590c',
+                2048: '#d9480f'
+            };
+            return palette[value] || '#ad1457';
+        }
+
+        function slide(row) {
+            const filtered = row.filter(v => v !== 0);
+            const merged = [];
+            let skip = false;
+            for (let i = 0; i < filtered.length; i++) {
+                if (skip) {
+                    skip = false;
+                    continue;
+                }
+                if (filtered[i] === filtered[i + 1]) {
+                    const value = filtered[i] * 2;
+                    score += value;
+                    merged.push(value);
+                    skip = true;
+                } else {
+                    merged.push(filtered[i]);
+                }
+            }
+            while (merged.length < size) merged.push(0);
+            return merged;
+        }
+
+        function rowsEqual(a, b) {
+            return a.length === b.length && a.every((v, i) => v === b[i]);
+        }
+
+        function move(direction) {
+            const snapshot = board.map(row => [...row]);
+            if (direction === 'left') {
+                for (let y = 0; y < size; y++) {
+                    board[y] = slide(board[y]);
+                }
+            } else if (direction === 'right') {
+                for (let y = 0; y < size; y++) {
+                    board[y] = slide(board[y].slice().reverse()).reverse();
+                }
+            } else if (direction === 'up') {
+                for (let x = 0; x < size; x++) {
+                    const column = board.map(row => row[x]);
+                    const newColumn = slide(column);
+                    board.forEach((row, y) => row[x] = newColumn[y]);
+                }
+            } else if (direction === 'down') {
+                for (let x = 0; x < size; x++) {
+                    const column = board.map(row => row[x]).reverse();
+                    const newColumn = slide(column).reverse();
+                    board.forEach((row, y) => row[x] = newColumn[y]);
+                }
+            }
+            return !snapshot.every((row, y) => row.every((value, x) => value === board[y][x]));
+        }
+
+        function canMove() {
+            for (let y = 0; y < size; y++) {
+                for (let x = 0; x < size; x++) {
+                    const value = board[y][x];
+                    if (value === 0) return true;
+                    if (x < size - 1 && board[y][x + 1] === value) return true;
+                    if (y < size - 1 && board[y + 1][x] === value) return true;
+                }
+            }
+            return false;
+        }
+
+        function handleMove(direction) {
+            const moved = move(direction);
+            if (!moved) return;
+            updateScore();
+            addRandomTile();
+            render();
+            if (!canMove()) {
+                setTimeout(() => alert('게임 오버! 점수: ' + score), 200);
+            }
+        }
+
+        document.addEventListener('keydown', (e) => {
+            const keyMap = {
+                ArrowLeft: 'left',
+                ArrowRight: 'right',
+                ArrowUp: 'up',
+                ArrowDown: 'down'
+            };
+            if (keyMap[e.key]) {
+                e.preventDefault();
+                handleMove(keyMap[e.key]);
+            }
+        });
+
+        let startX, startY;
+        boardEl.addEventListener('touchstart', e => {
+            const touch = e.touches[0];
+            startX = touch.clientX;
+            startY = touch.clientY;
+        });
+        boardEl.addEventListener('touchend', e => {
+            const touch = e.changedTouches[0];
+            const dx = touch.clientX - startX;
+            const dy = touch.clientY - startY;
+            if (Math.abs(dx) > Math.abs(dy)) {
+                if (Math.abs(dx) > 30) handleMove(dx > 0 ? 'right' : 'left');
+            } else {
+                if (Math.abs(dy) > 30) handleMove(dy > 0 ? 'down' : 'up');
+            }
+        });
+
+        restartBtn.addEventListener('click', createBoard);
+
+        createBoard();
+    </script>
+</body>
+</html>

--- a/game/breakout/index.html
+++ b/game/breakout/index.html
@@ -1,0 +1,485 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>네온 벽돌깨기</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: grid;
+            place-items: center;
+            background: radial-gradient(circle at 50% 0%, #0f1c2d, #050811 70%);
+            color: #f0f6ff;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+        }
+        .panel {
+            background: rgba(8, 16, 32, 0.88);
+            padding: 32px;
+            border-radius: 28px;
+            box-shadow: 0 32px 70px rgba(0, 0, 0, 0.55);
+            display: flex;
+            flex-direction: column;
+            gap: 18px;
+            align-items: center;
+        }
+        canvas {
+            background: radial-gradient(circle at 50% 20%, #0b1a2f, #02060e 80%);
+            border-radius: 20px;
+            border: 6px solid rgba(255, 255, 255, 0.04);
+        }
+        h1 {
+            margin: 0;
+            font-size: 28px;
+            letter-spacing: 2px;
+        }
+        .stats {
+            display: flex;
+            gap: 24px;
+            font-weight: 600;
+        }
+        .controls {
+            font-size: 14px;
+            color: rgba(255, 255, 255, 0.72);
+            text-align: center;
+            line-height: 1.6;
+        }
+        button {
+            background: linear-gradient(130deg, #00f5ff, #3a7bd5);
+            color: #02162c;
+            border: none;
+            border-radius: 999px;
+            padding: 10px 24px;
+            font-weight: 700;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 20px 30px rgba(0, 245, 255, 0.28);
+        }
+    </style>
+</head>
+<body>
+    <div class="panel">
+        <h1>네온 벽돌깨기</h1>
+        <div class="stats">
+            <div>점수: <span id="score">0</span></div>
+            <div>스테이지: <span id="stage">1</span></div>
+            <div>기회: <span id="lives">3</span></div>
+        </div>
+        <canvas id="game" width="520" height="640"></canvas>
+        <button id="restart">다시 시작</button>
+        <p class="controls">마우스 또는 ← → 키로 패들을 움직여 공을 튕기세요.<br>파워업을 받아 다양한 효과를 활용해 모든 벽돌을 제거하면 다음 스테이지로 진행합니다.</p>
+    </div>
+    <script>
+        const canvas = document.getElementById('game');
+        const ctx = canvas.getContext('2d');
+        const scoreEl = document.getElementById('score');
+        const stageEl = document.getElementById('stage');
+        const livesEl = document.getElementById('lives');
+        const restartBtn = document.getElementById('restart');
+
+        const WIDTH = canvas.width;
+        const HEIGHT = canvas.height;
+        const ROWS = 6;
+        const COLS = 10;
+        const BRICK_WIDTH = (WIDTH - 80) / COLS;
+        const BRICK_HEIGHT = 28;
+
+        let mouseX = WIDTH / 2;
+
+        const POWERUPS = [
+            { type: 'expand', color: '#6c5ce7', duration: 10000 },
+            { type: 'multi', color: '#fd79a8', duration: 0 },
+            { type: 'laser', color: '#74b9ff', duration: 8000 }
+        ];
+
+        const lasers = [];
+
+        class Paddle {
+            constructor() {
+                this.width = 110;
+                this.height = 16;
+                this.x = WIDTH / 2 - this.width / 2;
+                this.y = HEIGHT - 60;
+                this.speed = 9;
+                this.expireAt = 0;
+                this.hasLaser = false;
+            }
+            update(delta) {
+                if (keys.ArrowLeft) this.x -= this.speed;
+                if (keys.ArrowRight) this.x += this.speed;
+                const target = mouseX - this.width / 2;
+                this.x += (target - this.x) * Math.min(1, delta * 0.02);
+                this.x = Math.max(20, Math.min(WIDTH - 20 - this.width, this.x));
+                if (this.expireAt && performance.now() > this.expireAt) {
+                    this.width = 110;
+                    this.expireAt = 0;
+                }
+            }
+            draw() {
+                const grd = ctx.createLinearGradient(this.x, this.y, this.x + this.width, this.y + this.height);
+                grd.addColorStop(0, '#0ff0f7');
+                grd.addColorStop(1, '#3a7bd5');
+                ctx.fillStyle = grd;
+                ctx.fillRect(this.x, this.y, this.width, this.height);
+            }
+        }
+
+        class Ball {
+            constructor(x, y) {
+                this.x = x;
+                this.y = y;
+                this.radius = 9;
+                const angle = (Math.random() * 0.5 + 0.25) * Math.PI;
+                this.dx = Math.cos(angle) * 6;
+                this.dy = -Math.abs(Math.sin(angle) * 6);
+            }
+            update(delta) {
+                this.x += this.dx;
+                this.y += this.dy;
+
+                if (this.x < this.radius + 8 || this.x > WIDTH - this.radius - 8) {
+                    this.dx *= -1;
+                    this.x = Math.max(this.radius + 8, Math.min(WIDTH - this.radius - 8, this.x));
+                }
+                if (this.y < this.radius + 12) {
+                    this.dy *= -1;
+                    this.y = this.radius + 12;
+                }
+            }
+            draw() {
+                ctx.beginPath();
+                ctx.fillStyle = '#ffeaa7';
+                ctx.shadowBlur = 12;
+                ctx.shadowColor = '#ffeaa7aa';
+                ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
+                ctx.fill();
+                ctx.shadowBlur = 0;
+            }
+        }
+
+        class Brick {
+            constructor(x, y, hp) {
+                this.x = x;
+                this.y = y;
+                this.hp = hp;
+                this.width = BRICK_WIDTH;
+                this.height = BRICK_HEIGHT;
+                this.dropChance = Math.random() < 0.18;
+            }
+            draw() {
+                if (this.hp <= 0) return;
+                const colors = ['#1dd1a1', '#54a0ff', '#5f27cd'];
+                const color = colors[this.hp - 1] || '#ff7675';
+                ctx.fillStyle = color;
+                ctx.fillRect(this.x, this.y, this.width - 6, this.height - 6);
+            }
+        }
+
+        class PowerUp {
+            constructor(x, y, def) {
+                this.x = x;
+                this.y = y;
+                this.type = def.type;
+                this.color = def.color;
+                this.duration = def.duration;
+                this.speed = 3.2;
+                this.size = 18;
+            }
+            update() {
+                this.y += this.speed;
+            }
+            draw() {
+                ctx.fillStyle = this.color;
+                ctx.beginPath();
+                ctx.arc(this.x, this.y, this.size / 2, 0, Math.PI * 2);
+                ctx.fill();
+                ctx.fillStyle = '#0b1a2f';
+                ctx.font = 'bold 12px Pretendard';
+                ctx.textAlign = 'center';
+                ctx.fillText(this.type[0].toUpperCase(), this.x, this.y + 4);
+            }
+        }
+
+        class Laser {
+            constructor(x, y) {
+                this.x = x;
+                this.y = y;
+                this.speed = 9;
+            }
+            update() {
+                this.y -= this.speed;
+            }
+            draw() {
+                ctx.fillStyle = '#74b9ff';
+                ctx.fillRect(this.x - 2, this.y, 4, 20);
+            }
+        }
+
+        let paddle;
+        let balls;
+        let bricks;
+        let powerUps;
+        let stage = 1;
+        let score = 0;
+        let lives = 3;
+        let lastTime = 0;
+        let keys = { ArrowLeft: false, ArrowRight: false };
+        let running = true;
+
+        function createStage() {
+            bricks = [];
+            const offsetX = 40;
+            const offsetY = 80;
+            for (let r = 0; r < ROWS + stage - 1; r++) {
+                for (let c = 0; c < COLS; c++) {
+                    const hp = 1 + Math.floor(r / 2);
+                    const brickX = offsetX + c * BRICK_WIDTH;
+                    const brickY = offsetY + r * BRICK_HEIGHT;
+                    bricks.push(new Brick(brickX, brickY, Math.min(4, hp)));
+                }
+            }
+        }
+
+        function resetBall() {
+            balls = [new Ball(paddle.x + paddle.width / 2, paddle.y - 12)];
+            balls[0].dx = 0;
+            balls[0].dy = 0;
+        }
+
+        function resetGame() {
+            paddle = new Paddle();
+            stage = 1;
+            score = 0;
+            lives = 3;
+            powerUps = [];
+            lasers.length = 0;
+            createStage();
+            resetBall();
+            prepareServe();
+            running = true;
+            updateUI();
+        }
+
+        function updateUI() {
+            scoreEl.textContent = score;
+            stageEl.textContent = stage;
+            livesEl.textContent = lives;
+        }
+
+        function spawnPowerUp(brick) {
+            const power = POWERUPS[Math.floor(Math.random() * POWERUPS.length)];
+            powerUps.push(new PowerUp(brick.x + brick.width / 2, brick.y + brick.height / 2, power));
+        }
+
+        function activatePowerUp(power) {
+            if (power.type === 'expand') {
+                paddle.width = 160;
+                paddle.expireAt = performance.now() + power.duration;
+            } else if (power.type === 'multi') {
+                if (balls.length < 5) {
+                    const clones = balls.map(ball => {
+                        const clone = new Ball(ball.x, ball.y);
+                        clone.dx = -ball.dx;
+                        clone.dy = ball.dy;
+                        return clone;
+                    });
+                    balls.push(...clones);
+                }
+            } else if (power.type === 'laser') {
+                paddle.hasLaser = true;
+                paddle.expireAt = performance.now() + power.duration;
+            }
+        }
+
+        function launchBallFromPaddle(ball) {
+            if (ball.dy > 0) return;
+            const hit = (ball.x - paddle.x) / paddle.width - 0.5;
+            const angle = hit * Math.PI / 3;
+            const speed = Math.hypot(ball.dx, ball.dy);
+            ball.dx = Math.sin(angle) * speed * 1.05;
+            ball.dy = -Math.cos(angle) * speed * 1.05;
+        }
+
+        function handleCollisions(ball) {
+            if (ball.y + ball.radius >= paddle.y &&
+                ball.x >= paddle.x && ball.x <= paddle.x + paddle.width &&
+                ball.dy > 0) {
+                ball.y = paddle.y - ball.radius;
+                launchBallFromPaddle(ball);
+                if (paddle.hasLaser) {
+                    lasers.push(new Laser(ball.x - 12, paddle.y));
+                    lasers.push(new Laser(ball.x + 12, paddle.y));
+                }
+            }
+
+            for (const brick of bricks) {
+                if (brick.hp <= 0) continue;
+                if (ball.x + ball.radius < brick.x || ball.x - ball.radius > brick.x + brick.width) continue;
+                if (ball.y + ball.radius < brick.y || ball.y - ball.radius > brick.y + brick.height) continue;
+
+                const overlapX = Math.min(ball.x + ball.radius - brick.x, brick.x + brick.width - (ball.x - ball.radius));
+                const overlapY = Math.min(ball.y + ball.radius - brick.y, brick.y + brick.height - (ball.y - ball.radius));
+                if (overlapX < overlapY) {
+                    ball.dx *= -1;
+                } else {
+                    ball.dy *= -1;
+                }
+                brick.hp--;
+                score += 50;
+                updateUI();
+                if (brick.hp <= 0 && brick.dropChance && Math.random() < 0.6) {
+                    spawnPowerUp(brick);
+                }
+                break;
+            }
+        }
+
+        function update(time = 0) {
+            if (!running) return;
+            const delta = time - lastTime;
+            lastTime = time;
+            ctx.clearRect(0, 0, WIDTH, HEIGHT);
+
+            paddle.update(delta);
+            paddle.draw();
+
+            powerUps = powerUps.filter(power => {
+                power.update();
+                power.draw();
+                if (power.y > HEIGHT) return false;
+                if (power.y + power.size / 2 >= paddle.y && power.x >= paddle.x && power.x <= paddle.x + paddle.width) {
+                    activatePowerUp(power);
+                    return false;
+                }
+                return true;
+            });
+
+            lasers.forEach(laser => laser.update());
+            lasers.forEach(laser => laser.draw());
+            for (const laser of lasers) {
+                for (const brick of bricks) {
+                    if (brick.hp <= 0) continue;
+                    if (laser.x >= brick.x && laser.x <= brick.x + brick.width &&
+                        laser.y <= brick.y + brick.height && laser.y + 20 >= brick.y) {
+                        brick.hp--;
+                        score += 80;
+                        updateUI();
+                        laser.y = -100;
+                        if (brick.hp <= 0 && brick.dropChance && Math.random() < 0.5) {
+                            spawnPowerUp(brick);
+                        }
+                    }
+                }
+            }
+            for (let i = lasers.length - 1; i >= 0; i--) {
+                if (lasers[i].y < -30) lasers.splice(i, 1);
+            }
+
+            for (let i = balls.length - 1; i >= 0; i--) {
+                const ball = balls[i];
+                ball.update(delta);
+                handleCollisions(ball);
+                ball.draw();
+                if (ball.y - ball.radius > HEIGHT) {
+                    balls.splice(i, 1);
+                }
+            }
+
+            if (!balls.length) {
+                lives--;
+                updateUI();
+                paddle.hasLaser = false;
+                paddle.width = 110;
+                if (lives <= 0) {
+                    running = false;
+                    showGameOver();
+                    return;
+                }
+                resetBall();
+                powerUps = [];
+                prepareServe();
+            }
+
+            if (bricks.every(brick => brick.hp <= 0)) {
+                stage++;
+                updateUI();
+                paddle.hasLaser = false;
+                paddle.width = 110;
+                lasers.length = 0;
+                powerUps = [];
+                createStage();
+                resetBall();
+                prepareServe();
+            }
+
+            requestAnimationFrame(update);
+        }
+
+        function showGameOver() {
+            ctx.fillStyle = 'rgba(2, 6, 14, 0.82)';
+            ctx.fillRect(0, 0, WIDTH, HEIGHT);
+            ctx.fillStyle = '#f5f6fa';
+            ctx.font = '32px Pretendard, sans-serif';
+            ctx.textAlign = 'center';
+            ctx.fillText('게임 오버', WIDTH / 2, HEIGHT / 2 - 12);
+            ctx.font = '20px Pretendard, sans-serif';
+            ctx.fillText('다시 시작 버튼을 눌러 재도전하세요!', WIDTH / 2, HEIGHT / 2 + 24);
+        }
+
+        restartBtn.addEventListener('click', () => {
+            resetGame();
+            lastTime = performance.now();
+            requestAnimationFrame(update);
+        });
+
+        document.addEventListener('mousemove', e => {
+            const rect = canvas.getBoundingClientRect();
+            mouseX = e.clientX - rect.left;
+        });
+
+        document.addEventListener('keydown', e => {
+            if (keys.hasOwnProperty(e.key)) keys[e.key] = true;
+            if (e.code === 'Space' && running && balls.length === 1 && balls[0].dy === 0) {
+                balls[0].dy = -6;
+            }
+        });
+        document.addEventListener('keyup', e => {
+            if (keys.hasOwnProperty(e.key)) keys[e.key] = false;
+        });
+
+        canvas.addEventListener('click', () => {
+            if (!running) return;
+            const ball = balls[0];
+            if (ball && ball.dy === 0) {
+                ball.dy = -6;
+            } else if (paddle.hasLaser) {
+                lasers.push(new Laser(paddle.x + 20, paddle.y));
+                lasers.push(new Laser(paddle.x + paddle.width - 20, paddle.y));
+            }
+        });
+
+        function prepareServe() {
+            balls.forEach(ball => {
+                ball.x = paddle.x + paddle.width / 2;
+                ball.y = paddle.y - 12;
+                ball.dx = 0;
+                ball.dy = 0;
+            });
+        }
+
+        canvas.addEventListener('mouseenter', prepareServe);
+        canvas.addEventListener('mouseleave', prepareServe);
+
+        resetGame();
+        prepareServe();
+        requestAnimationFrame(update);
+    </script>
+</body>
+</html>

--- a/game/flappy/index.html
+++ b/game/flappy/index.html
@@ -1,0 +1,319 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>플래피 비행</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: grid;
+            place-items: center;
+            background: linear-gradient(180deg, #0f2027, #203a43, #2c5364);
+            color: #f5f6fa;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+        }
+        .container {
+            background: rgba(10, 25, 36, 0.88);
+            padding: 28px;
+            border-radius: 24px;
+            box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
+            text-align: center;
+            display: flex;
+            flex-direction: column;
+            gap: 18px;
+            align-items: center;
+        }
+        canvas {
+            border-radius: 18px;
+            border: 6px solid rgba(255, 255, 255, 0.08);
+            background: linear-gradient(180deg, #3c73d3 0%, #5ad0ff 40%, #98e4ff 60%, #fefefe 100%);
+        }
+        .stats {
+            display: flex;
+            gap: 18px;
+            font-weight: 600;
+        }
+        button {
+            background: linear-gradient(135deg, #ffb347, #ffcc33);
+            color: #1f2933;
+            border: none;
+            padding: 10px 24px;
+            border-radius: 999px;
+            cursor: pointer;
+            font-weight: 700;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 18px 26px rgba(255, 204, 51, 0.35);
+        }
+        p {
+            margin: 0;
+            font-size: 14px;
+            color: rgba(255, 255, 255, 0.75);
+            line-height: 1.6;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1 style="margin:0;font-size:28px;letter-spacing:1px;">플래피 비행</h1>
+        <div class="stats">
+            <div>점수: <span id="score">0</span></div>
+            <div>최고: <span id="best">0</span></div>
+        </div>
+        <canvas id="game" width="420" height="560"></canvas>
+        <button id="restart">다시 시작</button>
+        <p>탭/클릭 또는 스페이스, ↑ 키로 상승하세요. 파이프 사이를 통과해 점수를 올려 보세요!</p>
+    </div>
+
+    <script>
+        const canvas = document.getElementById('game');
+        const ctx = canvas.getContext('2d');
+        const scoreEl = document.getElementById('score');
+        const bestEl = document.getElementById('best');
+        const restartBtn = document.getElementById('restart');
+
+        const WIDTH = canvas.width;
+        const HEIGHT = canvas.height;
+        const GRAVITY = 0.0028;
+        const JUMP = -0.72;
+        const GAP = 150;
+
+        let bird;
+        let pipes;
+        let particles;
+        let score;
+        let best = Number(localStorage.getItem('flappy-best')) || 0;
+        let running = false;
+        let lastTime = 0;
+
+        bestEl.textContent = best;
+
+        function resetGame() {
+            bird = {
+                x: WIDTH * 0.25,
+                y: HEIGHT / 2,
+                radius: 18,
+                velocity: 0,
+                rotation: 0
+            };
+            pipes = [];
+            particles = [];
+            score = 0;
+            scoreEl.textContent = score;
+            running = true;
+            lastTime = performance.now();
+        }
+
+        function spawnPipe() {
+            const margin = 70;
+            const topHeight = margin + Math.random() * (HEIGHT - GAP - margin * 2);
+            pipes.push({
+                x: WIDTH + 40,
+                width: 64,
+                top: topHeight,
+                bottom: topHeight + GAP,
+                passed: false
+            });
+        }
+
+        function drawBackground() {
+            ctx.fillStyle = '#87ceeb';
+            ctx.fillRect(0, 0, WIDTH, HEIGHT);
+            ctx.fillStyle = '#fefefe';
+            for (let i = 0; i < 6; i++) {
+                ctx.globalAlpha = 0.25;
+                const radius = 40 + i * 12;
+                const cx = 60 + i * 50;
+                ctx.beginPath();
+                ctx.arc(cx, 90, radius, Math.PI * 0.5, Math.PI * 1.5);
+                ctx.arc(cx + radius, 90, radius, Math.PI * 1.5, Math.PI * 0.5);
+                ctx.fill();
+            }
+            ctx.globalAlpha = 1;
+            ctx.fillStyle = '#48a868';
+            ctx.fillRect(0, HEIGHT - 80, WIDTH, 80);
+            ctx.fillStyle = '#3b8b5d';
+            ctx.fillRect(0, HEIGHT - 70, WIDTH, 70);
+        }
+
+        function drawBird() {
+            ctx.save();
+            ctx.translate(bird.x, bird.y);
+            ctx.rotate(bird.rotation);
+            ctx.fillStyle = '#ffe066';
+            ctx.beginPath();
+            ctx.ellipse(0, 0, bird.radius + 4, bird.radius, 0, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.fillStyle = '#ff922b';
+            ctx.beginPath();
+            ctx.arc(bird.radius + 6, 0, 10, -0.5, 0.5);
+            ctx.fill();
+            ctx.fillStyle = '#1e272e';
+            ctx.beginPath();
+            ctx.arc(6, -5, 5, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.fillStyle = '#fff';
+            ctx.beginPath();
+            ctx.arc(7, -6, 2.5, 0, Math.PI * 2);
+            ctx.fill();
+            ctx.restore();
+        }
+
+        function drawPipes(delta) {
+            const speed = 0.22 + Math.min(score * 0.012, 0.18);
+            for (const pipe of pipes) {
+                pipe.x -= speed * delta;
+                ctx.fillStyle = '#2d3436';
+                ctx.fillRect(pipe.x - 3, 0, pipe.width + 6, pipe.top);
+                ctx.fillRect(pipe.x - 3, pipe.bottom, pipe.width + 6, HEIGHT - pipe.bottom);
+                ctx.fillStyle = '#55efc4';
+                ctx.fillRect(pipe.x, 0, pipe.width, pipe.top - 10);
+                ctx.fillRect(pipe.x, pipe.bottom + 10, pipe.width, HEIGHT - pipe.bottom - 10);
+                ctx.fillStyle = '#81ecec';
+                ctx.fillRect(pipe.x - 5, pipe.top - 10, pipe.width + 10, 12);
+                ctx.fillRect(pipe.x - 5, pipe.bottom - 2, pipe.width + 10, 12);
+            }
+            while (pipes.length && pipes[0].x + pipes[0].width < -60) {
+                pipes.shift();
+            }
+        }
+
+        function drawParticles(delta) {
+            particles = particles.filter(p => {
+                p.life -= delta;
+                if (p.life <= 0) return false;
+                p.x += p.vx * delta * 0.06;
+                p.y += p.vy * delta * 0.06;
+                p.vy += GRAVITY * 0.2;
+                ctx.fillStyle = `rgba(255, 255, 255, ${p.life / 600})`;
+                ctx.fillRect(p.x, p.y, 3, 3);
+                return true;
+            });
+        }
+
+        let spawnTimer = 0;
+
+        function update(time = 0) {
+            if (!running) return;
+            const delta = time - lastTime;
+            lastTime = time;
+            spawnTimer += delta;
+
+            drawBackground();
+            drawPipes(delta);
+            drawParticles(delta);
+
+            if (spawnTimer > 1600) {
+                spawnPipe();
+                spawnTimer = 0;
+            }
+
+            bird.velocity += GRAVITY * delta;
+            bird.y += bird.velocity * delta;
+            bird.rotation = Math.min(1.2, Math.max(-0.45, bird.velocity / 8));
+
+            if (bird.y + bird.radius > HEIGHT - 70) {
+                bird.y = HEIGHT - 70 - bird.radius;
+                endGame();
+            }
+            if (bird.y - bird.radius < 0) {
+                bird.y = bird.radius;
+                bird.velocity = 0;
+            }
+
+            for (const pipe of pipes) {
+                if (!pipe.passed && bird.x > pipe.x + pipe.width) {
+                    pipe.passed = true;
+                    score++;
+                    scoreEl.textContent = score;
+                    if (score > best) {
+                        best = score;
+                        localStorage.setItem('flappy-best', best);
+                        bestEl.textContent = best;
+                    }
+                }
+                if (bird.x + bird.radius > pipe.x && bird.x - bird.radius < pipe.x + pipe.width) {
+                    if (bird.y - bird.radius < pipe.top || bird.y + bird.radius > pipe.bottom) {
+                        endGame();
+                    }
+                }
+            }
+
+            drawBird();
+            requestAnimationFrame(update);
+        }
+
+        function flap() {
+            if (!running) {
+                resetGame();
+                spawnTimer = 0;
+                spawnPipe();
+                requestAnimationFrame(update);
+            }
+            bird.velocity = JUMP;
+            bird.rotation = -0.6;
+            for (let i = 0; i < 6; i++) {
+                particles.push({
+                    x: bird.x - 10,
+                    y: bird.y + 6,
+                    vx: -Math.random() * 0.12,
+                    vy: (Math.random() - 0.5) * 0.4,
+                    life: 600
+                });
+            }
+        }
+
+        function endGame() {
+            if (!running) return;
+            running = false;
+            ctx.fillStyle = 'rgba(2, 6, 14, 0.75)';
+            ctx.fillRect(0, 0, WIDTH, HEIGHT);
+            ctx.fillStyle = '#f5f6fa';
+            ctx.font = '28px Pretendard, sans-serif';
+            ctx.textAlign = 'center';
+            ctx.fillText('게임 오버!', WIDTH / 2, HEIGHT / 2 - 16);
+            ctx.font = '18px Pretendard, sans-serif';
+            ctx.fillText('다시 시작 버튼이나 화면을 눌러 재도전하세요.', WIDTH / 2, HEIGHT / 2 + 22);
+        }
+
+        function handleInput(e) {
+            e.preventDefault();
+            flap();
+        }
+
+        canvas.addEventListener('mousedown', handleInput);
+        canvas.addEventListener('touchstart', handleInput, { passive: false });
+        document.addEventListener('keydown', e => {
+            if (e.code === 'Space' || e.code === 'ArrowUp') {
+                handleInput(e);
+            }
+        });
+
+        restartBtn.addEventListener('click', () => {
+            resetGame();
+            spawnTimer = 0;
+            pipes = [];
+            spawnPipe();
+            requestAnimationFrame(update);
+        });
+
+        resetGame();
+        running = false;
+        drawBackground();
+        drawBird();
+        ctx.fillStyle = 'rgba(0, 0, 0, 0.45)';
+        ctx.fillRect(40, 220, WIDTH - 80, 120);
+        ctx.fillStyle = '#f5f6fa';
+        ctx.font = '20px Pretendard, sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillText('화면을 클릭하거나 스페이스 키로 시작하세요!', WIDTH / 2, 280);
+    </script>
+</body>
+</html>

--- a/game/index.html
+++ b/game/index.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>브라우저 미니 게임 아케이드</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+            margin: 0;
+            min-height: 100vh;
+            background: radial-gradient(circle at 10% 15%, #314867, #0b1521 58%, #04070b 100%);
+            color: #f5f6fa;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: clamp(32px, 5vw, 64px) clamp(16px, 3vw, 48px);
+        }
+        .container {
+            width: min(100%, 1080px);
+            background: rgba(10, 18, 32, 0.82);
+            border-radius: 28px;
+            box-shadow: 0 30px 90px rgba(0, 0, 0, 0.45);
+            padding: clamp(32px, 4vw, 56px);
+            backdrop-filter: blur(16px);
+        }
+        header {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            margin-bottom: 32px;
+        }
+        header h1 {
+            font-size: clamp(30px, 5vw, 46px);
+            font-weight: 700;
+            margin: 0;
+            letter-spacing: -0.02em;
+        }
+        header p {
+            margin: 0;
+            color: rgba(245, 246, 250, 0.78);
+            line-height: 1.6;
+        }
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: clamp(16px, 3vw, 26px);
+        }
+        a {
+            text-decoration: none;
+            color: inherit;
+        }
+        .card {
+            background: linear-gradient(150deg, rgba(40, 66, 102, 0.94), rgba(16, 30, 50, 0.92));
+            border-radius: 20px;
+            padding: 24px;
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            transition: transform 0.24s ease, box-shadow 0.24s ease, border-color 0.24s ease;
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+        .card:hover {
+            transform: translateY(-8px) scale(1.02);
+            box-shadow: 0 22px 38px rgba(0, 0, 0, 0.45);
+            border-color: rgba(255, 255, 255, 0.18);
+        }
+        .card h2 {
+            margin: 0;
+            font-size: 22px;
+        }
+        .card p {
+            margin: 0;
+            font-size: 15px;
+            color: rgba(255, 255, 255, 0.76);
+            line-height: 1.5;
+        }
+        .tag {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 10px;
+            border-radius: 999px;
+            font-size: 12px;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+            background: rgba(255, 255, 255, 0.12);
+            color: rgba(255, 255, 255, 0.85);
+        }
+        footer {
+            margin-top: 36px;
+            font-size: 14px;
+            color: rgba(255, 255, 255, 0.55);
+            text-align: center;
+            line-height: 1.6;
+        }
+    </style>
+</head>
+<body>
+    <main class="container">
+        <header>
+            <h1>브라우저 미니 게임 아케이드</h1>
+            <p>클래식 아케이드부터 퍼즐, 액션, 캐주얼 게임까지! 설치 없이 즐길 수 있는 미니 게임을 계속해서 확장 중입니다.</p>
+        </header>
+        <section class="grid">
+            <a href="./snake/">
+                <article class="card">
+                    <span class="tag">캐주얼</span>
+                    <h2>지렁이 게임</h2>
+                    <p>방향키로 지렁이를 조작해 사과를 먹고 성장하세요. 속도가 점점 빨라지는 클래식 스네이크!</p>
+                </article>
+            </a>
+            <a href="./tetris/">
+                <article class="card">
+                    <span class="tag">퍼즐</span>
+                    <h2>테트리스</h2>
+                    <p>떨어지는 블록을 회전하고 쌓아 라인을 지워 보세요. 레벨이 오를수록 속도가 빨라집니다.</p>
+                </article>
+            </a>
+            <a href="./2048/">
+                <article class="card">
+                    <span class="tag">두뇌</span>
+                    <h2>2048 퍼즐</h2>
+                    <p>같은 숫자 타일을 합쳐 2048에 도전하세요. 차분하지만 중독성 있는 퍼즐입니다.</p>
+                </article>
+            </a>
+            <a href="./sand-tetris/">
+                <article class="card">
+                    <span class="tag">샌드박스</span>
+                    <h2>모래 실험실</h2>
+                    <p>자유롭게 모래와 블록을 떨어뜨리고 쌓으며 물리 퍼즐을 해결해 보세요.</p>
+                </article>
+            </a>
+            <a href="./nebulous/">
+                <article class="card">
+                    <span class="tag">아케이드</span>
+                    <h2>세포 성장 게임</h2>
+                    <p>작은 입자를 흡수해 세포를 키우고 함정을 피해 생존하세요. 네뷸러스 스타일의 액션.</p>
+                </article>
+            </a>
+            <a href="./pong/">
+                <article class="card">
+                    <span class="tag">대전</span>
+                    <h2>레이저 핑퐁</h2>
+                    <p>마우스로 패들을 조작해 공을 반사하고 득점을 노려 보세요. 10점을 먼저 얻으면 승리!</p>
+                </article>
+            </a>
+            <a href="./breakout/">
+                <article class="card">
+                    <span class="tag">아케이드</span>
+                    <h2>네온 벽돌깨기</h2>
+                    <p>발판으로 공을 튕겨 벽돌을 모두 제거하세요. 콤보와 파워업으로 하이 스코어에 도전!</p>
+                </article>
+            </a>
+            <a href="./flappy/">
+                <article class="card">
+                    <span class="tag">반사신경</span>
+                    <h2>플래피 비행</h2>
+                    <p>탭/스페이스로 새를 조작해 장애물을 통과하세요. 속도감 있는 점프 액션 게임입니다.</p>
+                </article>
+            </a>
+            <a href="./minesweeper/">
+                <article class="card">
+                    <span class="tag">전략</span>
+                    <h2>지뢰찾기</h2>
+                    <p>논리와 추리로 지뢰의 위치를 찾아 플래그를 꽂아 보세요. 난이도를 선택할 수 있습니다.</p>
+                </article>
+            </a>
+            <a href="./memory-match/">
+                <article class="card">
+                    <span class="tag">기억력</span>
+                    <h2>카드 매칭</h2>
+                    <p>뒤집힌 카드를 두 장씩 선택해 짝을 맞추세요. 짧은 플레이로 집중력을 시험해 보세요.</p>
+                </article>
+            </a>
+            <a href="./space-shooter/">
+                <article class="card">
+                    <span class="tag">슈팅</span>
+                    <h2>우주 방위전</h2>
+                    <p>적 함대를 피하고 격추하며 보스를 방어하세요. 파워업을 모아 강력한 레이저를 발사!</p>
+                </article>
+            </a>
+            <a href="./runner/">
+                <article class="card">
+                    <span class="tag">러너</span>
+                    <h2>스카이 러너</h2>
+                    <p>장애물을 점프와 슬라이드로 피하며 더 멀리 달려 보세요. 속도는 계속 빨라집니다.</p>
+                </article>
+            </a>
+        </section>
+        <footer>
+            계속해서 새로운 게임을 추가하고 오류를 수정하고 있습니다. 제안하고 싶은 게임이 있다면 알려주세요!
+        </footer>
+    </main>
+</body>
+</html>

--- a/game/memory-match/index.html
+++ b/game/memory-match/index.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>카드 매칭</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: linear-gradient(135deg, #373b44, #4286f4);
+            color: #f5f6fa;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+            padding: clamp(20px, 5vw, 48px);
+        }
+        .container {
+            width: min(92vw, 620px);
+            background: rgba(16, 28, 48, 0.92);
+            border-radius: 28px;
+            padding: clamp(24px, 5vw, 48px);
+            box-shadow: 0 24px 70px rgba(0, 0, 0, 0.55);
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+        }
+        header {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: space-between;
+            gap: 16px;
+            align-items: center;
+        }
+        h1 {
+            margin: 0;
+            font-size: clamp(26px, 5vw, 34px);
+        }
+        .stats {
+            display: flex;
+            gap: 16px;
+            font-weight: 600;
+        }
+        #board {
+            display: grid;
+            grid-template-columns: repeat(4, minmax(80px, 1fr));
+            gap: clamp(12px, 3vw, 18px);
+        }
+        button.card {
+            position: relative;
+            width: 100%;
+            aspect-ratio: 3 / 4;
+            border-radius: 18px;
+            border: none;
+            cursor: pointer;
+            perspective: 800px;
+            background: transparent;
+        }
+        .card-face {
+            position: absolute;
+            inset: 0;
+            display: grid;
+            place-items: center;
+            border-radius: 18px;
+            font-size: clamp(24px, 7vw, 44px);
+            font-weight: 700;
+            backface-visibility: hidden;
+            transition: transform 0.4s ease;
+        }
+        .card-front {
+            background: rgba(255, 255, 255, 0.09);
+            border: 2px solid rgba(255, 255, 255, 0.2);
+        }
+        .card-back {
+            background: linear-gradient(135deg, #ff9a9e, #fad0c4);
+            color: #222;
+            transform: rotateY(180deg);
+        }
+        .card.revealed .card-front {
+            transform: rotateY(180deg);
+        }
+        .card.revealed .card-back {
+            transform: rotateY(360deg);
+        }
+        .card.matched .card-back {
+            background: linear-gradient(135deg, #6ee7b7, #3b82f6);
+            color: #0b1726;
+        }
+        .controls {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            align-items: center;
+        }
+        button.action {
+            background: linear-gradient(135deg, #fdfbfb, #ebedee);
+            color: #0f172a;
+            border: none;
+            padding: 10px 22px;
+            border-radius: 999px;
+            font-weight: 700;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        button.action:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 16px 24px rgba(255, 255, 255, 0.2);
+        }
+        .message {
+            font-size: 14px;
+            color: rgba(255, 255, 255, 0.75);
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>카드 매칭</h1>
+            <div class="stats">
+                <div>턴: <span id="turns">0</span></div>
+                <div>시간: <span id="time">0</span>s</div>
+            </div>
+        </header>
+        <div id="board"></div>
+        <div class="controls">
+            <button class="action" id="restart">다시 섞기</button>
+            <span class="message" id="message">두 장의 카드를 뒤집어 짝을 찾아보세요.</span>
+        </div>
+    </div>
+
+    <script>
+        const icons = ['🍎','🍉','🍓','🍊','🥝','🍇','🍍','🥕','🍒','🍅','🌽','🥑'];
+        const boardEl = document.getElementById('board');
+        const turnsEl = document.getElementById('turns');
+        const timeEl = document.getElementById('time');
+        const restartBtn = document.getElementById('restart');
+        const messageEl = document.getElementById('message');
+
+        let deck = [];
+        let flipped = [];
+        let matched = 0;
+        let turns = 0;
+        let startTime = null;
+        let timer = null;
+        let lock = false;
+
+        function shuffle(array) {
+            for (let i = array.length - 1; i > 0; i--) {
+                const j = Math.floor(Math.random() * (i + 1));
+                [array[i], array[j]] = [array[j], array[i]];
+            }
+            return array;
+        }
+
+        function buildDeck() {
+            const pairs = shuffle([...icons]).slice(0, 8);
+            deck = shuffle([...pairs, ...pairs]).map((icon, index) => ({ id: index, icon, matched: false }));
+        }
+
+        function startTimer() {
+            if (timer) return;
+            startTime = Date.now();
+            timer = setInterval(() => {
+                const elapsed = Math.floor((Date.now() - startTime) / 1000);
+                timeEl.textContent = elapsed;
+            }, 1000);
+        }
+
+        function stopTimer() {
+            clearInterval(timer);
+            timer = null;
+        }
+
+        function renderBoard() {
+            boardEl.innerHTML = '';
+            deck.forEach(card => {
+                const button = document.createElement('button');
+                button.className = 'card';
+                button.dataset.id = card.id;
+                button.innerHTML = `
+                    <div class="card-face card-front"></div>
+                    <div class="card-face card-back">${card.icon}</div>
+                `;
+                button.addEventListener('click', onCardClick);
+                boardEl.appendChild(button);
+                card.element = button;
+            });
+            turnsEl.textContent = turns;
+            timeEl.textContent = '0';
+        }
+
+        function onCardClick(e) {
+            const id = Number(e.currentTarget.dataset.id);
+            const card = deck[id];
+            if (lock || card.matched || flipped.includes(card) || flipped.length === 2) return;
+            card.element.classList.add('revealed');
+            flipped.push(card);
+            if (!startTime) startTimer();
+
+            if (flipped.length === 2) {
+                turns++;
+                turnsEl.textContent = turns;
+                if (flipped[0].icon === flipped[1].icon) {
+                    flipped.forEach(c => {
+                        c.matched = true;
+                        c.element.classList.add('matched');
+                    });
+                    matched += 2;
+                    flipped = [];
+                    checkVictory();
+                } else {
+                    lock = true;
+                    setTimeout(() => {
+                        flipped.forEach(c => c.element.classList.remove('revealed'));
+                        flipped = [];
+                        lock = false;
+                    }, 750);
+                }
+            }
+        }
+
+        function checkVictory() {
+            if (matched === deck.length) {
+                stopTimer();
+                const timeTaken = timeEl.textContent;
+                messageEl.textContent = `완벽합니다! ${turns}턴, ${timeTaken}초 만에 모든 카드를 맞췄어요.`;
+            }
+        }
+
+        function resetGame() {
+            stopTimer();
+            startTime = null;
+            turns = 0;
+            matched = 0;
+            flipped = [];
+            lock = false;
+            messageEl.textContent = '두 장의 카드를 뒤집어 짝을 찾아보세요.';
+            buildDeck();
+            renderBoard();
+        }
+
+        restartBtn.addEventListener('click', resetGame);
+
+        resetGame();
+    </script>
+</body>
+</html>

--- a/game/minesweeper/index.html
+++ b/game/minesweeper/index.html
@@ -1,0 +1,375 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>지뢰찾기</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        * {
+            box-sizing: border-box;
+        }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: radial-gradient(circle at 30% 20%, #102840, #050d18 70%);
+            color: #f0f6ff;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+        }
+        .wrapper {
+            width: min(94vw, 680px);
+            background: rgba(8, 18, 32, 0.92);
+            border-radius: 28px;
+            padding: 32px clamp(20px, 4vw, 40px);
+            box-shadow: 0 28px 70px rgba(0, 0, 0, 0.55);
+        }
+        header {
+            display: flex;
+            flex-direction: column;
+            gap: 14px;
+            margin-bottom: 24px;
+        }
+        h1 {
+            margin: 0;
+            font-size: clamp(26px, 5vw, 34px);
+        }
+        .status-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 16px;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .status {
+            font-weight: 600;
+            display: flex;
+            gap: 16px;
+            align-items: center;
+        }
+        .status span {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+        }
+        select, button.toggle {
+            background: rgba(255, 255, 255, 0.12);
+            border: 1px solid rgba(255, 255, 255, 0.18);
+            color: #f0f6ff;
+            padding: 10px 16px;
+            border-radius: 999px;
+            font-weight: 600;
+            cursor: pointer;
+        }
+        button.toggle.active {
+            background: linear-gradient(135deg, #00c6ff, #0072ff);
+            border-color: transparent;
+        }
+        #board {
+            display: grid;
+            gap: 6px;
+            justify-content: center;
+        }
+        .cell {
+            width: clamp(32px, 6vw, 42px);
+            height: clamp(32px, 6vw, 42px);
+            border-radius: 10px;
+            display: grid;
+            place-items: center;
+            font-weight: 700;
+            cursor: pointer;
+            user-select: none;
+            transition: transform 0.15s ease, background 0.15s ease;
+            background: rgba(255, 255, 255, 0.08);
+            border: 1px solid rgba(255, 255, 255, 0.12);
+        }
+        .cell.revealed {
+            cursor: default;
+            background: rgba(255, 255, 255, 0.18);
+            border-color: rgba(255, 255, 255, 0.25);
+            transform: none;
+        }
+        .cell.mine {
+            background: linear-gradient(135deg, #ef4444, #b91c1c);
+            border-color: rgba(255, 255, 255, 0.4);
+        }
+        .cell.flagged {
+            background: rgba(255, 176, 67, 0.3);
+            border-color: rgba(255, 176, 67, 0.6);
+        }
+        .cell:active:not(.revealed) {
+            transform: translateY(1px) scale(0.98);
+        }
+        footer {
+            margin-top: 20px;
+            color: rgba(255, 255, 255, 0.65);
+            font-size: 14px;
+            line-height: 1.6;
+            text-align: center;
+        }
+        @media (max-width: 520px) {
+            .status-row {
+                flex-direction: column;
+                align-items: stretch;
+            }
+            .status {
+                justify-content: space-between;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="wrapper">
+        <header>
+            <h1>지뢰찾기</h1>
+            <div class="status-row">
+                <div class="status">
+                    <span>⛏️ 남은 지뢰: <strong id="mines">0</strong></span>
+                    <span>⏱️ 시간: <strong id="time">0</strong>s</span>
+                </div>
+                <div style="display:flex; gap:12px;">
+                    <select id="difficulty" aria-label="난이도">
+                        <option value="easy">쉬움 (9×9)</option>
+                        <option value="normal" selected>보통 (16×16)</option>
+                        <option value="hard">어려움 (22×22)</option>
+                    </select>
+                    <button class="toggle" id="flagMode" type="button">🚩 플래그</button>
+                </div>
+            </div>
+        </header>
+        <div id="board" aria-label="게임판"></div>
+        <footer>
+            셀을 클릭하여 열고, 오른쪽 클릭 또는 플래그 모드에서 지뢰라고 생각되는 칸에 깃발을 꽂으세요.<br>
+            모든 안전한 칸을 열면 승리합니다!
+        </footer>
+    </div>
+
+    <script>
+        const boardEl = document.getElementById('board');
+        const minesEl = document.getElementById('mines');
+        const timeEl = document.getElementById('time');
+        const difficultyEl = document.getElementById('difficulty');
+        const flagButton = document.getElementById('flagMode');
+
+        const configs = {
+            easy: { size: 9, mines: 10 },
+            normal: { size: 16, mines: 40 },
+            hard: { size: 22, mines: 80 }
+        };
+
+        let config = configs[difficultyEl.value];
+        let board = [];
+        let mineLocations = new Set();
+        let revealedCount = 0;
+        let flagsPlaced = 0;
+        let startTime = null;
+        let timerInterval = null;
+        let flagMode = false;
+        let gameOver = false;
+
+        function buildBoard() {
+            board = [];
+            mineLocations = new Set();
+            revealedCount = 0;
+            flagsPlaced = 0;
+            gameOver = false;
+            clearInterval(timerInterval);
+            timeEl.textContent = '0';
+            startTime = null;
+            boardEl.style.gridTemplateColumns = `repeat(${config.size}, 1fr)`;
+            boardEl.innerHTML = '';
+
+            const totalCells = config.size * config.size;
+            const mines = config.mines;
+            const positions = Array.from({ length: totalCells }, (_, i) => i);
+            for (let i = positions.length - 1; i > 0; i--) {
+                const j = Math.floor(Math.random() * (i + 1));
+                [positions[i], positions[j]] = [positions[j], positions[i]];
+            }
+            positions.slice(0, mines).forEach(pos => mineLocations.add(pos));
+
+            for (let y = 0; y < config.size; y++) {
+                const row = [];
+                for (let x = 0; x < config.size; x++) {
+                    const index = y * config.size + x;
+                    const cell = document.createElement('button');
+                    cell.className = 'cell';
+                    cell.dataset.x = x;
+                    cell.dataset.y = y;
+                    cell.setAttribute('aria-label', '감춰진 칸');
+                    cell.addEventListener('click', onCellClick);
+                    cell.addEventListener('contextmenu', onCellRightClick);
+                    boardEl.appendChild(cell);
+                    row.push({
+                        element: cell,
+                        revealed: false,
+                        flagged: false,
+                        mine: mineLocations.has(index),
+                        adjacent: 0
+                    });
+                }
+                board.push(row);
+            }
+
+            for (let y = 0; y < config.size; y++) {
+                for (let x = 0; x < config.size; x++) {
+                    board[y][x].adjacent = countAdjacentMines(x, y);
+                }
+            }
+
+            updateMineCounter();
+        }
+
+        function countAdjacentMines(x, y) {
+            let count = 0;
+            for (let dy = -1; dy <= 1; dy++) {
+                for (let dx = -1; dx <= 1; dx++) {
+                    if (!dx && !dy) continue;
+                    const nx = x + dx;
+                    const ny = y + dy;
+                    if (nx >= 0 && nx < config.size && ny >= 0 && ny < config.size) {
+                        if (board[ny][nx].mine) count++;
+                    }
+                }
+            }
+            return count;
+        }
+
+        function startTimer() {
+            if (startTime) return;
+            startTime = Date.now();
+            timerInterval = setInterval(() => {
+                const elapsed = Math.floor((Date.now() - startTime) / 1000);
+                timeEl.textContent = elapsed;
+            }, 1000);
+        }
+
+        function revealCell(x, y) {
+            const cell = board[y][x];
+            if (cell.revealed || cell.flagged || gameOver) return;
+            if (!startTime) startTimer();
+
+            cell.revealed = true;
+            revealedCount++;
+            cell.element.classList.add('revealed');
+            cell.element.setAttribute('aria-label', '열린 칸');
+            cell.element.disabled = true;
+
+            if (cell.mine) {
+                cell.element.classList.add('mine');
+                cell.element.textContent = '💣';
+                triggerGameOver(false);
+                return;
+            }
+
+            if (cell.adjacent > 0) {
+                cell.element.textContent = cell.adjacent;
+                cell.element.style.color = ['#cddc39', '#4dd0e1', '#29b6f6', '#ff7043', '#ef5350', '#ab47bc', '#ffa726', '#ffca28'][cell.adjacent - 1];
+            } else {
+                floodReveal(x, y);
+            }
+
+            if (revealedCount === config.size * config.size - config.mines) {
+                triggerGameOver(true);
+            }
+        }
+
+        function floodReveal(x, y) {
+            const queue = [[x, y]];
+            while (queue.length) {
+                const [cx, cy] = queue.shift();
+                for (let dy = -1; dy <= 1; dy++) {
+                for (let dx = -1; dx <= 1; dx++) {
+                    if (!dx && !dy) continue;
+                    const nx = cx + dx;
+                    const ny = cy + dy;
+                        if (nx < 0 || ny < 0 || nx >= config.size || ny >= config.size) continue;
+                        const neighbor = board[ny][nx];
+                        if (neighbor.revealed || neighbor.flagged || neighbor.mine) continue;
+                        neighbor.revealed = true;
+                        neighbor.element.classList.add('revealed');
+                        neighbor.element.disabled = true;
+                        revealedCount++;
+                        if (neighbor.adjacent > 0) {
+                            neighbor.element.textContent = neighbor.adjacent;
+                            neighbor.element.style.color = ['#cddc39', '#4dd0e1', '#29b6f6', '#ff7043', '#ef5350', '#ab47bc', '#ffa726', '#ffca28'][neighbor.adjacent - 1];
+                        } else {
+                            queue.push([nx, ny]);
+                        }
+                    }
+                }
+            }
+        }
+
+        function toggleFlag(x, y) {
+            const cell = board[y][x];
+            if (cell.revealed || gameOver) return;
+            if (!cell.flagged && flagsPlaced >= config.mines) return;
+
+            cell.flagged = !cell.flagged;
+            cell.element.classList.toggle('flagged', cell.flagged);
+            cell.element.textContent = cell.flagged ? '🚩' : '';
+            flagsPlaced += cell.flagged ? 1 : -1;
+            updateMineCounter();
+        }
+
+        function updateMineCounter() {
+            minesEl.textContent = Math.max(0, config.mines - flagsPlaced);
+        }
+
+        function onCellClick(event) {
+            const x = Number(this.dataset.x);
+            const y = Number(this.dataset.y);
+            if (flagMode || event.shiftKey) {
+                toggleFlag(x, y);
+            } else {
+                revealCell(x, y);
+            }
+        }
+
+        function onCellRightClick(event) {
+            event.preventDefault();
+            const x = Number(this.dataset.x);
+            const y = Number(this.dataset.y);
+            toggleFlag(x, y);
+        }
+
+        function triggerGameOver(win) {
+            gameOver = true;
+            clearInterval(timerInterval);
+            board.flat().forEach(cell => {
+                cell.element.disabled = true;
+                if (cell.mine && !cell.revealed) {
+                    cell.element.textContent = '💣';
+                    cell.element.classList.add('mine');
+                }
+            });
+            setTimeout(() => {
+                alert(win ? `축하합니다! ${timeEl.textContent}초 만에 승리했습니다.` : '지뢰를 밟았습니다! 다시 도전해 보세요.');
+            }, 50);
+        }
+
+        difficultyEl.addEventListener('change', () => {
+            config = configs[difficultyEl.value];
+            buildBoard();
+        });
+
+        flagButton.addEventListener('click', () => {
+            flagMode = !flagMode;
+            flagButton.classList.toggle('active', flagMode);
+        });
+
+        document.addEventListener('keydown', e => {
+            if (e.key === 'r') {
+                buildBoard();
+            }
+        });
+
+        buildBoard();
+    </script>
+</body>
+</html>

--- a/game/nebulous/index.html
+++ b/game/nebulous/index.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>세포 성장 실험 (Nebulous)</title>
+    <style>
+        body {
+            margin: 0;
+            overflow: hidden;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+            background: radial-gradient(circle at center, #1a2a6c 0%, #16213e 45%, #0f172a 100%);
+            color: #e0f2ff;
+        }
+        header {
+            position: fixed;
+            top: 20px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: rgba(13, 26, 45, 0.75);
+            padding: 12px 24px;
+            border-radius: 999px;
+            backdrop-filter: blur(8px);
+            display: flex;
+            gap: 18px;
+            align-items: center;
+            box-shadow: 0 15px 35px rgba(0,0,0,0.4);
+        }
+        header strong {
+            font-size: 18px;
+        }
+        #game {
+            display: block;
+        }
+        .hint {
+            position: fixed;
+            bottom: 24px;
+            left: 50%;
+            transform: translateX(-50%);
+            font-size: 14px;
+            color: rgba(224, 242, 255, 0.75);
+            background: rgba(15, 23, 42, 0.65);
+            padding: 10px 16px;
+            border-radius: 999px;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <strong>세포 성장 실험</strong>
+        <span>크기: <span id="size">10</span></span>
+        <span>흡수한 입자: <span id="score">0</span></span>
+        <span>위험 세포: <span id="danger">0</span> / <span id="danger-total">0</span></span>
+    </header>
+    <canvas id="game"></canvas>
+    <div class="hint">마우스를 움직여 세포를 조종하고 작은 입자를 흡수하세요. 큰 세포를 피하세요!</div>
+
+    <script>
+        const canvas = document.getElementById('game');
+        const ctx = canvas.getContext('2d');
+        const sizeEl = document.getElementById('size');
+        const scoreEl = document.getElementById('score');
+        const dangerEl = document.getElementById('danger');
+        const dangerTotalEl = document.getElementById('danger-total');
+
+        const WORLD_SIZE = 2800;
+        const pelletCount = 250;
+        const enemyCount = 8;
+        const pellets = [];
+        const enemies = [];
+        const colors = ['#22d3ee', '#fb7185', '#a855f7', '#34d399', '#fbbf24'];
+
+        const player = {
+            x: WORLD_SIZE / 2,
+            y: WORLD_SIZE / 2,
+            radius: 24,
+            speed: 2.2,
+            mass: 24
+        };
+        let score = 0;
+        let pointer = { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+
+        function resize() {
+            canvas.width = window.innerWidth;
+            canvas.height = window.innerHeight;
+        }
+
+        window.addEventListener('resize', resize);
+        resize();
+
+        function spawnPellets() {
+            pellets.length = 0;
+            for (let i = 0; i < pelletCount; i++) {
+                pellets.push({
+                    x: Math.random() * WORLD_SIZE,
+                    y: Math.random() * WORLD_SIZE,
+                    radius: 6,
+                    color: colors[Math.floor(Math.random() * colors.length)]
+                });
+            }
+        }
+
+        function spawnEnemies() {
+            enemies.length = 0;
+            for (let i = 0; i < enemyCount; i++) {
+                const radius = 20 + Math.random() * 120;
+                enemies.push({
+                    x: Math.random() * WORLD_SIZE,
+                    y: Math.random() * WORLD_SIZE,
+                    radius,
+                    color: colors[Math.floor(Math.random() * colors.length)],
+                    speed: Math.max(0.4, 2.4 - radius / 80),
+                    angle: Math.random() * Math.PI * 2
+                });
+            }
+            dangerTotalEl.textContent = enemyCount;
+        }
+
+        function movePlayer() {
+            const targetX = pointer.x - canvas.width / 2;
+            const targetY = pointer.y - canvas.height / 2;
+            const len = Math.hypot(targetX, targetY);
+            const maxSpeed = Math.max(1.2, 4 - player.radius / 30);
+            if (len > 5) {
+                const vx = (targetX / len) * maxSpeed;
+                const vy = (targetY / len) * maxSpeed;
+                player.x += vx;
+                player.y += vy;
+            }
+            player.x = Math.max(player.radius, Math.min(WORLD_SIZE - player.radius, player.x));
+            player.y = Math.max(player.radius, Math.min(WORLD_SIZE - player.radius, player.y));
+        }
+
+        function moveEnemies() {
+            let dangerous = 0;
+            enemies.forEach(enemy => {
+                enemy.angle += (Math.random() - 0.5) * 0.2;
+                enemy.x += Math.cos(enemy.angle) * enemy.speed;
+                enemy.y += Math.sin(enemy.angle) * enemy.speed;
+                enemy.x = (enemy.x + WORLD_SIZE) % WORLD_SIZE;
+                enemy.y = (enemy.y + WORLD_SIZE) % WORLD_SIZE;
+                const dist = Math.hypot(enemy.x - player.x, enemy.y - player.y);
+                if (enemy.radius > player.radius * 1.15 && dist < 480) {
+                    enemy.angle = Math.atan2(player.y - enemy.y, player.x - enemy.x);
+                    dangerous++;
+                } else if (enemy.radius < player.radius && dist < 420) {
+                    enemy.angle = Math.atan2(enemy.y - player.y, enemy.x - player.x);
+                }
+            });
+            dangerEl.textContent = dangerous;
+        }
+
+        function handleCollisions() {
+            for (let i = pellets.length - 1; i >= 0; i--) {
+                const pellet = pellets[i];
+                if (Math.hypot(pellet.x - player.x, pellet.y - player.y) < player.radius) {
+                    pellets.splice(i, 1);
+                    score++;
+                    player.radius = Math.min(player.radius + 0.3, 180);
+                    updateHUD();
+                }
+            }
+            for (let i = enemies.length - 1; i >= 0; i--) {
+                const enemy = enemies[i];
+                const dist = Math.hypot(enemy.x - player.x, enemy.y - player.y);
+                if (dist < player.radius) {
+                    if (enemy.radius < player.radius * 0.85) {
+                        player.radius += enemy.radius * 0.2;
+                        enemies.splice(i, 1);
+                        score += Math.floor(enemy.radius);
+                        updateHUD();
+                    } else {
+                        alert('더 큰 세포에 흡수당했습니다! 점수: ' + score);
+                        resetGame();
+                        return;
+                    }
+                }
+            }
+            if (pellets.length < pelletCount) {
+                spawnPellets();
+            }
+            if (enemies.length < enemyCount) {
+                spawnEnemies();
+            }
+        }
+
+        function drawWorld() {
+            ctx.save();
+            const offsetX = canvas.width / 2 - player.x;
+            const offsetY = canvas.height / 2 - player.y;
+            ctx.translate(offsetX, offsetY);
+
+            const gridSize = 120;
+            ctx.strokeStyle = 'rgba(148, 163, 184, 0.15)';
+            ctx.lineWidth = 1;
+            for (let x = 0; x <= WORLD_SIZE; x += gridSize) {
+                ctx.beginPath();
+                ctx.moveTo(x, 0);
+                ctx.lineTo(x, WORLD_SIZE);
+                ctx.stroke();
+            }
+            for (let y = 0; y <= WORLD_SIZE; y += gridSize) {
+                ctx.beginPath();
+                ctx.moveTo(0, y);
+                ctx.lineTo(WORLD_SIZE, y);
+                ctx.stroke();
+            }
+
+            pellets.forEach(pellet => {
+                ctx.fillStyle = pellet.color;
+                ctx.beginPath();
+                ctx.arc(pellet.x, pellet.y, pellet.radius, 0, Math.PI * 2);
+                ctx.fill();
+            });
+
+            enemies.forEach(enemy => {
+                const gradient = ctx.createRadialGradient(enemy.x, enemy.y, enemy.radius * 0.3, enemy.x, enemy.y, enemy.radius);
+                gradient.addColorStop(0, enemy.color);
+                gradient.addColorStop(1, 'rgba(15, 23, 42, 0.8)');
+                ctx.fillStyle = gradient;
+                ctx.beginPath();
+                ctx.arc(enemy.x, enemy.y, enemy.radius, 0, Math.PI * 2);
+                ctx.fill();
+            });
+
+            const gradient = ctx.createRadialGradient(player.x, player.y, player.radius * 0.4, player.x, player.y, player.radius);
+            gradient.addColorStop(0, '#38bdf8');
+            gradient.addColorStop(1, '#0ea5e9');
+            ctx.fillStyle = gradient;
+            ctx.beginPath();
+            ctx.arc(player.x, player.y, player.radius, 0, Math.PI * 2);
+            ctx.fill();
+
+            ctx.restore();
+        }
+
+        function updateHUD() {
+            sizeEl.textContent = Math.round(player.radius);
+            scoreEl.textContent = score;
+        }
+
+        function resetGame() {
+            player.x = WORLD_SIZE / 2;
+            player.y = WORLD_SIZE / 2;
+            player.radius = 24;
+            score = 0;
+            spawnPellets();
+            spawnEnemies();
+            updateHUD();
+        }
+
+        canvas.addEventListener('mousemove', (e) => {
+            pointer = { x: e.clientX, y: e.clientY };
+        });
+
+        canvas.addEventListener('touchmove', (e) => {
+            const touch = e.touches[0];
+            pointer = { x: touch.clientX, y: touch.clientY };
+        }, { passive: false });
+
+        function loop() {
+            movePlayer();
+            moveEnemies();
+            handleCollisions();
+            drawWorld();
+            requestAnimationFrame(loop);
+        }
+
+        resetGame();
+        updateHUD();
+        loop();
+    </script>
+</body>
+</html>

--- a/game/pong/index.html
+++ b/game/pong/index.html
@@ -1,0 +1,180 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>레이저 핑퐁</title>
+    <style>
+        body {
+            margin: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            background: conic-gradient(from 120deg, #111827, #1f2937, #111827);
+            color: #f3f4f6;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+        }
+        .frame {
+            background: rgba(11, 22, 34, 0.88);
+            border-radius: 20px;
+            padding: 24px;
+            box-shadow: 0 25px 60px rgba(0,0,0,0.55);
+            display: grid;
+            gap: 16px;
+        }
+        canvas {
+            background: rgba(2, 6, 14, 0.94);
+            border-radius: 16px;
+            border: 4px solid rgba(255,255,255,0.08);
+            image-rendering: pixelated;
+        }
+        .info {
+            display: flex;
+            justify-content: space-between;
+            font-size: 16px;
+            color: rgba(243, 244, 246, 0.85);
+        }
+        .hint {
+            font-size: 14px;
+            color: rgba(209, 213, 219, 0.7);
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+    <div class="frame">
+        <div class="info">
+            <span>플레이어: <strong id="player-score">0</strong></span>
+            <span>AI: <strong id="ai-score">0</strong></span>
+        </div>
+        <canvas id="game" width="640" height="360"></canvas>
+        <p class="hint">마우스나 터치로 패들을 움직여 공을 튕겨내세요. 10점을 먼저 획득하면 승리!</p>
+    </div>
+
+    <script>
+        const canvas = document.getElementById('game');
+        const ctx = canvas.getContext('2d');
+        const playerScoreEl = document.getElementById('player-score');
+        const aiScoreEl = document.getElementById('ai-score');
+
+        const paddle = { width: 14, height: 90 };
+        const player = { x: 20, y: canvas.height / 2 - paddle.height / 2, score: 0 };
+        const ai = { x: canvas.width - 20 - paddle.width, y: canvas.height / 2 - paddle.height / 2, score: 0, speed: 4 };
+        const ball = { x: canvas.width / 2, y: canvas.height / 2, radius: 8, speed: 5, vx: 4, vy: 3 };
+
+        let targetY = player.y;
+
+        canvas.addEventListener('mousemove', e => {
+            const rect = canvas.getBoundingClientRect();
+            targetY = e.clientY - rect.top - paddle.height / 2;
+        });
+        canvas.addEventListener('touchmove', e => {
+            const rect = canvas.getBoundingClientRect();
+            targetY = e.touches[0].clientY - rect.top - paddle.height / 2;
+        }, { passive: false });
+
+        function clamp(value, min, max) {
+            return Math.max(min, Math.min(max, value));
+        }
+
+        function resetBall(direction = 1) {
+            ball.x = canvas.width / 2;
+            ball.y = canvas.height / 2;
+            const angle = (Math.random() * Math.PI / 3) - Math.PI / 6;
+            const speed = 5 + Math.random() * 1.5;
+            ball.vx = Math.cos(angle) * speed * direction;
+            ball.vy = Math.sin(angle) * speed;
+        }
+
+        function update() {
+            player.y += (targetY - player.y) * 0.2;
+            player.y = clamp(player.y, 0, canvas.height - paddle.height);
+
+            const aiCenter = ai.y + paddle.height / 2;
+            if (ball.y < aiCenter - 20) ai.y -= ai.speed;
+            else if (ball.y > aiCenter + 20) ai.y += ai.speed;
+            ai.y = clamp(ai.y, 0, canvas.height - paddle.height);
+
+            ball.x += ball.vx;
+            ball.y += ball.vy;
+
+            if (ball.y - ball.radius <= 0 || ball.y + ball.radius >= canvas.height) {
+                ball.vy *= -1;
+            }
+
+            function paddleCollision(p) {
+                if (
+                    ball.x - ball.radius < p.x + paddle.width &&
+                    ball.x + ball.radius > p.x &&
+                    ball.y + ball.radius > p.y &&
+                    ball.y - ball.radius < p.y + paddle.height
+                ) {
+                    const relativeIntersectY = (ball.y - (p.y + paddle.height / 2)) / (paddle.height / 2);
+                    const bounceAngle = relativeIntersectY * (Math.PI / 3);
+                    const direction = p === player ? 1 : -1;
+                    const speed = Math.min(10, Math.hypot(ball.vx, ball.vy) + 0.4);
+                    ball.vx = Math.cos(bounceAngle) * speed * direction;
+                    ball.vy = Math.sin(bounceAngle) * speed;
+                    ball.x = p === player ? p.x + paddle.width + ball.radius : p.x - ball.radius;
+                }
+            }
+
+            paddleCollision(player);
+            paddleCollision(ai);
+
+            if (ball.x < 0) {
+                ai.score++;
+                aiScoreEl.textContent = ai.score;
+                resetBall(1);
+            } else if (ball.x > canvas.width) {
+                player.score++;
+                playerScoreEl.textContent = player.score;
+                resetBall(-1);
+            }
+
+            if (player.score >= 10 || ai.score >= 10) {
+                alert((player.score > ai.score ? '플레이어 승리!' : 'AI 승리!') + ` (플레이어 ${player.score} : ${ai.score} AI)`);
+                player.score = 0;
+                ai.score = 0;
+                playerScoreEl.textContent = player.score;
+                aiScoreEl.textContent = ai.score;
+                resetBall(Math.random() < 0.5 ? 1 : -1);
+            }
+        }
+
+        function draw() {
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            const gradient = ctx.createLinearGradient(0, 0, canvas.width, canvas.height);
+            gradient.addColorStop(0, 'rgba(59, 130, 246, 0.2)');
+            gradient.addColorStop(1, 'rgba(236, 72, 153, 0.2)');
+            ctx.fillStyle = gradient;
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+            ctx.fillStyle = 'rgba(148, 163, 184, 0.35)';
+            for (let y = 0; y < canvas.height; y += 24) {
+                ctx.fillRect(canvas.width / 2 - 2, y, 4, 12);
+            }
+
+            ctx.fillStyle = '#38bdf8';
+            ctx.fillRect(player.x, player.y, paddle.width, paddle.height);
+            ctx.fillStyle = '#f472b6';
+            ctx.fillRect(ai.x, ai.y, paddle.width, paddle.height);
+
+            ctx.beginPath();
+            ctx.fillStyle = '#f8fafc';
+            ctx.arc(ball.x, ball.y, ball.radius, 0, Math.PI * 2);
+            ctx.fill();
+        }
+
+        function loop() {
+            update();
+            draw();
+            requestAnimationFrame(loop);
+        }
+
+        resetBall(Math.random() < 0.5 ? 1 : -1);
+        loop();
+    </script>
+</body>
+</html>

--- a/game/runner/index.html
+++ b/game/runner/index.html
@@ -1,0 +1,316 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>스카이 러너</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: linear-gradient(180deg, #0c1445 0%, #1b2b6b 40%, #0b1329 100%);
+            color: #f5f6fa;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+        }
+        .container {
+            background: rgba(10, 16, 36, 0.9);
+            padding: 30px;
+            border-radius: 28px;
+            box-shadow: 0 28px 70px rgba(0, 0, 0, 0.55);
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+            align-items: center;
+        }
+        canvas {
+            border-radius: 20px;
+            border: 6px solid rgba(255, 255, 255, 0.08);
+            background: linear-gradient(180deg, #2f80ed 0%, #56ccf2 55%, #ecf8ff 56%, #f3f9ff 100%);
+        }
+        h1 {
+            margin: 0;
+            font-size: 28px;
+        }
+        .stats {
+            display: flex;
+            gap: 20px;
+            font-weight: 600;
+        }
+        button {
+            background: linear-gradient(135deg, #c471ed, #f7797d);
+            color: #1f0b2f;
+            border: none;
+            border-radius: 999px;
+            padding: 10px 24px;
+            font-weight: 700;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 18px 28px rgba(247, 121, 125, 0.35);
+        }
+        p {
+            margin: 0;
+            font-size: 14px;
+            color: rgba(255, 255, 255, 0.75);
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>스카이 러너</h1>
+        <div class="stats">
+            <div>거리: <span id="distance">0</span>m</div>
+            <div>최고: <span id="best">0</span>m</div>
+            <div>속도: <span id="speed">0</span>m/s</div>
+        </div>
+        <canvas id="game" width="640" height="360"></canvas>
+        <button id="restart">다시 시작</button>
+        <p>스페이스/위 키로 점프, 아래 키로 구르기. 장애물을 피하며 더 멀리 달려 보세요!</p>
+    </div>
+
+    <script>
+        const canvas = document.getElementById('game');
+        const ctx = canvas.getContext('2d');
+        const distanceEl = document.getElementById('distance');
+        const bestEl = document.getElementById('best');
+        const speedEl = document.getElementById('speed');
+        const restartBtn = document.getElementById('restart');
+
+        const WIDTH = canvas.width;
+        const HEIGHT = canvas.height;
+
+        const GROUND = HEIGHT - 60;
+        const GRAVITY = 0.0022;
+        const JUMP_FORCE = -0.95;
+
+        let player;
+        let obstacles;
+        let clouds;
+        let distance;
+        let speed;
+        let best = Number(localStorage.getItem('runner-best')) || 0;
+        let running = false;
+        let lastTime = 0;
+        let slideTimer = 0;
+
+        const keys = new Set();
+
+        bestEl.textContent = best;
+
+        function resetGame() {
+            player = { x: 120, y: GROUND, vy: 0, width: 44, height: 64, sliding: false };
+            obstacles = [];
+            clouds = Array.from({ length: 5 }, () => ({
+                x: Math.random() * WIDTH,
+                y: 40 + Math.random() * 120,
+                speed: 0.02 + Math.random() * 0.05
+            }));
+            distance = 0;
+            speed = 0.25;
+            running = true;
+            lastTime = performance.now();
+            slideTimer = 0;
+            updateObstacles.nextSpawn = 600;
+            updateUI();
+        }
+
+        function updateUI() {
+            distanceEl.textContent = Math.floor(distance);
+            speedEl.textContent = speed.toFixed(2);
+        }
+
+        function spawnObstacle() {
+            const types = [
+                { width: 30, height: 60, yOffset: 0 },
+                { width: 54, height: 40, yOffset: 20 },
+                { width: 40, height: 32, yOffset: 28 }
+            ];
+            const type = types[Math.floor(Math.random() * types.length)];
+            obstacles.push({
+                x: WIDTH + 40,
+                width: type.width,
+                height: type.height,
+                y: GROUND - type.height + type.yOffset,
+                scored: false
+            });
+        }
+
+        function updateClouds(delta) {
+            clouds.forEach(cloud => {
+                cloud.x -= cloud.speed * delta;
+                if (cloud.x < -80) {
+                    cloud.x = WIDTH + Math.random() * 80;
+                    cloud.y = 40 + Math.random() * 120;
+                    cloud.speed = 0.02 + Math.random() * 0.05;
+                }
+            });
+        }
+
+        function updateObstacles(delta) {
+            const spawnInterval = Math.max(900 - distance * 2, 360);
+            if (!updateObstacles.nextSpawn) updateObstacles.nextSpawn = spawnInterval;
+            updateObstacles.nextSpawn -= delta;
+            if (updateObstacles.nextSpawn <= 0) {
+                spawnObstacle();
+                updateObstacles.nextSpawn = spawnInterval;
+            }
+            obstacles = obstacles.filter(obs => {
+                obs.x -= speed * delta * 1.4;
+                if (!obs.scored && obs.x + obs.width < player.x) {
+                    obs.scored = true;
+                    distance += 5;
+                }
+                return obs.x + obs.width > -20;
+            });
+        }
+
+        function handleInput(delta) {
+            if ((keys.has(' ') || keys.has('Space') || keys.has('ArrowUp')) && player.y >= GROUND) {
+                player.vy = JUMP_FORCE;
+                player.y = GROUND - 1;
+            }
+            if (keys.has('ArrowDown') && player.y >= GROUND - 1) {
+                player.sliding = true;
+                slideTimer += delta;
+                if (slideTimer > 600) {
+                    slideTimer = 0;
+                    player.sliding = false;
+                }
+            } else {
+                player.sliding = false;
+                slideTimer = 0;
+            }
+        }
+
+        function updatePlayer(delta) {
+            handleInput(delta);
+            player.vy += GRAVITY * delta;
+            player.y += player.vy * delta;
+            if (player.y >= GROUND) {
+                player.y = GROUND;
+                player.vy = 0;
+            }
+            updateUI();
+        }
+
+        function detectCollision(obstacle) {
+            const playerHeight = player.sliding ? player.height * 0.55 : player.height;
+            const playerTop = player.y - playerHeight;
+            const playerBottom = player.y;
+            const playerLeft = player.x - player.width / 2;
+            const playerRight = player.x + player.width / 2;
+            const obstacleTop = obstacle.y - obstacle.height;
+            const obstacleBottom = obstacle.y;
+            const obstacleLeft = obstacle.x;
+            const obstacleRight = obstacle.x + obstacle.width;
+            return !(playerRight < obstacleLeft || playerLeft > obstacleRight || playerBottom < obstacleTop || playerTop > obstacleBottom);
+        }
+
+        function drawBackground() {
+            ctx.fillStyle = '#90e0ff';
+            ctx.fillRect(0, 0, WIDTH, HEIGHT);
+            ctx.fillStyle = '#fff';
+            clouds.forEach(cloud => {
+                ctx.globalAlpha = 0.6;
+                ctx.beginPath();
+                ctx.arc(cloud.x, cloud.y, 24, Math.PI, 0);
+                ctx.arc(cloud.x + 24, cloud.y, 24, Math.PI, 0);
+                ctx.arc(cloud.x + 48, cloud.y, 24, Math.PI, 0);
+                ctx.fill();
+                ctx.globalAlpha = 1;
+            });
+            ctx.fillStyle = '#0f3d66';
+            ctx.fillRect(0, HEIGHT - 60, WIDTH, 60);
+            ctx.fillStyle = '#1f5a8a';
+            ctx.fillRect(0, HEIGHT - 56, WIDTH, 4);
+        }
+
+        function drawPlayer() {
+            ctx.save();
+            ctx.translate(player.x, player.y);
+            const height = player.sliding ? player.height * 0.55 : player.height;
+            ctx.fillStyle = '#f8cdda';
+            ctx.fillRect(-player.width / 2, -height, player.width, height);
+            ctx.fillStyle = '#ff5f6d';
+            ctx.fillRect(-player.width / 2, -height, player.width, 16);
+            ctx.restore();
+        }
+
+        function drawObstacles() {
+            ctx.fillStyle = '#ffd166';
+            obstacles.forEach(obs => {
+                ctx.fillRect(obs.x, obs.y - obs.height, obs.width, obs.height);
+                ctx.fillStyle = '#f8961e';
+                ctx.fillRect(obs.x, obs.y - 8, obs.width, 8);
+                ctx.fillStyle = '#ffd166';
+            });
+        }
+
+        function update(time = 0) {
+            if (!running) return;
+            const delta = time - lastTime;
+            lastTime = time;
+            speed += delta * 0.00002;
+            distance += speed * delta * 0.01;
+            updateClouds(delta);
+            updateObstacles(delta);
+            updatePlayer(delta);
+            drawBackground();
+            drawObstacles();
+            drawPlayer();
+            if (obstacles.some(detectCollision)) {
+                endGame();
+                return;
+            }
+            requestAnimationFrame(update);
+        }
+
+        function endGame() {
+            running = false;
+            best = Math.max(best, Math.floor(distance));
+            localStorage.setItem('runner-best', best);
+            bestEl.textContent = best;
+            ctx.fillStyle = 'rgba(0, 0, 0, 0.55)';
+            ctx.fillRect(0, 0, WIDTH, HEIGHT);
+            ctx.fillStyle = '#f5f6fa';
+            ctx.font = '28px Pretendard, sans-serif';
+            ctx.textAlign = 'center';
+            ctx.fillText('게임 오버', WIDTH / 2, HEIGHT / 2 - 12);
+            ctx.font = '18px Pretendard, sans-serif';
+            ctx.fillText(`거리: ${Math.floor(distance)}m`, WIDTH / 2, HEIGHT / 2 + 20);
+        }
+
+        restartBtn.addEventListener('click', () => {
+            resetGame();
+            requestAnimationFrame(update);
+        });
+
+        document.addEventListener('keydown', e => {
+            keys.add(e.key);
+            if (e.key === ' ') e.preventDefault();
+            if (!running) {
+                resetGame();
+                requestAnimationFrame(update);
+            }
+        });
+        document.addEventListener('keyup', e => {
+            keys.delete(e.key);
+        });
+
+        resetGame();
+        running = false;
+        drawBackground();
+        drawObstacles();
+        drawPlayer();
+    </script>
+</body>
+</html>

--- a/game/sand-tetris/index.html
+++ b/game/sand-tetris/index.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>모래 테트리스 실험실</title>
+    <style>
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: radial-gradient(circle at 30% 20%, #0f2027, #203a43 60%, #2c5364);
+            color: #eaf6ff;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+        }
+        .layout {
+            display: grid;
+            gap: 24px;
+            background: rgba(5, 18, 26, 0.9);
+            padding: 32px;
+            border-radius: 24px;
+            box-shadow: 0 25px 50px rgba(0,0,0,0.5);
+        }
+        canvas {
+            border-radius: 18px;
+            border: 6px solid rgba(255,255,255,0.08);
+            background: linear-gradient(180deg, rgba(12,26,35,0.8), rgba(6,14,20,0.95));
+            image-rendering: pixelated;
+        }
+        .controls {
+            display: flex;
+            gap: 12px;
+            flex-wrap: wrap;
+        }
+        button {
+            background: linear-gradient(135deg, #00b4db, #0083b0);
+            color: #021218;
+            border: none;
+            border-radius: 999px;
+            padding: 10px 20px;
+            font-weight: 700;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 12px 20px rgba(0, 132, 176, 0.35);
+        }
+        .info {
+            max-width: 420px;
+            line-height: 1.6;
+            font-size: 14px;
+            color: rgba(234, 246, 255, 0.8);
+        }
+        strong { color: #9be7ff; }
+    </style>
+</head>
+<body>
+    <div class="layout">
+        <canvas id="board" width="320" height="480"></canvas>
+        <div class="controls">
+            <button id="dropShape">랜덤 블록 떨어뜨리기</button>
+            <button id="clear">초기화</button>
+        </div>
+        <div class="info">
+            <p><strong>사용 방법</strong></p>
+            <ul>
+                <li>마우스로 화면을 드래그하면 모래를 뿌릴 수 있습니다.</li>
+                <li>랜덤 블록 버튼을 누르면 테트리스 모양의 굳은 블록이 등장합니다.</li>
+                <li>모래는 중력에 따라 흘러내리고, 굳은 블록은 지형을 지탱합니다.</li>
+                <li>공간을 창의적으로 채우며 지형을 만들어 보세요!</li>
+            </ul>
+        </div>
+    </div>
+
+    <script>
+        const canvas = document.getElementById('board');
+        const ctx = canvas.getContext('2d');
+        const gridWidth = 32;
+        const gridHeight = 48;
+        const cellSize = canvas.width / gridWidth;
+        const sandColor = '#f1c27d';
+        const blockColor = '#4dd0e1';
+        const settledColor = '#80cbc4';
+
+        const grid = Array.from({ length: gridHeight }, () => Array(gridWidth).fill(0));
+        let dragging = false;
+        let currentShape = null;
+
+        const SHAPES = [
+            [[1, 1, 1, 1]],
+            [[1, 0, 0], [1, 1, 1]],
+            [[0, 0, 1], [1, 1, 1]],
+            [[1, 1], [1, 1]],
+            [[0, 1, 1], [1, 1, 0]],
+            [[0, 1, 0], [1, 1, 1]],
+            [[1, 1, 0], [0, 1, 1]]
+        ];
+
+        function spawnShape() {
+            const matrix = SHAPES[Math.floor(Math.random() * SHAPES.length)];
+            currentShape = {
+                matrix: matrix.map(row => [...row]),
+                x: Math.floor((gridWidth - matrix[0].length) / 2),
+                y: -matrix.length,
+                settled: false
+            };
+        }
+
+        function addSand(x, y) {
+            if (x < 0 || x >= gridWidth || y < 0 || y >= gridHeight) return;
+            grid[y][x] = 1;
+        }
+
+        canvas.addEventListener('mousedown', (e) => {
+            dragging = true;
+            addSandFromEvent(e);
+        });
+        window.addEventListener('mouseup', () => dragging = false);
+        canvas.addEventListener('mousemove', (e) => {
+            if (dragging) addSandFromEvent(e);
+        });
+
+        function addSandFromEvent(e) {
+            const rect = canvas.getBoundingClientRect();
+            const x = Math.floor((e.clientX - rect.left) / cellSize);
+            const y = Math.floor((e.clientY - rect.top) / cellSize);
+            for (let dy = -1; dy <= 1; dy++) {
+                for (let dx = -1; dx <= 1; dx++) {
+                    addSand(x + dx, y + dy);
+                }
+            }
+        }
+
+        document.getElementById('dropShape').addEventListener('click', () => {
+            if (!currentShape) spawnShape();
+        });
+
+        document.getElementById('clear').addEventListener('click', () => {
+            for (let y = 0; y < gridHeight; y++) {
+                grid[y].fill(0);
+            }
+            currentShape = null;
+        });
+
+        function updateSand() {
+            for (let y = gridHeight - 2; y >= 0; y--) {
+                for (let x = 0; x < gridWidth; x++) {
+                    if (grid[y][x] === 1) {
+                        if (grid[y + 1][x] === 0) {
+                            grid[y + 1][x] = 1;
+                            grid[y][x] = 0;
+                        } else {
+                            const dir = Math.random() < 0.5 ? -1 : 1;
+                            if (x + dir >= 0 && x + dir < gridWidth && grid[y + 1][x + dir] === 0) {
+                                grid[y + 1][x + dir] = 1;
+                                grid[y][x] = 0;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        function canPlace(matrix, offsetX, offsetY) {
+            for (let y = 0; y < matrix.length; y++) {
+                for (let x = 0; x < matrix[y].length; x++) {
+                    if (!matrix[y][x]) continue;
+                    const gridX = offsetX + x;
+                    const gridY = offsetY + y;
+                    if (gridX < 0 || gridX >= gridWidth) return false;
+                    if (gridY >= gridHeight) return false;
+                    if (gridY >= 0 && grid[gridY][gridX]) return false;
+                }
+            }
+            return true;
+        }
+
+        function settleShape(shape) {
+            shape.matrix.forEach((row, y) => {
+                row.forEach((value, x) => {
+                    if (value) {
+                        const gridX = shape.x + x;
+                        const gridY = shape.y + y;
+                        if (gridY >= 0 && gridY < gridHeight) {
+                            grid[gridY][gridX] = 2;
+                        }
+                    }
+                });
+            });
+        }
+
+        function updateShape() {
+            if (!currentShape) return;
+            if (canPlace(currentShape.matrix, currentShape.x, currentShape.y + 1)) {
+                currentShape.y += 1;
+            } else {
+                settleShape(currentShape);
+                currentShape = null;
+            }
+        }
+
+        function draw() {
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            for (let y = 0; y < gridHeight; y++) {
+                for (let x = 0; x < gridWidth; x++) {
+                    const value = grid[y][x];
+                    if (value) {
+                        ctx.fillStyle = value === 1 ? sandColor : settledColor;
+                        ctx.fillRect(x * cellSize, y * cellSize, cellSize, cellSize);
+                    }
+                }
+            }
+            if (currentShape) {
+                ctx.fillStyle = blockColor;
+                currentShape.matrix.forEach((row, y) => {
+                    row.forEach((value, x) => {
+                        if (value) {
+                            const drawX = (currentShape.x + x) * cellSize;
+                            const drawY = (currentShape.y + y) * cellSize;
+                            ctx.fillRect(drawX, drawY, cellSize, cellSize);
+                        }
+                    });
+                });
+            }
+        }
+
+        function loop() {
+            updateSand();
+            updateShape();
+            draw();
+            requestAnimationFrame(loop);
+        }
+
+        loop();
+    </script>
+</body>
+</html>

--- a/game/snake/index.html
+++ b/game/snake/index.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>지렁이 게임</title>
+    <style>
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: linear-gradient(135deg, #09203f 0%, #537895 100%);
+            color: #ecf0f1;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+        }
+        .panel {
+            text-align: center;
+            background: rgba(9, 32, 63, 0.85);
+            padding: 32px;
+            border-radius: 20px;
+            box-shadow: 0 18px 35px rgba(0, 0, 0, 0.35);
+        }
+        canvas {
+            background: #04101f;
+            border-radius: 16px;
+            border: 6px solid rgba(255, 255, 255, 0.08);
+            box-shadow: inset 0 0 20px rgba(0,0,0,0.5);
+        }
+        h1 {
+            margin-bottom: 16px;
+            letter-spacing: 2px;
+            font-size: 28px;
+        }
+        .score {
+            margin-bottom: 18px;
+            font-size: 20px;
+            font-weight: 600;
+        }
+        .hint {
+            margin-top: 18px;
+            color: rgba(255, 255, 255, 0.7);
+            font-size: 14px;
+        }
+        button {
+            background: #1abc9c;
+            color: #04101f;
+            border: none;
+            border-radius: 999px;
+            padding: 10px 24px;
+            font-weight: 700;
+            cursor: pointer;
+            margin-top: 12px;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 10px 20px rgba(26, 188, 156, 0.35);
+        }
+    </style>
+</head>
+<body>
+    <div class="panel">
+        <h1>지렁이 게임</h1>
+        <div class="score">점수: <span id="score">0</span></div>
+        <canvas id="board" width="400" height="400"></canvas>
+        <button id="restart">다시 시작</button>
+        <p class="hint">방향키로 조작하세요. 벽이나 몸에 부딪히면 게임이 종료됩니다.</p>
+    </div>
+
+    <script>
+        const canvas = document.getElementById('board');
+        const ctx = canvas.getContext('2d');
+        const gridSize = 20;
+        const tileCount = canvas.width / gridSize;
+        const scoreEl = document.getElementById('score');
+        const restartBtn = document.getElementById('restart');
+
+        let snake, direction, food, score, speed, frameId;
+
+        function init() {
+            snake = [
+                { x: 9, y: 10 },
+                { x: 8, y: 10 },
+                { x: 7, y: 10 }
+            ];
+            direction = { x: 1, y: 0 };
+            score = 0;
+            speed = 150;
+            placeFood();
+            updateScore();
+            if (frameId) cancelAnimationFrame(frameId);
+            loop();
+        }
+
+        function placeFood() {
+            do {
+                food = {
+                    x: Math.floor(Math.random() * tileCount),
+                    y: Math.floor(Math.random() * tileCount)
+                };
+            } while (snake.some(part => part.x === food.x && part.y === food.y));
+        }
+
+        function updateScore() {
+            scoreEl.textContent = score;
+        }
+
+        let lastRender = 0;
+        function loop(timestamp = 0) {
+            frameId = requestAnimationFrame(loop);
+            if (timestamp - lastRender < speed) return;
+            lastRender = timestamp;
+
+            const head = { x: snake[0].x + direction.x, y: snake[0].y + direction.y };
+            if (head.x < 0) head.x = tileCount - 1;
+            if (head.y < 0) head.y = tileCount - 1;
+            if (head.x >= tileCount) head.x = 0;
+            if (head.y >= tileCount) head.y = 0;
+
+            if (snake.some(part => part.x === head.x && part.y === head.y)) {
+                gameOver();
+                return;
+            }
+
+            snake.unshift(head);
+            if (head.x === food.x && head.y === food.y) {
+                score += 10;
+                speed = Math.max(60, speed - 5);
+                placeFood();
+                updateScore();
+            } else {
+                snake.pop();
+            }
+
+            draw();
+        }
+
+        function draw() {
+            ctx.fillStyle = '#020811';
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+            ctx.fillStyle = '#ff5252';
+            ctx.shadowBlur = 20;
+            ctx.shadowColor = '#ff5252aa';
+            ctx.fillRect(food.x * gridSize, food.y * gridSize, gridSize, gridSize);
+            ctx.shadowBlur = 0;
+
+            snake.forEach((segment, index) => {
+                const t = index / snake.length;
+                const hue = 150 + t * 120;
+                ctx.fillStyle = `hsl(${hue}, 70%, ${60 - t * 20}%)`;
+                ctx.fillRect(segment.x * gridSize, segment.y * gridSize, gridSize - 2, gridSize - 2);
+            });
+        }
+
+        function gameOver() {
+            cancelAnimationFrame(frameId);
+            ctx.fillStyle = 'rgba(0, 0, 0, 0.7)';
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+            ctx.fillStyle = '#ecf0f1';
+            ctx.font = '28px Pretendard, sans-serif';
+            ctx.textAlign = 'center';
+            ctx.fillText('게임 오버!', canvas.width / 2, canvas.height / 2 - 10);
+            ctx.font = '18px Pretendard, sans-serif';
+            ctx.fillText('다시 시작 버튼을 눌러 재도전하세요.', canvas.width / 2, canvas.height / 2 + 24);
+        }
+
+        window.addEventListener('keydown', (e) => {
+            const { key } = e;
+            if (key === 'ArrowUp' && direction.y === 0) direction = { x: 0, y: -1 };
+            else if (key === 'ArrowDown' && direction.y === 0) direction = { x: 0, y: 1 };
+            else if (key === 'ArrowLeft' && direction.x === 0) direction = { x: -1, y: 0 };
+            else if (key === 'ArrowRight' && direction.x === 0) direction = { x: 1, y: 0 };
+        });
+
+        restartBtn.addEventListener('click', init);
+
+        init();
+    </script>
+</body>
+</html>

--- a/game/space-shooter/index.html
+++ b/game/space-shooter/index.html
@@ -1,0 +1,421 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>우주 방위전</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: grid;
+            place-items: center;
+            background: radial-gradient(circle at 50% 20%, #040b18, #020409 70%);
+            color: #f5f6fa;
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+        }
+        .panel {
+            background: rgba(6, 14, 28, 0.9);
+            padding: 32px;
+            border-radius: 28px;
+            box-shadow: 0 30px 70px rgba(0, 0, 0, 0.55);
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+            align-items: center;
+        }
+        h1 {
+            margin: 0;
+            font-size: 28px;
+            letter-spacing: 1px;
+        }
+        .stats {
+            display: flex;
+            gap: 20px;
+            font-weight: 600;
+        }
+        canvas {
+            background: radial-gradient(circle at 50% 50%, rgba(12, 24, 48, 0.85), rgba(2, 6, 16, 0.92));
+            border-radius: 20px;
+            border: 6px solid rgba(255, 255, 255, 0.08);
+        }
+        button {
+            background: linear-gradient(135deg, #38ef7d, #11998e);
+            color: #02120f;
+            border: none;
+            border-radius: 999px;
+            padding: 10px 24px;
+            font-weight: 700;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 18px 28px rgba(56, 239, 125, 0.28);
+        }
+        p {
+            margin: 0;
+            font-size: 14px;
+            color: rgba(255, 255, 255, 0.72);
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+    <div class="panel">
+        <h1>우주 방위전</h1>
+        <div class="stats">
+            <div>점수: <span id="score">0</span></div>
+            <div>쉴드: <span id="shield">100</span></div>
+            <div>웨이브: <span id="wave">1</span></div>
+        </div>
+        <canvas id="game" width="540" height="720"></canvas>
+        <button id="restart">다시 시작</button>
+        <p>WASD/방향키로 이동하고 스페이스 또는 클릭으로 레이저를 발사하세요. 파워업을 모아 우주를 지키세요!</p>
+    </div>
+
+    <script>
+        const canvas = document.getElementById('game');
+        const ctx = canvas.getContext('2d');
+        const scoreEl = document.getElementById('score');
+        const shieldEl = document.getElementById('shield');
+        const waveEl = document.getElementById('wave');
+        const restartBtn = document.getElementById('restart');
+
+        const WIDTH = canvas.width;
+        const HEIGHT = canvas.height;
+
+        const keys = new Set();
+        let pointerDown = false;
+
+        const particles = [];
+        const bullets = [];
+        const enemies = [];
+        const powerUps = [];
+
+        let player;
+        let score;
+        let wave;
+        let spawnTimer;
+        let running = true;
+        let lastTime = 0;
+
+        const POWER_TYPES = ['heal', 'rapid', 'spread'];
+
+        function createPlayer() {
+            return {
+                x: WIDTH / 2,
+                y: HEIGHT - 80,
+                width: 32,
+                height: 42,
+                speed: 0.4,
+                shield: 100,
+                rapidUntil: 0,
+                spreadUntil: 0
+            };
+        }
+
+        function resetGame() {
+            player = createPlayer();
+            score = 0;
+            wave = 1;
+            spawnTimer = 0;
+            bullets.length = 0;
+            enemies.length = 0;
+            particles.length = 0;
+            powerUps.length = 0;
+            running = true;
+            lastTime = performance.now();
+            shoot.lastShot = 0;
+            pointerDown = false;
+            keys.clear();
+            updateHUD();
+        }
+
+        function updateHUD() {
+            scoreEl.textContent = Math.floor(score);
+            shieldEl.textContent = Math.max(0, Math.floor(player.shield));
+            waveEl.textContent = Math.max(1, Math.floor(wave));
+        }
+
+        function spawnEnemy() {
+            const size = 28 + Math.random() * 16;
+            const x = size + Math.random() * (WIDTH - size * 2);
+            const speed = 0.12 + Math.random() * 0.12 + wave * 0.01;
+            enemies.push({
+                x,
+                y: -size,
+                size,
+                speed,
+                angle: Math.random() * Math.PI * 2,
+                hp: 2 + Math.floor(wave / 2),
+                fireCooldown: 1500 + Math.random() * 1000
+            });
+        }
+
+        function spawnPowerUp(x, y) {
+            const type = POWER_TYPES[Math.floor(Math.random() * POWER_TYPES.length)];
+            powerUps.push({ x, y, type, speed: 0.12 });
+        }
+
+        function shoot() {
+            const now = performance.now();
+            if (!running) return;
+            const rapid = now < player.rapidUntil ? 100 : 280;
+            if (shoot.lastShot && now - shoot.lastShot < rapid) return;
+            shoot.lastShot = now;
+
+            const spreadActive = now < player.spreadUntil;
+            const projectiles = spreadActive ? [-0.18, 0, 0.18] : [0];
+            for (const angle of projectiles) {
+                bullets.push({
+                    x: player.x,
+                    y: player.y - player.height / 2,
+                    vx: Math.sin(angle) * 0.3,
+                    vy: -0.6,
+                    life: 0
+                });
+            }
+            addParticles(player.x, player.y, '#38ef7d');
+        }
+
+        function addParticles(x, y, color) {
+            for (let i = 0; i < 12; i++) {
+                particles.push({
+                    x,
+                    y,
+                    vx: (Math.random() - 0.5) * 0.6,
+                    vy: (Math.random() - 0.5) * 0.6,
+                    life: 600,
+                    color
+                });
+            }
+        }
+
+        function updatePlayer(delta) {
+            const velocity = player.speed * delta;
+            if (keys.has('ArrowLeft') || keys.has('a')) player.x -= velocity;
+            if (keys.has('ArrowRight') || keys.has('d')) player.x += velocity;
+            if (keys.has('ArrowUp') || keys.has('w')) player.y -= velocity;
+            if (keys.has('ArrowDown') || keys.has('s')) player.y += velocity;
+            player.x = Math.max(30, Math.min(WIDTH - 30, player.x));
+            player.y = Math.max(60, Math.min(HEIGHT - 40, player.y));
+            if (pointerDown || keys.has(' ') || keys.has('Space')) shoot();
+        }
+
+        function updateBullets(delta) {
+            for (let i = bullets.length - 1; i >= 0; i--) {
+                const b = bullets[i];
+                b.x += b.vx * delta;
+                b.y += b.vy * delta;
+                b.life += delta;
+                if (b.y < -20 || b.life > 2200) {
+                    bullets.splice(i, 1);
+                }
+            }
+        }
+
+        function updateEnemies(delta) {
+            spawnTimer += delta;
+            if (spawnTimer > Math.max(500 - wave * 10, 180)) {
+                spawnEnemy();
+                spawnTimer = 0;
+            }
+            for (let i = enemies.length - 1; i >= 0; i--) {
+                const enemy = enemies[i];
+                enemy.y += enemy.speed * delta;
+                enemy.x += Math.sin(enemy.angle + performance.now() * 0.001) * 0.12 * delta;
+                if (enemy.y > HEIGHT + enemy.size) {
+                    enemies.splice(i, 1);
+                    continue;
+                }
+                for (let j = bullets.length - 1; j >= 0; j--) {
+                    const b = bullets[j];
+                    if (Math.hypot(b.x - enemy.x, b.y - enemy.y) < enemy.size) {
+                        bullets.splice(j, 1);
+                        enemy.hp--;
+                        score += 15;
+                        updateHUD();
+                        addParticles(enemy.x, enemy.y, '#4facfe');
+                        if (enemy.hp <= 0) {
+                            if (Math.random() < 0.2) spawnPowerUp(enemy.x, enemy.y);
+                            enemies.splice(i, 1);
+                            wave += 0.05;
+                            updateHUD();
+                            break;
+                        }
+                        break;
+                    }
+                }
+                if (!enemies[i]) continue;
+                if (enemies[i]) {
+                    const dist = Math.hypot(player.x - enemy.x, player.y - enemy.y);
+                    if (dist < enemy.size + 24) {
+                        player.shield -= 25;
+                        addParticles(player.x, player.y, '#ff6b6b');
+                        enemies.splice(i, 1);
+                        if (player.shield <= 0) {
+                            endGame();
+                            return;
+                        }
+                        updateHUD();
+                    }
+                }
+            }
+        }
+
+        function updatePowerUps(delta) {
+            for (let i = powerUps.length - 1; i >= 0; i--) {
+                const p = powerUps[i];
+                p.y += p.speed * delta;
+                p.x += Math.sin(performance.now() * 0.002 + i) * 0.06 * delta;
+                if (p.y > HEIGHT + 20) {
+                    powerUps.splice(i, 1);
+                    continue;
+                }
+                if (Math.hypot(player.x - p.x, player.y - p.y) < 28) {
+                    applyPowerUp(p.type);
+                    addParticles(p.x, p.y, '#ffe66d');
+                    powerUps.splice(i, 1);
+                }
+            }
+        }
+
+        function applyPowerUp(type) {
+            if (type === 'heal') {
+                player.shield = Math.min(120, player.shield + 30);
+            } else if (type === 'rapid') {
+                player.rapidUntil = performance.now() + 6000;
+            } else if (type === 'spread') {
+                player.spreadUntil = performance.now() + 6000;
+            }
+            updateHUD();
+        }
+
+        function updateParticles(delta) {
+            for (let i = particles.length - 1; i >= 0; i--) {
+                const p = particles[i];
+                p.x += p.vx * delta;
+                p.y += p.vy * delta;
+                p.life -= delta;
+                if (p.life <= 0) particles.splice(i, 1);
+            }
+        }
+
+        function draw() {
+            ctx.clearRect(0, 0, WIDTH, HEIGHT);
+            ctx.fillStyle = '#0b1731';
+            ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+            ctx.strokeStyle = 'rgba(255,255,255,0.08)';
+            for (let y = 40; y < HEIGHT; y += 60) {
+                ctx.beginPath();
+                ctx.moveTo(0, y + (performance.now() / 40) % 60);
+                ctx.lineTo(WIDTH, y + (performance.now() / 40) % 60);
+                ctx.stroke();
+            }
+
+            particles.forEach(p => {
+                ctx.fillStyle = p.color;
+                ctx.globalAlpha = Math.max(0, p.life / 600);
+                ctx.fillRect(p.x, p.y, 3, 3);
+                ctx.globalAlpha = 1;
+            });
+
+            ctx.fillStyle = '#38ef7d';
+            ctx.beginPath();
+            ctx.moveTo(player.x, player.y - player.height / 2);
+            ctx.lineTo(player.x - player.width / 2, player.y + player.height / 2);
+            ctx.lineTo(player.x + player.width / 2, player.y + player.height / 2);
+            ctx.closePath();
+            ctx.fill();
+
+            ctx.fillStyle = '#74b9ff';
+            bullets.forEach(b => {
+                ctx.fillRect(b.x - 3, b.y - 12, 6, 18);
+            });
+
+            enemies.forEach(enemy => {
+                ctx.fillStyle = '#4facfe';
+                ctx.beginPath();
+                ctx.arc(enemy.x, enemy.y, enemy.size * 0.6, 0, Math.PI * 2);
+                ctx.fill();
+                ctx.strokeStyle = '#c9d6ff';
+                ctx.lineWidth = 2;
+                ctx.stroke();
+            });
+
+            powerUps.forEach(p => {
+                ctx.fillStyle = '#ffe66d';
+                ctx.beginPath();
+                ctx.arc(p.x, p.y, 14, 0, Math.PI * 2);
+                ctx.fill();
+                ctx.fillStyle = '#222';
+                ctx.font = 'bold 14px Pretendard';
+                ctx.textAlign = 'center';
+                ctx.fillText(p.type[0].toUpperCase(), p.x, p.y + 5);
+            });
+
+            ctx.fillStyle = 'rgba(255, 255, 255, 0.2)';
+            ctx.fillRect(40, HEIGHT - 26, (player.shield / 120) * (WIDTH - 80), 12);
+        }
+
+        function update(time = 0) {
+            if (!running) return;
+            const delta = time - lastTime;
+            lastTime = time;
+            updatePlayer(delta);
+            updateBullets(delta);
+            updateEnemies(delta);
+            updatePowerUps(delta);
+            updateParticles(delta);
+            draw();
+            requestAnimationFrame(update);
+        }
+
+        function endGame() {
+            if (!running) return;
+            running = false;
+            updateHUD();
+            ctx.fillStyle = 'rgba(0, 0, 0, 0.65)';
+            ctx.fillRect(0, 0, WIDTH, HEIGHT);
+            ctx.fillStyle = '#f5f6fa';
+            ctx.font = '30px Pretendard, sans-serif';
+            ctx.textAlign = 'center';
+            ctx.fillText('게임 오버', WIDTH / 2, HEIGHT / 2 - 20);
+            ctx.font = '20px Pretendard, sans-serif';
+            ctx.fillText(`최종 점수: ${scoreEl.textContent}`, WIDTH / 2, HEIGHT / 2 + 18);
+        }
+
+        restartBtn.addEventListener('click', () => {
+            resetGame();
+            requestAnimationFrame(update);
+        });
+
+        document.addEventListener('keydown', e => {
+            keys.add(e.key);
+            if (e.key === ' ') e.preventDefault();
+        });
+        document.addEventListener('keyup', e => {
+            keys.delete(e.key);
+        });
+
+        canvas.addEventListener('mousedown', () => {
+            pointerDown = true;
+        });
+        canvas.addEventListener('mouseup', () => {
+            pointerDown = false;
+        });
+        canvas.addEventListener('mouseleave', () => {
+            pointerDown = false;
+        });
+
+        resetGame();
+        draw();
+        requestAnimationFrame(update);
+    </script>
+</body>
+</html>

--- a/game/tetris/index.html
+++ b/game/tetris/index.html
@@ -1,0 +1,412 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>테트리스</title>
+    <style>
+        :root {
+            color-scheme: dark;
+        }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: radial-gradient(circle at 20% 20%, #41295a, #2f0743 65%, #120024);
+            font-family: 'Pretendard', 'Noto Sans KR', system-ui, sans-serif;
+            color: #f1f2f6;
+        }
+        .wrapper {
+            display: flex;
+            gap: 36px;
+            background: rgba(15, 5, 26, 0.85);
+            padding: 32px 44px;
+            border-radius: 28px;
+            box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5);
+            align-items: flex-start;
+        }
+        canvas {
+            background: rgba(5, 1, 12, 0.9);
+            border-radius: 12px;
+            border: 5px solid rgba(255,255,255,0.1);
+            box-shadow: inset 0 0 25px rgba(0,0,0,0.55);
+        }
+        .panel {
+            width: 220px;
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+        }
+        h1 {
+            margin: 0;
+            font-size: 30px;
+            letter-spacing: 2px;
+        }
+        .stat {
+            background: rgba(255,255,255,0.05);
+            border-radius: 18px;
+            padding: 16px 20px;
+            line-height: 1.6;
+        }
+        .next {
+            height: 160px;
+            display: grid;
+            place-items: center;
+            background: rgba(255,255,255,0.05);
+            border-radius: 18px;
+        }
+        #next-board {
+            width: 140px;
+            height: 140px;
+        }
+        button {
+            background: linear-gradient(135deg, #ff7e5f, #feb47b);
+            color: #120024;
+            border: none;
+            padding: 12px 18px;
+            border-radius: 999px;
+            font-weight: 700;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 15px 20px rgba(255, 126, 95, 0.35);
+        }
+        ul {
+            margin: 0;
+            padding-left: 18px;
+            font-size: 14px;
+            color: rgba(255,255,255,0.8);
+        }
+        @media (max-width: 800px) {
+            .wrapper {
+                flex-direction: column;
+                align-items: center;
+            }
+            .panel {
+                width: 100%;
+                flex-direction: column;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="wrapper">
+        <canvas id="board" width="240" height="480"></canvas>
+        <div class="panel">
+            <h1>테트리스</h1>
+            <div class="stat">
+                <div>점수: <strong id="score">0</strong></div>
+                <div>라인: <strong id="lines">0</strong></div>
+                <div>레벨: <strong id="level">1</strong></div>
+            </div>
+            <div class="next">
+                <canvas id="next-board" width="120" height="120"></canvas>
+            </div>
+            <button id="restart">새 게임</button>
+            <div class="stat">
+                <h2 style="margin:0 0 8px;font-size:18px;">조작 방법</h2>
+                <ul>
+                    <li>← → : 좌우 이동</li>
+                    <li>↑ : 회전</li>
+                    <li>↓ : 빠른 하강</li>
+                    <li>Space : 즉시 낙하</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        const canvas = document.getElementById('board');
+        const ctx = canvas.getContext('2d');
+        const nextCanvas = document.getElementById('next-board');
+        const nextCtx = nextCanvas.getContext('2d');
+        const ROWS = 20;
+        const COLS = 10;
+        const BLOCK = 24;
+        const COLORS = {
+            I: '#00d8ff',
+            J: '#3b82f6',
+            L: '#f97316',
+            O: '#facc15',
+            S: '#22c55e',
+            T: '#a855f7',
+            Z: '#ef4444'
+        };
+        const SHAPES = {
+            I: [
+                [0, 0, 0, 0],
+                [1, 1, 1, 1],
+                [0, 0, 0, 0],
+                [0, 0, 0, 0]
+            ],
+            J: [
+                [1, 0, 0],
+                [1, 1, 1],
+                [0, 0, 0]
+            ],
+            L: [
+                [0, 0, 1],
+                [1, 1, 1],
+                [0, 0, 0]
+            ],
+            O: [
+                [1, 1],
+                [1, 1]
+            ],
+            S: [
+                [0, 1, 1],
+                [1, 1, 0],
+                [0, 0, 0]
+            ],
+            T: [
+                [0, 1, 0],
+                [1, 1, 1],
+                [0, 0, 0]
+            ],
+            Z: [
+                [1, 1, 0],
+                [0, 1, 1],
+                [0, 0, 0]
+            ]
+        };
+
+        let board, current, next, dropCounter, dropInterval, lastTime;
+        let scoreEl = document.getElementById('score');
+        let linesEl = document.getElementById('lines');
+        let levelEl = document.getElementById('level');
+        let score, lines, level;
+
+        function createMatrix(rows, cols) {
+            return Array.from({ length: rows }, () => Array(cols).fill(0));
+        }
+
+        function randomPiece() {
+            const keys = Object.keys(SHAPES);
+            const type = keys[Math.floor(Math.random() * keys.length)];
+            return {
+                type,
+                matrix: SHAPES[type].map(row => [...row]),
+                pos: { x: Math.floor(COLS / 2) - 1, y: -1 }
+            };
+        }
+
+        function rotate(matrix) {
+            const size = matrix.length;
+            const rotated = matrix.map((row, y) => row.map((_, x) => matrix[size - 1 - x][y]));
+            return rotated;
+        }
+
+        function collide(board, piece) {
+            const { matrix, pos } = piece;
+            for (let y = 0; y < matrix.length; y++) {
+                for (let x = 0; x < matrix[y].length; x++) {
+                    if (!matrix[y][x]) continue;
+                    const boardY = y + pos.y;
+                    const boardX = x + pos.x;
+                    if (boardY < 0) continue;
+                    if (boardX < 0 || boardX >= COLS || boardY >= ROWS || board[boardY][boardX]) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        function merge(board, piece) {
+            piece.matrix.forEach((row, y) => {
+                row.forEach((value, x) => {
+                    if (value) {
+                        const boardY = y + piece.pos.y;
+                        if (boardY >= 0) {
+                            board[boardY][x + piece.pos.x] = piece.type;
+                        }
+                    }
+                });
+            });
+        }
+
+        function clearLines() {
+            let cleared = 0;
+            outer: for (let y = ROWS - 1; y >= 0; y--) {
+                for (let x = 0; x < COLS; x++) {
+                    if (!board[y][x]) {
+                        continue outer;
+                    }
+                }
+                const row = board.splice(y, 1)[0].fill(0);
+                board.unshift(row);
+                y++;
+                cleared++;
+            }
+            if (cleared) {
+                score += [0, 100, 300, 500, 800][cleared];
+                lines += cleared;
+                level = 1 + Math.floor(lines / 10);
+                dropInterval = Math.max(120, 1000 - (level - 1) * 80);
+                updateUI();
+            }
+        }
+
+        function drawBlock(x, y, type, context, size = BLOCK) {
+            context.fillStyle = COLORS[type] || '#64748b';
+            context.fillRect(x * size, y * size, size, size);
+            context.strokeStyle = 'rgba(255,255,255,0.35)';
+            context.lineWidth = 2;
+            context.strokeRect(x * size + 1, y * size + 1, size - 2, size - 2);
+        }
+
+        function drawMatrix(matrix, offset, context, size = BLOCK) {
+            matrix.forEach((row, y) => {
+                row.forEach((value, x) => {
+                    if (value) {
+                        drawBlock(x + offset.x, y + offset.y, current.type, context, size);
+                    }
+                });
+            });
+        }
+
+        function drawBoard() {
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+            board.forEach((row, y) => {
+                row.forEach((value, x) => {
+                    if (value) drawBlock(x, y, value, ctx);
+                });
+            });
+            drawMatrix(current.matrix, current.pos, ctx);
+        }
+
+        function drawNext() {
+            nextCtx.clearRect(0, 0, nextCanvas.width, nextCanvas.height);
+            const matrix = next.matrix;
+            const size = nextCanvas.width / 6;
+            const offsetX = Math.floor((6 - matrix[0].length) / 2);
+            const offsetY = Math.floor((6 - matrix.length) / 2);
+            matrix.forEach((row, y) => {
+                row.forEach((value, x) => {
+                    if (value) {
+                        drawBlock(x + offsetX, y + offsetY, next.type, nextCtx, size);
+                    }
+                });
+            });
+        }
+
+        function drop() {
+            current.pos.y++;
+            if (collide(board, current)) {
+                current.pos.y--;
+                merge(board, current);
+                clearLines();
+                spawnPiece();
+                if (collide(board, current)) {
+                    init();
+                }
+            }
+            dropCounter = 0;
+        }
+
+        function hardDrop() {
+            while (!collide(board, current)) {
+                current.pos.y++;
+            }
+            current.pos.y--;
+            merge(board, current);
+            score += 2;
+            clearLines();
+            spawnPiece();
+        }
+
+        function move(dir) {
+            current.pos.x += dir;
+            if (collide(board, current)) {
+                current.pos.x -= dir;
+            }
+        }
+
+        function rotateCurrent() {
+            const original = current.matrix;
+            current.matrix = rotate(current.matrix);
+            const pos = current.pos.x;
+            let offset = 1;
+            while (collide(board, current)) {
+                current.pos.x += offset;
+                offset = -(offset + (offset > 0 ? 1 : -1));
+                if (offset > current.matrix[0].length) {
+                    current.matrix = original;
+                    current.pos.x = pos;
+                    return;
+                }
+            }
+        }
+
+        function update(time = 0) {
+            const delta = time - lastTime;
+            lastTime = time;
+            dropCounter += delta;
+            if (dropCounter > dropInterval) {
+                drop();
+            }
+            drawBoard();
+            drawNext();
+            requestAnimationFrame(update);
+        }
+
+        function spawnPiece() {
+            current = next;
+            current.pos = { x: Math.floor(COLS / 2) - Math.ceil(current.matrix[0].length / 2), y: -1 };
+            next = randomPiece();
+            drawNext();
+        }
+
+        function updateUI() {
+            scoreEl.textContent = score;
+            linesEl.textContent = lines;
+            levelEl.textContent = level;
+        }
+
+        function init() {
+            board = createMatrix(ROWS, COLS);
+            score = 0;
+            lines = 0;
+            level = 1;
+            dropInterval = 1000;
+            dropCounter = 0;
+            lastTime = 0;
+            next = randomPiece();
+            spawnPiece();
+            updateUI();
+        }
+
+        document.addEventListener('keydown', e => {
+            switch (e.code) {
+                case 'ArrowLeft':
+                    move(-1);
+                    break;
+                case 'ArrowRight':
+                    move(1);
+                    break;
+                case 'ArrowDown':
+                    drop();
+                    score++;
+                    updateUI();
+                    break;
+                case 'ArrowUp':
+                    rotateCurrent();
+                    break;
+                case 'Space':
+                    hardDrop();
+                    updateUI();
+                    break;
+            }
+        });
+
+        document.getElementById('restart').addEventListener('click', init);
+
+        init();
+        update();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- expand the /game hub with additional experiences and refreshed styling
- add breakout, flappy flight, minesweeper, memory match, space shooter, and endless runner browser games
- refine the 2048 move logic to prevent invalid spawns and smooth tile animations

## Testing
- not run (static HTML/JS content)


------
https://chatgpt.com/codex/tasks/task_e_68f03b8f5ff8832981f84eb349b88c15