### PR TITLE
🧹 Refactor redundant ignoreThemeUpdate checks

### DIFF
--- a/clock/script.js
+++ b/clock/script.js
@@ -295,54 +295,46 @@ function regenerateStars(density) {
   starField.style.backgroundImage = stars.join(',');
 }
 
-accentColorInput.addEventListener('input', event => {
-  updateCSSVariable('--accent', event.target.value);
+function handleThemeUpdate() {
   if (!ignoreThemeUpdate) {
     themePresetSelect.value = 'custom';
   }
+}
+
+accentColorInput.addEventListener('input', event => {
+  updateCSSVariable('--accent', event.target.value);
+  handleThemeUpdate();
 });
 
 glowColorInput.addEventListener('input', event => {
   const color = event.target.value;
   updateCSSVariable('--glow', hexToRgba(color, 0.6));
-  if (!ignoreThemeUpdate) {
-    themePresetSelect.value = 'custom';
-  }
+  handleThemeUpdate();
 });
 
 bgTopInput.addEventListener('input', event => {
   updateCSSVariable('--bg-top', event.target.value);
-  if (!ignoreThemeUpdate) {
-    themePresetSelect.value = 'custom';
-  }
+  handleThemeUpdate();
 });
 
 bgBottomInput.addEventListener('input', event => {
   updateCSSVariable('--bg-bottom', event.target.value);
-  if (!ignoreThemeUpdate) {
-    themePresetSelect.value = 'custom';
-  }
+  handleThemeUpdate();
 });
 
 starDensityInput.addEventListener('input', event => {
   regenerateStars(event.target.value);
-  if (!ignoreThemeUpdate) {
-    themePresetSelect.value = 'custom';
-  }
+  handleThemeUpdate();
 });
 
 glowStrengthInput.addEventListener('input', event => {
   updateCSSVariable('--glow-strength', `${event.target.value}px`);
-  if (!ignoreThemeUpdate) {
-    themePresetSelect.value = 'custom';
-  }
+  handleThemeUpdate();
 });
 
 fontWeightSelect.addEventListener('change', event => {
   updateCSSVariable('--font-weight', event.target.value);
-  if (!ignoreThemeUpdate) {
-    themePresetSelect.value = 'custom';
-  }
+  handleThemeUpdate();
 });
 
 themePresetSelect.addEventListener('change', event => {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Refactored duplicated `if (!ignoreThemeUpdate) { themePresetSelect.value = 'custom'; }` logic found across multiple input event listeners in `clock/script.js` into a new helper function `handleThemeUpdate()`.

💡 **Why:** How this improves maintainability
Extracting duplicated logic into a single helper function adheres to the DRY (Don't Repeat Yourself) principle. It reduces the size of the event listeners, making the code cleaner and easier to read. Any future changes to how theme updates are ignored only need to be made in one place.

✅ **Verification:** How you confirmed the change is safe
- Visually reviewed the changes using `read_file` to ensure all 7 instances of the duplicated block were correctly replaced.
- Ran `node -c clock/script.js` to verify there were no syntax errors introduced.
- Wrote and executed a Playwright script (`verify_theme_update.py`) to launch the local `clock/index.html`, programmatically change the `accentColorInput`, and verify that `themePresetSelect.value` correctly updated to 'custom'. A successful screenshot was captured.

✨ **Result:** The improvement achieved
The codebase is cleaner, with less repeated code, improving overall code health and maintainability of the clock settings logic.

---
*PR created automatically by Jules for task [1305973443135195756](https://jules.google.com/task/1305973443135195756) started by @gorics*