### PR TITLE
🧹 Refactor redundant ignoreThemeUpdate logic in clock settings

### DIFF
--- a/clock/script.js
+++ b/clock/script.js
@@ -295,19 +295,21 @@ function regenerateStars(density) {
   starField.style.backgroundImage = stars.join(',');
 }
 
-accentColorInput.addEventListener('input', event => {
-  updateCSSVariable('--accent', event.target.value);
+function handleThemeUpdate() {
   if (!ignoreThemeUpdate) {
     themePresetSelect.value = 'custom';
   }
+}
+
+accentColorInput.addEventListener('input', event => {
+  updateCSSVariable('--accent', event.target.value);
+  handleThemeUpdate();
 });
 
 glowColorInput.addEventListener('input', event => {
   const color = event.target.value;
   updateCSSVariable('--glow', hexToRgba(color, 0.6));
-  if (!ignoreThemeUpdate) {
-    themePresetSelect.value = 'custom';
-  }
+  handleThemeUpdate();
 });
 
 bgTopInput.addEventListener('input', event => {


### PR DESCRIPTION
🎯 **What:** Extracted the redundant `if (!ignoreThemeUpdate)` check in `clock/script.js` into a reusable `handleThemeUpdate` helper function.
💡 **Why:** Reduces code duplication across the `accentColorInput` and `glowColorInput` event listeners, improving readability and maintainability of the theme update logic.
✅ **Verification:** Visually verified that changing the custom colors still automatically switches the theme preset to 'custom' via a Playwright test script simulating user input.
✨ **Result:** Cleaner, more maintainable code without altering functionality.

---
*PR created automatically by Jules for task [6974788023849225272](https://jules.google.com/task/6974788023849225272) started by @gorics*