### PR TITLE
ci(os): enable canonical workflows and trigger uncontested R19 deployment

### DIFF
--- a/.github/workflows/force-real-multiboot-deploy.yml
+++ b/.github/workflows/force-real-multiboot-deploy.yml
@@ -33,10 +33,15 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 1
 
-      - name: Dispatch pinned Pages deployment
+      - name: Enable and dispatch pinned Pages deployment
         uses: actions/github-script@v7
         with:
           script: |
+            await github.rest.actions.enableWorkflow({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'static.yml'
+            });
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -82,10 +87,15 @@ jobs:
             test "$bytes" -gt 0
           done
 
-      - name: Dispatch canonical R19 graphical verification
+      - name: Enable and dispatch canonical R19 graphical verification
         uses: actions/github-script@v7
         with:
           script: |
+            await github.rest.actions.enableWorkflow({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'verify-real-multiboot-r19-v2.yml'
+            });
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/publish-os-status-to-pages.yml
+++ b/.github/workflows/publish-os-status-to-pages.yml
@@ -19,10 +19,15 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Dispatch pinned Pages deployment
+      - name: Enable and dispatch pinned Pages deployment
         uses: actions/github-script@v7
         with:
           script: |
+            await github.rest.actions.enableWorkflow({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'static.yml'
+            });
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/os/real-multiboot/deployment-r12-v86-atomic.txt
+++ b/os/real-multiboot/deployment-r12-v86-atomic.txt
@@ -5,4 +5,6 @@ status_policy=isolated-r19-canonical-status
 pages_policy=sanitized-latest-only
 runtime_policy=cache-safe-intent-prefetch-bounded-log
 verification=public-media-plus-chromium-graphical-boot
-trigger_reason=final-full-os-audit
+legacy_pages_publishers=removed
+workflow_activation=explicit-before-dispatch
+trigger_reason=final-full-os-audit-after-r17-overwriter-removal


### PR DESCRIPTION
## 보강
- dispatcher가 `static.yml`을 먼저 명시적으로 활성화한 뒤 exact-SHA 배포
- Chromium canonical verifier도 실행 전 활성화
- 상태 재배포 브리지 역시 Pages workflow 활성화 후 호출

## 최종 트리거
R17/V3 Pages overwriter와 모든 구형 watcher를 제거한 상태에서 최종 R19 배포를 다시 실행합니다.

이번 squash merge SHA가 경쟁 배포가 없는 최종 source SHA가 됩니다.