### PR TITLE
ci(os): enforce deployment-before-verification ordering

### DIFF
--- a/.github/workflows/force-real-multiboot-deploy.yml
+++ b/.github/workflows/force-real-multiboot-deploy.yml
@@ -1,12 +1,16 @@
 name: Deploy and Verify Real Multiboot
 
 on:
-  pull_request:
-    types: [closed]
+  workflow_dispatch:
+  push:
     branches: [main]
     paths:
       - 'os/real-multiboot/**'
-  workflow_dispatch:
+      - 'vendor/v86/**'
+      - '.github/scripts/verify-real-multiboot-r19.mjs'
+      - '.github/workflows/verify-real-multiboot-r19-v2.yml'
+      - '.github/workflows/force-real-multiboot-deploy.yml'
+      - '.github/workflows/static.yml'
 
 permissions:
   actions: write
@@ -18,9 +22,8 @@ concurrency:
 
 jobs:
   deploy:
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Checkout main
         uses: actions/checkout@v4
@@ -39,29 +42,41 @@ jobs:
               ref: 'main'
             });
 
-      - name: Verify public R19 deployment
+      - name: Wait for exact public deployment and local media
         shell: bash
         run: |
           set -euo pipefail
-          PAGE='https://gorics.github.io/website/os/real-multiboot/'
+          ROOT='https://gorics.github.io/website'
+          PAGE="$ROOT/os/real-multiboot/"
           deployed=0
-          for attempt in $(seq 1 120); do
+          for attempt in $(seq 1 150); do
             stamp="${GITHUB_RUN_ID}-${attempt}-$(date +%s)"
             if curl -fsSL --max-time 30 "${PAGE}?verify=${stamp}" -o /tmp/multiboot-index.html \
               && grep -q 'r19-stable-runtime-cache-safe-local-media-pointer-calibration' /tmp/multiboot-index.html \
               && grep -q 'responsive-overrides.css?v=' /tmp/multiboot-index.html \
               && grep -q 'pointer-calibration.js?v=' /tmp/multiboot-index.html \
               && curl -fsSL --max-time 30 "${PAGE}performance-mode.js?verify=${stamp}" -o /tmp/performance-mode.js \
-              && grep -q 'logCapChars: 120000' /tmp/performance-mode.js; then
+              && grep -q 'logCapChars: 120000' /tmp/performance-mode.js \
+              && curl -fsSL --max-time 30 "${PAGE}assets/deployment.json?verify=${stamp}" -o /tmp/deployment.json \
+              && grep -q "\"version\": \"${GITHUB_SHA}-" /tmp/deployment.json; then
               deployed=1
-              echo "R19 deployment verified on attempt ${attempt}"
+              echo "exact R19 deployment verified on attempt ${attempt}"
               break
             fi
-            echo "R19 deployment not visible, attempt ${attempt}/120"
+            echo "exact R19 deployment not visible, attempt ${attempt}/150"
             sleep 10
           done
           test "$deployed" = 1
           node --check /tmp/performance-mode.js
+
+          : > /tmp/local-media-probe.txt
+          for image in buildroot-bzimage68.bin linux4.iso linux.iso freedos722.img; do
+            code=$(curl -sS -L --max-time 120 -r 0-4095 -o "/tmp/${image}.probe" -w '%{http_code}' "$ROOT/vendor/v86/images/$image?deploy=$GITHUB_RUN_ID")
+            bytes=$(stat -c %s "/tmp/${image}.probe" 2>/dev/null || echo 0)
+            printf '%s status=%s bytes=%s\n' "$image" "$code" "$bytes" | tee -a /tmp/local-media-probe.txt
+            case "$code" in 200|206) ;; *) exit 1;; esac
+            test "$bytes" -gt 0
+          done
 
       - name: Dispatch canonical R19 graphical verification
         uses: actions/github-script@v7

--- a/.github/workflows/verify-real-multiboot-r19-v2.yml
+++ b/.github/workflows/verify-real-multiboot-r19-v2.yml
@@ -2,20 +2,13 @@ name: Verify Real Multiboot R19 V2
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
-    paths:
-      - 'os/real-multiboot/**'
-      - 'vendor/v86/**'
-      - '.github/scripts/verify-real-multiboot-r19.mjs'
-      - '.github/workflows/verify-real-multiboot-r19-v2.yml'
 
 permissions:
   contents: write
 
 concurrency:
   group: verify-real-multiboot-canonical
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   verify:
@@ -81,7 +74,7 @@ jobs:
           npx playwright install --with-deps chromium
           node --check verify.mjs
 
-      - name: Wait for public R19 deployment and all preset media
+      - name: Verify public R19 deployment and all preset media
         run: |
           set -euo pipefail
           ROOT='https://gorics.github.io/website'
@@ -133,16 +126,18 @@ jobs:
           exit "$browser_exit"
 
       - name: Guarantee diagnostic result
-        if: always()
+        if: always() && !cancelled()
         run: |
           if test ! -s /tmp/real-multiboot-r19.json; then
             python3 - <<'PY'
           import json, os
           from pathlib import Path
-          log = Path('/tmp/real-multiboot-r19.log').read_text(errors='replace') if Path('/tmp/real-multiboot-r19.log').exists() else ''
+          process_log = Path('/tmp/real-multiboot-r19.log').read_text(errors='replace') if Path('/tmp/real-multiboot-r19.log').exists() else ''
+          media_probe = Path('/tmp/public-media-probe.txt').read_text(errors='replace').splitlines() if Path('/tmp/public-media-probe.txt').exists() else []
+          public_seen = Path('/tmp/public-index.html').exists()
           result = {
               'success': False,
-              'state': 'verifier-process-failed',
+              'state': 'public-preflight-failed' if public_seen else 'verifier-process-failed',
               'version': '20260710-r19-stability',
               'run_id': os.environ.get('GITHUB_RUN_ID'),
               'workflow_sha': os.environ.get('GITHUB_SHA'),
@@ -150,7 +145,8 @@ jobs:
               'xorg_ready': False,
               'gui_ready': False,
               'graphical_canvas': False,
-              'process_log_tail': log.splitlines()[-240:],
+              'public_media_probe': media_probe,
+              'process_log_tail': process_log.splitlines()[-240:],
           }
           Path('/tmp/real-multiboot-r19.json').write_text(json.dumps(result, indent=2) + '\n')
           PY
@@ -158,7 +154,7 @@ jobs:
           cat /tmp/real-multiboot-r19.json
 
       - name: Upload verification proof
-        if: always()
+        if: always() && !cancelled()
         uses: actions/upload-artifact@v4
         with:
           name: real-multiboot-r19-v2-${{ github.run_id }}
@@ -175,9 +171,10 @@ jobs:
           if-no-files-found: warn
 
       - name: Publish canonical status
-        if: always() && github.ref == 'refs/heads/main'
+        if: always() && !cancelled() && github.ref == 'refs/heads/main'
         run: |
           set -euo pipefail
+          test -s /tmp/real-multiboot-r19.json
           git config user.name github-actions
           git config user.email github-actions@github.com
           for attempt in $(seq 1 8); do
@@ -192,7 +189,7 @@ jobs:
           exit 1
 
       - name: Require graphical boot success
-        if: always()
+        if: always() && !cancelled()
         run: |
           python3 - <<'PY'
           import json

--- a/os/MAINTENANCE.md
+++ b/os/MAINTENANCE.md
@@ -41,7 +41,9 @@ Canonical verification: `.github/workflows/verify-real-multiboot-r19-v2.yml`
 
 Browser verifier: `.github/scripts/verify-real-multiboot-r19.mjs`
 
-The deployment dispatcher runs the canonical Pages deployment, waits for the R19 public bundle, and then dispatches the canonical verification. Do not add another graphical boot workflow to that chain.
+Runtime, v86, deployment-workflow, or verifier changes trigger the deployment dispatcher. It deploys the exact triggering main-branch commit, waits until `assets/deployment.json` reports that commit, verifies all local preset media, and only then dispatches the canonical graphical verification.
+
+The canonical verification is `workflow_dispatch` only. Do not add a direct runtime-file push trigger, because it can start before GitHub Pages finishes deploying and produce false 404 failures. Canonical runs are never cancelled in favor of another run, and a cancelled run must never publish status.
 
 Only the canonical verification may publish `os/iso/real-multiboot-status.json`. Obsolete versioned verifiers and separate media-probe status writers must not be restored because they create duplicate browser runs, extra commits, and nondeterministic hub results.
 


### PR DESCRIPTION
## 원인
R19 V2가 런타임 변경 push 직후 바로 시작되면서 GitHub Pages 배포보다 앞서 실행됐고, 아직 배포되지 않은 `vendor/v86/images/buildroot-bzimage68.bin`을 404로 판정했습니다. 실제 R19 GUI 코드는 이전 Chromium 검증에서 정상 통과했습니다.

## 수정
- canonical R19 V2를 `workflow_dispatch` 전용으로 변경
- 런타임·v86·검증기 변경은 배포 dispatcher 하나만 자동 실행
- dispatcher가 `assets/deployment.json`에서 정확한 triggering SHA를 확인한 뒤 모든 local preset 미디어를 검사
- 그 이후에만 canonical Chromium GUI 검증 실행
- canonical 실행끼리 서로 취소하지 않음
- 취소된 실행은 아티팩트·상태 파일을 발행하지 않음
- 사전검증 실패를 `public-preflight-failed`로 구분하고 media probe를 진단 JSON에 포함

## 기대 효과
배포 전 404를 실제 장애로 오인하는 race condition과 정상 상태 덮어쓰기를 제거합니다.