### PR TITLE
ci(os): synchronize canonical status commits to Pages

### DIFF
--- a/.github/workflows/force-real-multiboot-deploy.yml
+++ b/.github/workflows/force-real-multiboot-deploy.yml
@@ -5,11 +5,13 @@ on:
   push:
     branches: [main]
     paths:
+      - 'os/index.html'
       - 'os/real-multiboot/**'
       - 'vendor/v86/**'
       - '.github/scripts/verify-real-multiboot-r19.mjs'
       - '.github/workflows/verify-real-multiboot-r19-v2.yml'
       - '.github/workflows/force-real-multiboot-deploy.yml'
+      - '.github/workflows/publish-os-status-to-pages.yml'
       - '.github/workflows/static.yml'
 
 permissions:

--- a/.github/workflows/publish-os-status-to-pages.yml
+++ b/.github/workflows/publish-os-status-to-pages.yml
@@ -1,0 +1,31 @@
+name: Publish OS Status to Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'os/iso/real-multiboot-status.json'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: publish-os-status-to-pages
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch canonical Pages deployment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'static.yml',
+              ref: 'main'
+            });

--- a/os/MAINTENANCE.md
+++ b/os/MAINTENANCE.md
@@ -39,13 +39,17 @@ Deployment dispatcher: `.github/workflows/force-real-multiboot-deploy.yml`
 
 Canonical verification: `.github/workflows/verify-real-multiboot-r19-v2.yml`
 
+Status-to-Pages bridge: `.github/workflows/publish-os-status-to-pages.yml`
+
 Browser verifier: `.github/scripts/verify-real-multiboot-r19.mjs`
 
-Runtime, v86, deployment-workflow, or verifier changes trigger the deployment dispatcher. It deploys the exact triggering main-branch commit, waits until `assets/deployment.json` reports that commit, verifies all local preset media, and only then dispatches the canonical graphical verification.
+Runtime, hub, v86, deployment-workflow, or verifier changes trigger the deployment dispatcher. It deploys the exact triggering main-branch commit, waits until `assets/deployment.json` reports that commit, verifies all local preset media, and only then dispatches the canonical graphical verification.
 
 The canonical verification is `workflow_dispatch` only. Do not add a direct runtime-file push trigger, because it can start before GitHub Pages finishes deploying and produce false 404 failures. Canonical runs are never cancelled in favor of another run, and a cancelled run must never publish status.
 
-Only the canonical verification may publish `os/iso/real-multiboot-status.json`. Obsolete versioned verifiers and separate media-probe status writers must not be restored because they create duplicate browser runs, extra commits, and nondeterministic hub results.
+Only the canonical verification may write `os/iso/real-multiboot-status.json`. When that file changes, the status-to-Pages bridge dispatches a Pages deployment without launching another graphical verification. This keeps the public hub status synchronized without creating a verification loop.
+
+Obsolete versioned verifiers, separate media-probe status writers, and workflows that publish raw failure logs into the repository must not be restored. Diagnostic logs belong in private Actions logs or downloadable workflow artifacts, not in the public Pages tree.
 
 The canonical verification checks:
 


### PR DESCRIPTION
## 문제
GitHub Pages가 Actions 아티팩트 방식이라 canonical 검증이 저장소의 `os/iso/real-multiboot-status.json`을 갱신해도 공개 허브는 이전 아티팩트의 상태를 계속 표시할 수 있었습니다.

## 수정
- 상태 JSON 변경 시 `static.yml`만 다시 배포하는 전용 브리지 추가
- 상태 재배포에서는 Chromium 그래픽 검증을 다시 실행하지 않아 무한 루프 방지
- OS 허브와 상태 브리지 변경도 canonical 배포 체인 트리거에 포함
- 유지보수 문서에 상태 작성자·Pages 동기화 흐름 명시

## 최종 흐름
런타임 변경 → 정확한 SHA Pages 배포 → local preset 미디어 확인 → canonical R19 Chromium 검증 → 상태 JSON 커밋 → 상태 포함 Pages 재배포