### PR TITLE
Trigger PR-target permanent math PDF build

### DIFF
--- a/study/math-nje/source/trigger-pr.txt
+++ b/study/math-nje/source/trigger-pr.txt
@@ -1,0 +1,1 @@
+Trigger the pull_request_target permanent PDF build.


### PR DESCRIPTION
The permanent PDF workflow has now produced and committed latest.pdf successfully. This trigger-only PR is no longer needed.