### PR TITLE
Dispatch verified R12 publisher now

### DIFF
--- a/os/real-multiboot/.trigger-r12-publisher-now
+++ b/os/real-multiboot/.trigger-r12-publisher-now
@@ -1,0 +1,1 @@
+Dispatch the artifact-first R12 publisher from the already verified ISO artifact.


### PR DESCRIPTION
Starts the artifact-first R12 publisher immediately from the already uploaded, mapped-window-verified ISO artifact instead of waiting for the optional convenience release upload.