### PR TITLE
ci(os): pin every Pages deployment to an exact source SHA

### DIFF
--- a/.github/workflows/force-real-multiboot-deploy.yml
+++ b/.github/workflows/force-real-multiboot-deploy.yml
@@ -27,13 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Checkout main
+      - name: Checkout exact source
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.sha }}
           fetch-depth: 1
 
-      - name: Dispatch canonical Pages deployment
+      - name: Dispatch pinned Pages deployment
         uses: actions/github-script@v7
         with:
           script: |
@@ -41,7 +41,8 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'static.yml',
-              ref: 'main'
+              ref: 'main',
+              inputs: { source_sha: context.sha }
             });
 
       - name: Wait for exact public deployment and local media
@@ -60,12 +61,13 @@ jobs:
               && curl -fsSL --max-time 30 "${PAGE}performance-mode.js?verify=${stamp}" -o /tmp/performance-mode.js \
               && grep -q 'logCapChars: 120000' /tmp/performance-mode.js \
               && curl -fsSL --max-time 30 "${PAGE}assets/deployment.json?verify=${stamp}" -o /tmp/deployment.json \
+              && grep -q "\"source_sha\": \"${GITHUB_SHA}\"" /tmp/deployment.json \
               && grep -q "\"version\": \"${GITHUB_SHA}-" /tmp/deployment.json; then
               deployed=1
-              echo "exact R19 deployment verified on attempt ${attempt}"
+              echo "exact R19 deployment verified on attempt ${attempt} sha=${GITHUB_SHA}"
               break
             fi
-            echo "exact R19 deployment not visible, attempt ${attempt}/150"
+            echo "exact R19 deployment not visible, attempt ${attempt}/150 sha=${GITHUB_SHA}"
             sleep 10
           done
           test "$deployed" = 1

--- a/.github/workflows/publish-os-status-to-pages.yml
+++ b/.github/workflows/publish-os-status-to-pages.yml
@@ -19,7 +19,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Dispatch canonical Pages deployment
+      - name: Dispatch pinned Pages deployment
         uses: actions/github-script@v7
         with:
           script: |
@@ -27,5 +27,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'static.yml',
-              ref: 'main'
+              ref: 'main',
+              inputs: { source_sha: context.sha }
             });

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -2,6 +2,11 @@ name: Deploy static content to Pages
 
 on:
   workflow_dispatch:
+    inputs:
+      source_sha:
+        description: Exact repository commit to publish
+        required: false
+        type: string
   push:
     branches: [main]
     paths:
@@ -25,15 +30,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - name: Checkout
+      - name: Checkout exact source
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_sha || github.sha }}
 
       - name: Assemble sanitized Pages tree
         env:
-          DEPLOY_VERSION: ${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          SOURCE_SHA: ${{ inputs.source_sha || github.sha }}
+          DEPLOY_VERSION: ${{ inputs.source_sha || github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
           rm -rf _site
           python3 - <<'PY'
           import pathlib
@@ -154,6 +163,7 @@ jobs:
 
           deployment = {
               'version': version,
+              'source_sha': os.environ['SOURCE_SHA'],
               'architecture': 'i386',
               'desktop': 'openbox-tint2-pcmanfm-xterm',
               'direct_boot': True,
@@ -224,7 +234,8 @@ jobs:
 
       - name: Verify exact public deployment
         env:
-          DEPLOY_VERSION: ${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          SOURCE_SHA: ${{ inputs.source_sha || github.sha }}
+          DEPLOY_VERSION: ${{ inputs.source_sha || github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           set -euo pipefail
           ROOT='https://gorics.github.io/website'
@@ -236,6 +247,7 @@ jobs:
               && grep -q 'asset-versioning.js?v=' /tmp/index.html \
               && grep -q 'gorics-build' /tmp/index.html \
               && curl -fsSL --max-time 45 "$PAGE/assets/deployment.json?v=$stamp" -o /tmp/deployment.json \
+              && grep -q "\"source_sha\": \"${SOURCE_SHA}\"" /tmp/deployment.json \
               && grep -q "\"version\": \"${DEPLOY_VERSION}\"" /tmp/deployment.json \
               && grep -q '"isolated_canonical_status": true' /tmp/deployment.json \
               && curl -fsSL --max-time 45 "$ROOT/os/iso/real-multiboot-status.json?v=$stamp" -o /tmp/public-status.json \

--- a/os/MAINTENANCE.md
+++ b/os/MAINTENANCE.md
@@ -45,13 +45,13 @@ Browser verifier: `.github/scripts/verify-real-multiboot-r19.mjs`
 
 Canonical repository status: `os/iso/r19-canonical-status.json`
 
-Runtime, hub, v86, deployment-workflow, or verifier changes trigger the deployment dispatcher. It deploys the exact triggering main-branch commit, waits until `assets/deployment.json` reports that commit, verifies all local preset media, and only then dispatches the canonical graphical verification.
+Runtime, hub, v86, deployment-workflow, or verifier changes trigger the deployment dispatcher. It passes the triggering commit as the `source_sha` input, the Pages workflow checks out that exact commit even if main changes during the run, and `assets/deployment.json` records the same source SHA. The dispatcher verifies all local preset media and only then starts the canonical graphical verification.
 
 The canonical verification is `workflow_dispatch` only. Do not add a direct runtime-file push trigger, because it can start before GitHub Pages finishes deploying and produce false 404 failures. Canonical runs are never cancelled in favor of another run, and a cancelled run must never publish status.
 
 Only the canonical R19 verification may write `os/iso/r19-canonical-status.json`. Legacy workflows may still finish old in-flight runs and write historical files such as `real-multiboot-status.json`, but the Pages assembly always replaces the public `real-multiboot-status.json` with the isolated canonical R19 file. Therefore legacy results cannot change the hub badge.
 
-When `r19-canonical-status.json` changes, the status-to-Pages bridge dispatches a Pages deployment without launching another graphical verification. This keeps the public hub synchronized without creating a verification loop.
+When `r19-canonical-status.json` changes, the status-to-Pages bridge deploys that exact status commit by passing its SHA to the Pages workflow, without launching another graphical verification. This keeps the public hub synchronized without creating a verification loop or a moving-main race.
 
 Obsolete versioned verifiers, workflow-run recorders, separate media-probe status writers, and workflows that publish raw failure logs into the repository must not be restored. Diagnostic logs belong in private Actions logs or downloadable workflow artifacts, not in the public Pages tree.
 


### PR DESCRIPTION
## 문제
workflow가 `ref: main`만 전달하면 실행 도중 다른 자동 커밋이 들어올 때 처음 요청한 SHA가 아닌 더 최신 main을 배포할 수 있습니다.

## 수정
- `static.yml`에 선택적 `source_sha` 입력 추가
- checkout, 배포 버전, `deployment.json.source_sha`, 공개 검증을 모두 같은 SHA로 고정
- canonical dispatcher는 triggering SHA를 Pages에 전달
- 상태-to-Pages 브리지는 canonical 상태 커밋 SHA를 전달
- checkout HEAD와 source SHA 불일치 시 즉시 실패

이제 배포 중 main이 움직여도 요청된 코드와 상태만 정확히 공개됩니다.