### PR TITLE
Rebuild GORICS with a visibly rendered desktop

### DIFF
--- a/os/real-multiboot/.trigger-visible-desktop-rebuild
+++ b/os/real-multiboot/.trigger-visible-desktop-rebuild
@@ -1,0 +1,1 @@
+Patch the ISO source so Openbox renders a visible wallpaper, panel, mapped terminal, and mapped-window readiness marker, then rebuild the i386 ISO.


### PR DESCRIPTION
Triggers the deterministic ISO source patch and clean i386 rebuild. The new guest requires a mapped `GORICS Control Center` window, fixes Tint2's background ID, adds a visible wallpaper, launches Openbox/PCManFM/Tint2/xterm directly, and emits `GORICS_VISIBLE_WINDOW_READY` only after X11 confirms the window tree.