### PR TITLE
Capture the current static Pages failure

### DIFF
--- a/os/real-multiboot/.trigger-capture-static-failure
+++ b/os/real-multiboot/.trigger-capture-static-failure
@@ -1,0 +1,1 @@
+Capture the exact tail of the latest failed static Pages deployment.


### PR DESCRIPTION
Records the exact failed log tail from the latest static Pages deployment so the R12 public deployment blocker can be fixed precisely.