### PR TITLE
Deploy responsive Real Multiboot UI

### DIFF
--- a/os/real-multiboot/.deploy-r7-responsive
+++ b/os/real-multiboot/.deploy-r7-responsive
@@ -1,0 +1,3 @@
+Deploy GORICS Real Multiboot responsive UI r7.
+Commit source: latest main
+Requested page: https://gorics.github.io/website/os/real-multiboot/


### PR DESCRIPTION
Merges the responsive Real Multiboot page deployment trigger into `main` so the Pages workflow runs from a GitHub-generated merge commit.