### PR TITLE
Trigger clean e2scrub-free Openbox ISO rebuild

### DIFF
--- a/.github/workflows/build-gorics-openbox-i386.yml
+++ b/.github/workflows/build-gorics-openbox-i386.yml
@@ -1,3 +1,4 @@
+# Clean-boot rebuild trigger: e2scrub timers must stay disabled.
 name: Build GORICS Direct Openbox i386 ISO
 
 on:


### PR DESCRIPTION
Rebuild the i386 Openbox ISO with e2scrub timers disabled, require Xorg/Openbox readiness markers, and fail verification if any e2scrub startup failure appears.