### PR TITLE
Run full graphical Real Multiboot verification chain

### DIFF
--- a/os/real-multiboot/.trigger-graphical-v5-chain
+++ b/os/real-multiboot/.trigger-graphical-v5-chain
@@ -1,0 +1,1 @@
+Trigger Pages deployment, public responsive verification, and graphical V5 boot verification.


### PR DESCRIPTION
Triggers Pages deployment, cache-busted public responsive verification, and the Chromium V5 test that requires the GORICS graphical canvas to reach at least 640×480.