### PR TITLE
ci(os): keep only the latest Pages deployment

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -15,7 +15,7 @@ permissions:
 
 concurrency:
   group: pages-visibility-safe-r19
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   deploy:


### PR DESCRIPTION
## 문제
Pages 워크플로가 `cancel-in-progress: false`라 구형 OS 배포가 대기열에 남고, 최신 R19 배포가 뒤에서 기다리거나 오래된 아티팩트가 나중에 공개될 수 있었습니다.

## 수정
- Pages concurrency를 `cancel-in-progress: true`로 변경
- 같은 배포 그룹의 구형 실행을 취소하고 최신 main SHA만 조립·공개

canonical dispatcher가 정확한 `deployment.json` SHA를 확인하므로, 최신 배포만 유지하는 편이 더 안전하고 빠릅니다.