### PR TITLE
Run V9 unobscured desktop proof

### DIFF
--- a/os/real-multiboot/.trigger-v9-overlay-proof
+++ b/os/real-multiboot/.trigger-v9-overlay-proof
@@ -1,0 +1,1 @@
+Run V9 independent proof for responsive layout, graphical boot, hidden overlay, and ready controls.


### PR DESCRIPTION
Runs the independent V9 verifier against the repaired public loader. It requires responsive layout at five viewport widths, real GORICS Xorg/Openbox boot, a visible graphical canvas, a fully hidden loading overlay, stable 100% completion, and enabled running controls.