### PR TITLE
Run isolated V10 final visible-pixel proof

### DIFF
--- a/os/real-multiboot/.trigger-v10-final-proof
+++ b/os/real-multiboot/.trigger-v10-final-proof
@@ -1,0 +1,1 @@
+Run the isolated final V10 proof for responsive layout, mapped Openbox window, visible pixel variance, hidden overlay, and ready controls.


### PR DESCRIPTION
Runs a non-cancelling V10 verification against the public R12 build. It requires five responsive viewport checks, actual Xorg/Openbox and mapped window readiness, non-flat canvas pixel variance, hidden loading overlay, stable 100% completion, and enabled controls.