### PR TITLE
🧪 [tower-defense] Add tests for canPlaceTower

### DIFF
--- a/game/tower-defense/index.html
+++ b/game/tower-defense/index.html
@@ -112,6 +112,7 @@
             </ul>
         </aside>
     </main>
+    <script src="logic.js"></script>
     <script>
         const canvas = document.getElementById('game');
         const ctx = canvas.getContext('2d');
@@ -203,7 +204,7 @@
         function handlePlacement(event) {
             if (!placingTower || !selectedTower) return;
             const { offsetX, offsetY } = event;
-            if (!canPlaceTower(offsetX, offsetY)) {
+            if (!canPlaceTower(offsetX, offsetY, canvas.width, canvas.height, towers, path)) {
                 logEl.textContent = '이 위치에는 타워를 지을 수 없습니다.';
                 return;
             }
@@ -222,18 +223,6 @@
             towerContainers.forEach((container) => container.classList.remove('active'));
             logEl.textContent = '타워를 배치했습니다! 웨이브를 시작하거나 추가 배치를 계속하세요.';
             ghostPosition = null;
-        }
-
-        function canPlaceTower(x, y) {
-            const margin = 28;
-            if (x < margin || y < margin || x > canvas.width - margin || y > canvas.height - margin) return false;
-            if (towers.some((tower) => distance(tower, { x, y }) < 50)) return false;
-            for (let i = 0; i < path.length - 1; i++) {
-                const a = path[i];
-                const b = path[i + 1];
-                if (pointToSegmentDistance({ x, y }, a, b) < 32) return false;
-            }
-            return true;
         }
 
         function startWave() {
@@ -462,21 +451,9 @@
             energyEl.textContent = energy;
         }
 
-        function distance(a, b) {
-            return Math.hypot(a.x - b.x, a.y - b.y);
-        }
-
         function normalize(vec) {
             const length = Math.hypot(vec.x, vec.y) || 1;
             return { x: vec.x / length, y: vec.y / length };
-        }
-
-        function pointToSegmentDistance(point, a, b) {
-            const ab = { x: b.x - a.x, y: b.y - a.y };
-            const ap = { x: point.x - a.x, y: point.y - a.y };
-            const t = Math.max(0, Math.min(1, (ap.x * ab.x + ap.y * ab.y) / (ab.x * ab.x + ab.y * ab.y)));
-            const closest = { x: a.x + ab.x * t, y: a.y + ab.y * t };
-            return distance(point, closest);
         }
 
         function resetGame() {

--- a/game/tower-defense/logic.js
+++ b/game/tower-defense/logic.js
@@ -1,0 +1,31 @@
+function distance(a, b) {
+    return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+function pointToSegmentDistance(point, a, b) {
+    const ab = { x: b.x - a.x, y: b.y - a.y };
+    const ap = { x: point.x - a.x, y: point.y - a.y };
+    const t = Math.max(0, Math.min(1, (ap.x * ab.x + ap.y * ab.y) / (ab.x * ab.x + ab.y * ab.y)));
+    const closest = { x: a.x + ab.x * t, y: a.y + ab.y * t };
+    return distance(point, closest);
+}
+
+function canPlaceTower(x, y, canvasWidth, canvasHeight, towers, path) {
+    const margin = 28;
+    if (x < margin || y < margin || x > canvasWidth - margin || y > canvasHeight - margin) return false;
+    if (towers.some((tower) => distance(tower, { x, y }) < 50)) return false;
+    for (let i = 0; i < path.length - 1; i++) {
+        const a = path[i];
+        const b = path[i + 1];
+        if (pointToSegmentDistance({ x, y }, a, b) < 32) return false;
+    }
+    return true;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        distance,
+        pointToSegmentDistance,
+        canPlaceTower
+    };
+}

--- a/game/tower-defense/logic.test.js
+++ b/game/tower-defense/logic.test.js
@@ -1,0 +1,79 @@
+const assert = require('assert');
+const { canPlaceTower } = require('./logic.js');
+
+function runTests() {
+    console.log('Running Tower Defense logic tests...');
+
+    const canvasWidth = 720;
+    const canvasHeight = 480;
+    const margin = 28;
+
+    // Sample path similar to the actual game path
+    const path = [
+        { x: 60, y: 460 },
+        { x: 60, y: 300 },
+        { x: 240, y: 300 }
+    ];
+
+    // Empty towers array initially
+    let towers = [];
+
+    // Test 1: Happy Path - Valid placement
+    // x, y well within boundaries, no towers, far from path
+    let result = canPlaceTower(150, 150, canvasWidth, canvasHeight, towers, path);
+    assert.strictEqual(result, true, 'Should be able to place a tower in a valid empty spot');
+
+    // Test 2: Canvas Boundary Violations (margin = 28)
+    // Left boundary
+    result = canPlaceTower(margin - 1, 150, canvasWidth, canvasHeight, towers, path);
+    assert.strictEqual(result, false, 'Should fail to place a tower too close to the left edge');
+
+    // Top boundary
+    result = canPlaceTower(150, margin - 1, canvasWidth, canvasHeight, towers, path);
+    assert.strictEqual(result, false, 'Should fail to place a tower too close to the top edge');
+
+    // Right boundary
+    result = canPlaceTower(canvasWidth - margin + 1, 150, canvasWidth, canvasHeight, towers, path);
+    assert.strictEqual(result, false, 'Should fail to place a tower too close to the right edge');
+
+    // Bottom boundary
+    result = canPlaceTower(150, canvasHeight - margin + 1, canvasWidth, canvasHeight, towers, path);
+    assert.strictEqual(result, false, 'Should fail to place a tower too close to the bottom edge');
+
+    // Test 3: Tower Overlap Violations (distance < 50)
+    towers = [{ x: 150, y: 150, type: 'basic', cooldown: 0 }];
+
+    // Exactly on the same spot
+    result = canPlaceTower(150, 150, canvasWidth, canvasHeight, towers, path);
+    assert.strictEqual(result, false, 'Should fail to place a tower on top of another tower');
+
+    // Just within 50px (e.g., 49px away)
+    result = canPlaceTower(150 + 49, 150, canvasWidth, canvasHeight, towers, path);
+    assert.strictEqual(result, false, 'Should fail to place a tower within 50px of another tower');
+
+    // Just outside 50px (e.g., 50px away)
+    result = canPlaceTower(150 + 50, 150, canvasWidth, canvasHeight, towers, path);
+    assert.strictEqual(result, true, 'Should be able to place a tower exactly 50px away from another tower');
+
+    // Reset towers
+    towers = [];
+
+    // Test 4: Path Overlap Violations (distance < 32)
+    // The path segment is from (60, 460) to (60, 300)
+
+    // Exactly on the path
+    result = canPlaceTower(60, 400, canvasWidth, canvasHeight, towers, path);
+    assert.strictEqual(result, false, 'Should fail to place a tower exactly on the path');
+
+    // Just within 32px of the path (e.g., 31px away horizontally)
+    result = canPlaceTower(60 + 31, 400, canvasWidth, canvasHeight, towers, path);
+    assert.strictEqual(result, false, 'Should fail to place a tower within 32px of the path');
+
+    // Just outside 32px of the path (e.g., 32px away horizontally)
+    result = canPlaceTower(60 + 32, 400, canvasWidth, canvasHeight, towers, path);
+    assert.strictEqual(result, true, 'Should be able to place a tower exactly 32px away from the path');
+
+    console.log('All tests passed successfully! 🎉');
+}
+
+runTests();


### PR DESCRIPTION
🎯 **What:** The `canPlaceTower` boundary check function in `game/tower-defense/index.html` was relying on global variables (`canvas`, `towers`, `path`), making it untestable in isolation. The testing gap prevented safe modifications to the tower placement logic.

📊 **Coverage:** 
- The happy path (valid empty placements)
- Canvas boundary margin violations (testing left, right, top, and bottom)
- Tower overlap detection (ensuring towers are >50px apart)
- Path overlap prevention (ensuring towers are >32px away from path segments)

✨ **Result:** `canPlaceTower` is now an isolated, purely functional component tested thoroughly in `game/tower-defense/logic.test.js`. This prevents future regressions when the map, tower bounds, or margin values are updated.

---
*PR created automatically by Jules for task [8308977231890084713](https://jules.google.com/task/8308977231890084713) started by @gorics*