### PR TITLE
Record active R12 pipeline runs

### DIFF
--- a/os/real-multiboot/.trigger-record-r12-pipeline
+++ b/os/real-multiboot/.trigger-record-r12-pipeline
@@ -1,0 +1,1 @@
+Record current R12 build, publisher, Pages, and V10 workflow runs.


### PR DESCRIPTION
Records the current verified ISO build, artifact-first R12 publisher, Pages deployment, and visible-pixel V10 verification run IDs and states.