### PR TITLE
Apply overlay completion repair now

### DIFF
--- a/os/real-multiboot/.trigger-apply-overlay-fix
+++ b/os/real-multiboot/.trigger-apply-overlay-fix
@@ -1,0 +1,1 @@
+Apply the completion-state repair now and deploy the repaired loader.


### PR DESCRIPTION
Triggers the atomic app.js repair that converts the verified GUI signal into a 100% running state, hides the loading overlay, enables controls, clears the boot timeout, and deploys the repaired loader.