### PR TITLE
ci(os): kick off the canonical R19 chain explicitly once

### DIFF
--- a/.github/workflows/kickoff-canonical-r19-once.yml
+++ b/.github/workflows/kickoff-canonical-r19-once.yml
@@ -1,0 +1,42 @@
+name: Kick Off Canonical R19 Once
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/kickoff-canonical-r19-once.yml'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: kickoff-canonical-r19-once
+  cancel-in-progress: true
+
+jobs:
+  kickoff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable canonical workflows and dispatch final chain
+        uses: actions/github-script@v7
+        with:
+          script: |
+            for (const workflow_id of [
+              'static.yml',
+              'verify-real-multiboot-r19-v2.yml',
+              'force-real-multiboot-deploy.yml'
+            ]) {
+              await github.rest.actions.enableWorkflow({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id
+              });
+            }
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'force-real-multiboot-deploy.yml',
+              ref: 'main'
+            });


### PR DESCRIPTION
자동 push 트리거 상태와 무관하게 최종 canonical 체인을 반드시 시작시키는 one-shot workflow입니다.

실행 순서:
1. `static.yml` 활성화
2. `verify-real-multiboot-r19-v2.yml` 활성화
3. `force-real-multiboot-deploy.yml` 활성화
4. force dispatcher를 main에서 직접 workflow_dispatch

최종 R19 상태가 기록되면 이 one-shot 파일은 제거합니다.