### PR TITLE
Add study schedule manager page (study/schedule/index.html)

### DIFF
--- a/study/schedule/index.html
+++ b/study/schedule/index.html
@@ -1,0 +1,363 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>스케줄 매니저</title>
+  <style>
+    :root {
+      --bg: #0b1020;
+      --card: #141b34;
+      --card-soft: #1b2547;
+      --text: #f3f6ff;
+      --muted: #b9c4e3;
+      --accent: #58a6ff;
+      --ok: #4ade80;
+      --warn: #fbbf24;
+    }
+
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: "Pretendard", "Apple SD Gothic Neo", "Noto Sans KR", sans-serif;
+      background: radial-gradient(circle at top, #172347, var(--bg));
+      color: var(--text);
+      line-height: 1.45;
+    }
+
+    .container {
+      max-width: 1100px;
+      margin: 0 auto;
+      padding: 20px;
+    }
+
+    h1 {
+      margin: 8px 0 14px;
+      font-size: clamp(1.5rem, 4vw, 2.2rem);
+    }
+
+    .now {
+      color: var(--muted);
+      margin-bottom: 18px;
+      font-size: 0.96rem;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(12, 1fr);
+      gap: 12px;
+    }
+
+    .card {
+      grid-column: span 12;
+      background: linear-gradient(180deg, var(--card), var(--card-soft));
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 16px;
+      padding: 16px;
+      box-shadow: 0 8px 30px rgba(0, 0, 0, 0.22);
+    }
+
+    .card h2 {
+      margin: 0 0 8px;
+      font-size: 1.1rem;
+    }
+
+    .status-big {
+      font-size: clamp(1.2rem, 3vw, 1.6rem);
+      font-weight: 800;
+      margin: 4px 0 8px;
+    }
+
+    .meta {
+      color: var(--muted);
+      font-size: 0.95rem;
+      margin: 4px 0;
+    }
+
+    .pill {
+      display: inline-block;
+      padding: 3px 10px;
+      border-radius: 999px;
+      font-size: 0.78rem;
+      background: rgba(88, 166, 255, 0.2);
+      color: #cde3ff;
+      margin-bottom: 8px;
+    }
+
+    .pill.ok { background: rgba(74, 222, 128, 0.2); color: #d8ffe7; }
+    .pill.warn { background: rgba(251, 191, 36, 0.2); color: #fff1c2; }
+
+    ul {
+      margin: 8px 0 0;
+      padding-left: 18px;
+    }
+
+    li + li { margin-top: 4px; }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 8px;
+      font-size: 0.95rem;
+    }
+
+    th, td {
+      padding: 10px;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+      text-align: left;
+      vertical-align: top;
+    }
+
+    th { color: #dce8ff; }
+    td { color: var(--muted); }
+
+    @media (min-width: 900px) {
+      .span-6 { grid-column: span 6; }
+      .span-8 { grid-column: span 8; }
+      .span-4 { grid-column: span 4; }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>📘 스케줄 매니저</h1>
+    <div class="now" id="nowText">현재 시간 계산 중...</div>
+
+    <div class="grid">
+      <section class="card span-8">
+        <span class="pill" id="stateBadge">상태</span>
+        <div class="status-big" id="mainStatus">불러오는 중...</div>
+        <p class="meta" id="statusDetail"></p>
+        <p class="meta" id="studyDetail"></p>
+      </section>
+
+      <section class="card span-4">
+        <h2>오늘 요약</h2>
+        <p class="meta" id="todayClassCount"></p>
+        <p class="meta" id="nextClass"></p>
+        <p class="meta" id="dayEnd"></p>
+      </section>
+
+      <section class="card span-6">
+        <h2>오늘 수업 타임라인</h2>
+        <ul id="todayTimeline"></ul>
+      </section>
+
+      <section class="card span-6">
+        <h2>이번 주 시간표 (교실 번호 제외)</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>요일</th>
+              <th>시간</th>
+              <th>수업</th>
+            </tr>
+          </thead>
+          <tbody id="weeklyTable"></tbody>
+        </table>
+      </section>
+    </div>
+  </div>
+
+  <script>
+    const KOR_DAYS = ["일", "월", "화", "수", "목", "금", "토"];
+
+    const schedule = {
+      1: [
+        { start: "10:10", end: "11:50", title: "수학 I", teacher: "권현석", group: "A조" },
+        { start: "15:10", end: "17:50", title: "사회문화", teacher: "이형수" }
+      ],
+      2: [
+        { start: "10:10", end: "11:50", title: "독서", teacher: "이정수" },
+        { start: "13:10", end: "14:50", title: "영어", teacher: "최은정" }
+      ],
+      3: [
+        { start: "10:10", end: "11:50", title: "수학 II", teacher: "손승연", group: "B조" }
+      ],
+      4: [
+        { start: "08:10", end: "09:50", title: "문학", teacher: "고광수" },
+        { start: "10:10", end: "11:50", title: "수리논술", teacher: "신재호" }
+      ],
+      5: [
+        { start: "10:10", end: "11:50", title: "미적분", teacher: "김범준", group: "A조" },
+        { start: "16:10", end: "17:50", title: "국어종합(문학)", teacher: "정미영" }
+      ],
+      6: [],
+      0: []
+    };
+
+    const fixedBlocks = [
+      { start: "11:50", end: "13:00", type: "meal", label: "점심시간" },
+      { start: "17:50", end: "18:50", type: "meal", label: "저녁시간" }
+    ];
+
+    const DAY_STUDY_START = "08:10";
+    const DAY_STUDY_END = "22:00";
+    const NIGHT_STUDY_START = "22:00";
+    const NIGHT_STUDY_END = "24:00";
+    const REST_START = "00:00";
+    const REST_END = "07:50";
+
+    const toMinutes = (hhmm) => {
+      const [h, m] = hhmm.split(":").map(Number);
+      return h * 60 + m;
+    };
+
+    const toDateTime = (baseDate, hhmm) => {
+      const d = new Date(baseDate);
+      const [h, m] = hhmm.split(":").map(Number);
+      d.setHours(h, m, 0, 0);
+      return d;
+    };
+
+    const formatRemain = (mins) => {
+      if (mins <= 0) return "0분";
+      const h = Math.floor(mins / 60);
+      const m = mins % 60;
+      if (h && m) return `${h}시간 ${m}분`;
+      if (h) return `${h}시간`;
+      return `${m}분`;
+    };
+
+    const formatEvent = (ev) => {
+      const base = `${ev.title}${ev.teacher ? ` · ${ev.teacher}` : ""}`;
+      return ev.group ? `${base} (${ev.group})` : base;
+    };
+
+    function getTodayBlocks(dayIndex) {
+      const classes = (schedule[dayIndex] || []).map((ev) => ({ ...ev, type: "class" }));
+      const meals = fixedBlocks.map((b) => ({ ...b }));
+      return [...classes, ...meals].sort((a, b) => toMinutes(a.start) - toMinutes(b.start));
+    }
+
+    function getCurrentState(now, dayIndex) {
+      const blocks = getTodayBlocks(dayIndex);
+      const nowM = now.getHours() * 60 + now.getMinutes();
+      const dayStudyStart = toMinutes(DAY_STUDY_START);
+      const dayStudyEnd = toMinutes(DAY_STUDY_END);
+
+      let currentBlock = null;
+      for (const b of blocks) {
+        if (nowM >= toMinutes(b.start) && nowM < toMinutes(b.end)) {
+          currentBlock = b;
+          break;
+        }
+      }
+
+      const futureBlocks = blocks.filter((b) => toMinutes(b.start) > nowM);
+      const nextBlock = futureBlocks[0] || null;
+
+      let totalStudyRemain = 0;
+      for (let m = Math.max(nowM, dayStudyStart); m < dayStudyEnd; m++) {
+        const blocked = blocks.some((b) => m >= toMinutes(b.start) && m < toMinutes(b.end));
+        if (!blocked) totalStudyRemain++;
+      }
+
+      return { currentBlock, nextBlock, totalStudyRemain };
+    }
+
+    function render() {
+      const now = new Date();
+      const dayIndex = now.getDay();
+      const todayClasses = schedule[dayIndex] || [];
+      const { currentBlock, nextBlock, totalStudyRemain } = getCurrentState(now, dayIndex);
+
+      const nowText = `${now.getFullYear()}년 ${now.getMonth() + 1}월 ${now.getDate()}일 (${KOR_DAYS[dayIndex]}) ${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")}`;
+      document.getElementById("nowText").textContent = `현재 시각: ${nowText}`;
+
+      const badge = document.getElementById("stateBadge");
+      const mainStatus = document.getElementById("mainStatus");
+      const statusDetail = document.getElementById("statusDetail");
+      const studyDetail = document.getElementById("studyDetail");
+
+      const nowM = now.getHours() * 60 + now.getMinutes();
+      const isRestTime = nowM >= toMinutes(REST_START) && nowM < toMinutes(REST_END);
+      const isNightStudyTime = nowM >= toMinutes(NIGHT_STUDY_START) && nowM < toMinutes(NIGHT_STUDY_END);
+
+      if (isRestTime) {
+        const restRemain = toMinutes(REST_END) - nowM;
+        badge.textContent = "휴식 시간";
+        badge.className = "pill";
+        mainStatus.textContent = "현재는 휴식시간입니다.";
+        statusDetail.textContent = `휴식시간 종료까지 ${formatRemain(restRemain)} 남았습니다.`;
+      } else if (currentBlock?.type === "class") {
+        const remain = toMinutes(currentBlock.end) - (now.getHours() * 60 + now.getMinutes());
+        badge.textContent = "수업 중";
+        badge.className = "pill warn";
+        mainStatus.textContent = `지금은 ${formatEvent(currentBlock)} 수업 시간입니다.`;
+        statusDetail.textContent = `현재 수업 종료까지 ${formatRemain(remain)} 남았습니다.`;
+      } else if (currentBlock?.type === "meal") {
+        const remain = toMinutes(currentBlock.end) - (now.getHours() * 60 + now.getMinutes());
+        badge.textContent = "식사 시간";
+        badge.className = "pill";
+        mainStatus.textContent = `현재는 ${currentBlock.label}입니다.`;
+        statusDetail.textContent = `${currentBlock.label} 종료까지 ${formatRemain(remain)} 남았습니다.`;
+      } else {
+        badge.textContent = "자습 가능";
+        badge.className = "pill ok";
+        mainStatus.textContent = isNightStudyTime ? "현재는 자율자습시간입니다. (22:00~24:00)" : "현재는 자습시간입니다.";
+
+        if (nextBlock) {
+          const minsToNext = toMinutes(nextBlock.start) - (now.getHours() * 60 + now.getMinutes());
+          statusDetail.textContent = `${formatRemain(minsToNext)} 뒤에 ${nextBlock.type === "class" ? formatEvent(nextBlock) : nextBlock.label} 시작입니다.`;
+        } else {
+          statusDetail.textContent = "오늘 남은 공식 일정이 없습니다.";
+        }
+      }
+
+      const tenPmRemain = Math.max(0, toMinutes(DAY_STUDY_END) - nowM);
+      studyDetail.textContent = `22:00 기준 남은 시간: ${formatRemain(tenPmRemain)} / 남은 자습 가능 시간 합계: ${formatRemain(totalStudyRemain)}.`;
+
+      document.getElementById("todayClassCount").textContent = `오늘 수업 수: ${todayClasses.length}개`;
+
+      if (nextBlock) {
+        const minsToNext = toMinutes(nextBlock.start) - (now.getHours() * 60 + now.getMinutes());
+        document.getElementById("nextClass").textContent = `${formatRemain(minsToNext)} 뒤에 ${nextBlock.type === "class" ? formatEvent(nextBlock) : nextBlock.label} 예정`;
+      } else {
+        document.getElementById("nextClass").textContent = "다음 일정: 없음";
+      }
+
+      document.getElementById("dayEnd").textContent = `자율자습 종료 시각: ${NIGHT_STUDY_END}`;
+
+      const timeline = document.getElementById("todayTimeline");
+      timeline.innerHTML = "";
+
+      if (todayClasses.length === 0) {
+        timeline.innerHTML = "<li>오늘 등록된 수업이 없습니다.</li>";
+      } else {
+        todayClasses
+          .sort((a, b) => toMinutes(a.start) - toMinutes(b.start))
+          .forEach((ev) => {
+            const li = document.createElement("li");
+            li.textContent = `${ev.start}~${ev.end} · ${formatEvent(ev)}`;
+            timeline.appendChild(li);
+          });
+      }
+
+      const weeklyTable = document.getElementById("weeklyTable");
+      weeklyTable.innerHTML = "";
+      [1, 2, 3, 4, 5, 6, 0].forEach((d) => {
+        const events = schedule[d] || [];
+        if (events.length === 0) {
+          const tr = document.createElement("tr");
+          tr.innerHTML = `<td>${KOR_DAYS[d]}</td><td>-</td><td>수업 없음</td>`;
+          weeklyTable.appendChild(tr);
+        } else {
+          events.forEach((ev, idx) => {
+            const tr = document.createElement("tr");
+            tr.innerHTML = `
+              <td>${idx === 0 ? KOR_DAYS[d] : ""}</td>
+              <td>${ev.start}~${ev.end}</td>
+              <td>${formatEvent(ev)}</td>
+            `;
+            weeklyTable.appendChild(tr);
+          });
+        }
+      });
+    }
+
+    render();
+    setInterval(render, 30000);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation

- Provide a compact, localized schedule manager page to show current time, today's timeline, weekly timetable and live status (class / meal / self-study / rest) for students.

### Description

- Add new file `study/schedule/index.html` that implements a responsive UI and theme for the schedule manager with CSS styles and layout.
- Implement client-side schedule data and constants in JavaScript, including `schedule`, `fixedBlocks`, `DAY_STUDY_START`, `DAY_STUDY_END`, and rest/night ranges.
- Add time helper functions `toMinutes`, `toDateTime`, `formatRemain`, and schedule helpers `getTodayBlocks`, `getCurrentState`, and `render` to compute current/next blocks and remaining study time.
- Render live UI elements (now text, status badge, timeline, weekly table) and refresh with `setInterval(render, 30000)` for periodic updates.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de6ccc492483278b201bfce351a5d2)