### PR TITLE
Update linux.iso url to use remote file

### DIFF
--- a/os/linux/1/index.html
+++ b/os/linux/1/index.html
@@ -260,7 +260,7 @@
     // ── ISO 존재 여부 확인 ──
     async function checkISO() {
       try {
-        const res = await fetch('./linux.iso', { method: 'HEAD', cache: 'no-store' });
+        const res = await fetch('https://gorics.github.io/website/os/linux/1/linux.iso', { method: 'HEAD', cache: 'no-store' });
         return res.ok;
       } catch (_) {
         return false;
@@ -400,7 +400,7 @@
           screen_container: document.getElementById('screen_container'),
           bios:     { url: cdn.bios },
           vga_bios: { url: cdn.vga },
-          cdrom:    { url: './linux.iso' },
+          cdrom:    { url: 'https://gorics.github.io/website/os/linux/1/linux.iso' },
           autostart: true,
           disable_mouse: true,
         });


### PR DESCRIPTION
The user wants the application to run a real Linux operating system instead of a simulated one by using the provided ISO file url (`https://gorics.github.io/website/os/linux/1/linux.iso`).

This commit updates `os/linux/1/index.html` to point the WebAssembly x86 Emulator (v86) to the remote ISO URL. It removes the necessity to bundle large binary files into the repo directly while enabling actual Linux execution as requested.

---
*PR created automatically by Jules for task [16497239579286964865](https://jules.google.com/task/16497239579286964865) started by @gorics*